### PR TITLE
Refactor: unified exception hierarchy, extract validation, DRY sanitize

### DIFF
--- a/docs/superpowers/specs/2026-06-04-architecture-cleanup.md
+++ b/docs/superpowers/specs/2026-06-04-architecture-cleanup.md
@@ -1,0 +1,92 @@
+# Architecture Cleanup — Exception Hierarchy, Validation Extract, DRY Sanitize
+
+> GitHub issue: #15
+
+## Goal
+
+Internal refactoring to improve maintainability and correctness without changing behavior. Clean up exception handling, extract validation into a dedicated module, eliminate duplicated code, and consolidate validation to a single boundary.
+
+## Current State
+
+**Exceptions** — four independent exception classes across three modules:
+- `ValidationError` in `server.py`
+- `AnsibleDocError` in `parser.py`
+- `GalaxyError` in `galaxy.py`
+- `CollectionInstallError` in `collections.py`
+
+The Galaxy fallback in `_resolve_module_doc()` catches bare `Exception` and uses string-matching (`_is_missing_collection_error`) to decide whether to attempt Galaxy lookup.
+
+**Validation** — seven `_validate_*` functions plus regex constants and length limits all live in `server.py` (lines 28–121). This is ~95 lines of validation mixed into the server module.
+
+**`_sanitize_error`** — identical function exists in `server.py:123` and `collections.py:35`, both using the same `_PATH_RE` pattern.
+
+**FQCN validation** — `server.py` validates full FQCNs with `_FQCN_RE` at the tool boundary. `galaxy.py` validates individual namespace/name components with `_validate_component()` internally. Both do validation, but at different granularities.
+
+## Design
+
+### 1. New file: `src/ansible_know/errors.py`
+
+```python
+class AnsibleKnowError(Exception):
+    """Base exception for all ansible-know errors."""
+
+class AnsibleDocError(AnsibleKnowError):
+    """ansible-doc CLI failures."""
+
+class CollectionNotFoundError(AnsibleDocError):
+    """Module/collection not found — triggers Galaxy fallback."""
+
+class GalaxyError(AnsibleKnowError):
+    """Galaxy API failures."""
+
+class CollectionInstallError(AnsibleKnowError):
+    """ansible-galaxy install failures."""
+
+class ValidationError(AnsibleKnowError):
+    """Input validation failures."""
+```
+
+- `parser.py` raises `CollectionNotFoundError` instead of `AnsibleDocError` when the error message matches missing-collection patterns.
+- `_resolve_module_doc()` catches `CollectionNotFoundError` explicitly instead of string-matching.
+- All other code catches `AnsibleKnowError` or specific subtypes — no bare `Exception`.
+
+### 2. New file: `src/ansible_know/validation.py`
+
+Move from `server.py`:
+- All `_validate_*` functions → public `validate_*` functions
+- All regex constants (`_FQCN_RE`, `_NAMESPACE_RE`, `_VERSION_RE`, `_TAGS_RE`, `_SENSITIVE_PREFIXES`)
+- All length constants (`MAX_KEYWORD_LENGTH`, `MAX_QUERY_LENGTH`, etc.)
+- `_sanitize_error()` → `sanitize_error()` (shared utility, DRYs item 4)
+- `_truncate_response()` → `truncate_response()`
+
+`server.py` and `collections.py` import from `validation.py`.
+
+### 3. Consolidate FQCN validation
+
+- Remove `_validate_component()` from `galaxy.py`.
+- Galaxy methods trust their inputs (they're only called from `server.py` tools which already validate).
+- `_parse_fqcn()` stays in `galaxy.py` (it's format parsing, not security validation).
+
+### 4. Updated `_resolve_module_doc` fallback
+
+```python
+async def _resolve_module_doc(module_name: str) -> tuple[dict, dict | None]:
+    try:
+        raw_doc = await _run_in_executor(parser.get_module_doc, module_name)
+        return raw_doc, None
+    except CollectionNotFoundError:
+        # Explicit type — no string matching needed
+        logger.info("Collection not installed, trying Galaxy for %s", module_name)
+        try:
+            client = GalaxyClient()
+            galaxy_doc, galaxy_meta = await client.fetch_module_doc(module_name)
+            return galaxy_doc, galaxy_meta
+        except GalaxyError as galaxy_exc:
+            raise CollectionNotFoundError(...) from galaxy_exc
+```
+
+## Non-goals
+
+- No new features
+- No API changes (tool signatures, return shapes unchanged)
+- No test behavior changes (tests may need import path updates)

--- a/src/ansible_know/collections.py
+++ b/src/ansible_know/collections.py
@@ -16,24 +16,18 @@ import tempfile
 import threading
 from pathlib import Path
 
+from ansible_know.errors import CollectionInstallError
+from ansible_know.validation import sanitize_error
+
 logger = logging.getLogger("ansible_know")
 
 _VERSION_PARSE_RE = re.compile(r"(\S+\.\S+):(\d+\.\d+\.\d+\S*)")
-_PATH_RE = re.compile(r"/(?:home|tmp|usr|etc|var|opt)/\S+")
 
 _tmp_dir: tempfile.TemporaryDirectory | None = None
 _installed: dict[str, str] = {}
 _install_locks: dict[str, threading.Lock] = {}
 _locks_lock = threading.Lock()
 _install_gate = threading.Lock()  # serializes all ansible-galaxy subprocess calls
-
-
-class CollectionInstallError(Exception):
-    """Raised when ansible-galaxy collection install fails."""
-
-
-def _sanitize_error(msg: str) -> str:
-    return _PATH_RE.sub("<path>", str(msg))
 
 
 def _find_ansible_galaxy() -> str:
@@ -129,7 +123,7 @@ def ensure_collection(namespace: str, version: str | None = None) -> dict:
 
             if result.returncode != 0:
                 raise CollectionInstallError(
-                    _sanitize_error(result.stderr.strip())
+                    sanitize_error(result.stderr.strip())
                 )
 
         installed_version = _parse_version(result.stdout, namespace, tmpdir)

--- a/src/ansible_know/errors.py
+++ b/src/ansible_know/errors.py
@@ -1,0 +1,27 @@
+"""Unified exception hierarchy for ansible-know."""
+
+from __future__ import annotations
+
+
+class AnsibleKnowError(Exception):
+    """Base exception for all ansible-know errors."""
+
+
+class AnsibleDocError(AnsibleKnowError):
+    """Raised when ansible-doc fails or returns unexpected output."""
+
+
+class CollectionNotFoundError(AnsibleDocError):
+    """Module or collection not found locally — triggers Galaxy fallback."""
+
+
+class GalaxyError(AnsibleKnowError):
+    """Raised when a Galaxy API request fails."""
+
+
+class CollectionInstallError(AnsibleKnowError):
+    """Raised when ansible-galaxy collection install fails."""
+
+
+class ValidationError(AnsibleKnowError):
+    """Raised when tool input fails validation."""

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 import threading
 from collections import OrderedDict
 from typing import Any
@@ -16,10 +15,9 @@ from typing import Any
 import httpx
 
 from ansible_know.config import GALAXY_BASE_URL
+from ansible_know.errors import GalaxyError
 
 logger = logging.getLogger("ansible_know")
-
-_COMPONENT_RE_PATTERN = r"^[a-zA-Z0-9_]+$"
 
 MAX_GALAXY_RESPONSE_SIZE = 5_000_000  # 5MB
 MAX_VERSION_CACHE_SIZE = 500
@@ -61,16 +59,6 @@ def clear_cache() -> None:
         _version_cache.clear()
     with _blob_lock:
         _blob_cache.clear()
-
-
-class GalaxyError(Exception):
-    """Raised when a Galaxy API request fails."""
-
-
-def _validate_component(value: str, label: str) -> None:
-    """Validate a namespace or name component for safe URL interpolation."""
-    if not value or not re.match(_COMPONENT_RE_PATTERN, value):
-        raise GalaxyError(f"Invalid {label}: '{value}'")
 
 
 def _parse_fqcn(module_name: str) -> tuple[str, str, str]:
@@ -150,8 +138,6 @@ class GalaxyClient:
         Raises:
             GalaxyError: If the collection is not found or the API fails.
         """
-        _validate_component(namespace, "namespace")
-        _validate_component(name, "name")
         cache_key = (namespace, name)
         cached = _get_version_cache(cache_key)
         if cached is not None:
@@ -175,8 +161,6 @@ class GalaxyClient:
         self, namespace: str, name: str,
         client: httpx.AsyncClient | None = None,
     ) -> dict[str, Any]:
-        _validate_component(namespace, "namespace")
-        _validate_component(name, "name")
         path = (
             f"/api/v3/plugin/ansible/content/published/collections/index/"
             f"{namespace}/{name}/"

--- a/src/ansible_know/parser.py
+++ b/src/ansible_know/parser.py
@@ -14,9 +14,9 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from ansible_know.errors import AnsibleDocError, CollectionNotFoundError
 
-class AnsibleDocError(Exception):
-    """Raised when ansible-doc fails or returns unexpected output."""
+_MISSING_COLLECTION_PATTERNS = ("has no attribute", "was not found", "could not be found")
 
 
 def _find_ansible_doc() -> str:
@@ -63,9 +63,11 @@ def _run_ansible_doc(*args: str) -> str:
         raise AnsibleDocError(f"ansible-doc timed out: {' '.join(cmd)}")
 
     if result.returncode != 0:
-        raise AnsibleDocError(
-            f"ansible-doc failed (exit {result.returncode}): {result.stderr.strip()}"
-        )
+        msg = f"ansible-doc failed (exit {result.returncode}): {result.stderr.strip()}"
+        msg_lower = msg.lower()
+        if any(p in msg_lower for p in _MISSING_COLLECTION_PATTERNS):
+            raise CollectionNotFoundError(msg)
+        raise AnsibleDocError(msg)
     return result.stdout
 
 

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -9,27 +9,28 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import re
 from functools import partial
-from pathlib import Path
 from typing import Annotated, Any
 
 from fastmcp import FastMCP, Context
 from mcp.types import ToolAnnotations
 
+from ansible_know.errors import ValidationError
+from ansible_know.validation import (
+    validate_fqcn,
+    validate_namespace,
+    validate_keyword,
+    validate_version,
+    validate_query,
+    validate_tags,
+    validate_install_path,
+    validate_path_containment,
+    sanitize_error,
+    truncate_response,
+    MAX_RESPONSE_SIZE,
+)
+
 logger = logging.getLogger("ansible_know")
-
-MAX_RESPONSE_SIZE = 500_000  # 500KB
-MAX_KEYWORD_LENGTH = 200
-MAX_QUERY_LENGTH = 500
-MAX_NAMESPACE_LENGTH = 128
-MAX_VERSION_LENGTH = 64
-
-_FQCN_RE = re.compile(r"^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$")
-_NAMESPACE_RE = re.compile(r"^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$")
-_VERSION_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
-_SENSITIVE_PREFIXES = ("/etc", "/usr", "/bin", "/sbin", "/boot", "/proc", "/sys", "/dev")
-_PATH_RE = re.compile(r"/(?:home|tmp|usr|etc|var|opt)/\S+")
 
 mcp = FastMCP(
     name="Ansible Know",
@@ -43,91 +44,6 @@ mcp = FastMCP(
         "(6) generate_skill to create ready-to-use skill packages."
     ),
 )
-
-
-class ValidationError(Exception):
-    """Raised when tool input fails validation."""
-
-
-def _validate_fqcn(name: str) -> None:
-    if not name or not _FQCN_RE.match(name):
-        raise ValidationError(
-            f"Invalid module name: expected format 'namespace.collection.module' "
-            f"with alphanumeric/underscore segments."
-        )
-
-
-def _validate_namespace(ns: str) -> None:
-    if not ns or len(ns) > MAX_NAMESPACE_LENGTH or not _NAMESPACE_RE.match(ns):
-        raise ValidationError(
-            f"Invalid collection namespace: expected format 'namespace.collection' "
-            f"with alphanumeric/underscore segments."
-        )
-
-
-def _validate_keyword(keyword: str) -> None:
-    if len(keyword) > MAX_KEYWORD_LENGTH:
-        raise ValidationError(
-            f"Keyword too long: {len(keyword)} chars (max {MAX_KEYWORD_LENGTH})."
-        )
-
-
-def _validate_version(version: str) -> None:
-    if not version or len(version) > MAX_VERSION_LENGTH or not _VERSION_RE.match(version):
-        raise ValidationError(
-            f"Invalid version format: use alphanumeric characters, dots, dashes only."
-        )
-
-
-def _validate_query(query: str) -> None:
-    if not query or not query.strip():
-        raise ValidationError("Query must not be empty.")
-    if len(query) > MAX_QUERY_LENGTH:
-        raise ValidationError(
-            f"Query too long: {len(query)} chars (max {MAX_QUERY_LENGTH})."
-        )
-
-
-_TAGS_RE = re.compile(r"^[a-zA-Z0-9_,-]+$")
-MAX_TAGS_LENGTH = 500
-
-
-def _validate_tags(tags: str) -> None:
-    if len(tags) > MAX_TAGS_LENGTH:
-        raise ValidationError(
-            f"Tags too long: {len(tags)} chars (max {MAX_TAGS_LENGTH})."
-        )
-    if not _TAGS_RE.match(tags):
-        raise ValidationError(
-            "Invalid tags: use alphanumeric characters, hyphens, underscores, and commas only."
-        )
-
-
-def _validate_install_path(path_str: str) -> Path:
-    resolved = Path(path_str).resolve()
-    for prefix in _SENSITIVE_PREFIXES:
-        if str(resolved).startswith(prefix):
-            raise ValidationError(
-                f"Install path not allowed: cannot write to system directories."
-            )
-    return resolved
-
-
-def _validate_path_containment(child: Path, parent: Path) -> None:
-    try:
-        child.resolve().relative_to(parent.resolve())
-    except ValueError:
-        raise ValidationError("Path escapes the allowed directory.")
-
-
-def _sanitize_error(msg: str) -> str:
-    return _PATH_RE.sub("<path>", str(msg))
-
-
-def _truncate_response(text: str) -> str:
-    if len(text) > MAX_RESPONSE_SIZE:
-        return text[:MAX_RESPONSE_SIZE] + "\n\n[Truncated — response exceeded size limit]"
-    return text
 
 
 def _run_in_executor(func, *args, **kwargs):
@@ -166,22 +82,20 @@ async def _resolve_module_doc(module_name: str) -> tuple[dict, dict | None]:
     errors and when both local and Galaxy lookups fail.
     """
     from ansible_know import parser
+    from ansible_know.errors import CollectionNotFoundError, GalaxyError
 
     try:
         raw_doc = await _run_in_executor(parser.get_module_doc, module_name)
         return raw_doc, None
-    except Exception as local_exc:
-        if not _is_missing_collection_error(str(local_exc)):
-            raise
-
-        logger.info("Local lookup failed, trying Galaxy: %s", local_exc)
+    except CollectionNotFoundError as local_exc:
+        logger.info("Collection not installed, trying Galaxy: %s", local_exc)
         try:
             from ansible_know.galaxy import GalaxyClient
 
             client = GalaxyClient()
             galaxy_doc, galaxy_meta = await client.fetch_module_doc(module_name)
             return galaxy_doc, galaxy_meta
-        except Exception as galaxy_exc:
+        except GalaxyError as galaxy_exc:
             logger.warning("Galaxy fallback also failed: %s", galaxy_exc)
             raise local_exc from galaxy_exc
 
@@ -197,9 +111,9 @@ async def search_modules(
     """Find Ansible modules by keyword in name or description. Returns up to 50 matches as {fqcn: short_description}."""
     logger.info("search_modules keyword=%r namespace=%r", keyword, namespace)
     try:
-        _validate_keyword(keyword)
+        validate_keyword(keyword)
         if namespace:
-            _validate_namespace(namespace)
+            validate_namespace(namespace)
     except ValidationError as exc:
         return {"error": str(exc)}
 
@@ -213,7 +127,7 @@ async def search_modules(
         return results
     except Exception as exc:
         logger.warning("search_modules failed: %s", exc)
-        return {"error": _maybe_add_hint(_sanitize_error(str(exc)), namespace)}
+        return {"error": _maybe_add_hint(sanitize_error(str(exc)), namespace)}
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -229,7 +143,7 @@ async def get_module_doc(
     """
     logger.info("get_module_doc module=%r", module_name)
     try:
-        _validate_fqcn(module_name)
+        validate_fqcn(module_name)
     except ValidationError as exc:
         return {"error": str(exc)}
 
@@ -246,7 +160,7 @@ async def get_module_doc(
     except Exception as exc:
         logger.warning("get_module_doc failed: %s", exc)
         ns = ".".join(module_name.split(".")[:2]) if "." in module_name else None
-        return {"error": _maybe_add_hint(_sanitize_error(str(exc)), ns)}
+        return {"error": _maybe_add_hint(sanitize_error(str(exc)), ns)}
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -263,7 +177,7 @@ async def search_docs(
     """
     logger.info("search_docs query=%r", query)
     try:
-        _validate_query(query)
+        validate_query(query)
     except ValidationError as exc:
         return [{"error": str(exc)}]
 
@@ -275,7 +189,7 @@ async def search_docs(
         )
     except Exception as exc:
         logger.warning("search_docs failed: %s", exc)
-        return [{"error": _sanitize_error(str(exc))}]
+        return [{"error": sanitize_error(str(exc))}]
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -298,9 +212,9 @@ async def search_collections(
     """
     logger.info("search_collections query=%r tags=%r", query, tags)
     try:
-        _validate_query(query)
+        validate_query(query)
         if tags:
-            _validate_tags(tags)
+            validate_tags(tags)
     except ValidationError as exc:
         return {"error": str(exc)}
 
@@ -311,7 +225,7 @@ async def search_collections(
         return await client.search_collections(query, tags=tags)
     except Exception as exc:
         logger.warning("search_collections failed: %s", exc)
-        return {"error": _sanitize_error(str(exc))}
+        return {"error": sanitize_error(str(exc))}
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -325,7 +239,7 @@ async def get_collection_manifest(
     """
     logger.info("get_collection_manifest namespace=%r", collection_namespace)
     try:
-        _validate_namespace(collection_namespace)
+        validate_namespace(collection_namespace)
     except ValidationError as exc:
         return {"error": str(exc)}
 
@@ -356,7 +270,7 @@ async def get_collection_manifest(
         raise
     except Exception as exc:
         logger.warning("get_collection_manifest failed: %s", exc)
-        return {"error": _maybe_add_hint(_sanitize_error(str(exc)), collection_namespace)}
+        return {"error": _maybe_add_hint(sanitize_error(str(exc)), collection_namespace)}
 
 
 @mcp.tool(annotations=ToolAnnotations(idempotentHint=True, readOnlyHint=False))
@@ -380,9 +294,9 @@ async def ensure_collection(
     """
     logger.info("ensure_collection namespace=%r version=%r", collection_namespace, version)
     try:
-        _validate_namespace(collection_namespace)
+        validate_namespace(collection_namespace)
         if version:
-            _validate_version(version)
+            validate_version(version)
     except ValidationError as exc:
         return {"error": str(exc)}
 
@@ -397,7 +311,7 @@ async def ensure_collection(
         return result
     except Exception as exc:
         logger.warning("ensure_collection failed: %s", exc)
-        return {"error": _sanitize_error(str(exc))}
+        return {"error": sanitize_error(str(exc))}
 
 
 # --- Skill management tools ---
@@ -432,7 +346,7 @@ async def list_skills() -> list[dict[str, str]]:
         return results
     except Exception as exc:
         logger.warning("list_skills failed: %s", exc)
-        return [{"error": _sanitize_error(str(exc))}]
+        return [{"error": sanitize_error(str(exc))}]
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -442,7 +356,7 @@ async def get_skill(
     """Read a specific skill's SKILL.md content by name."""
     logger.info("get_skill name=%r", skill_name)
     try:
-        _validate_fqcn(skill_name)
+        validate_fqcn(skill_name)
     except ValidationError as exc:
         return str(exc)
 
@@ -450,15 +364,15 @@ async def get_skill(
         from ansible_know.config import SKILLS_DIR
 
         skill_path = (SKILLS_DIR / skill_name / "SKILL.md").resolve()
-        _validate_path_containment(skill_path, SKILLS_DIR)
+        validate_path_containment(skill_path, SKILLS_DIR)
         if not skill_path.exists():
             return f"Skill '{skill_name}' not found."
-        return _truncate_response(skill_path.read_text())
+        return truncate_response(skill_path.read_text())
     except ValidationError as exc:
         return str(exc)
     except Exception as exc:
         logger.warning("get_skill failed: %s", exc)
-        return _sanitize_error(str(exc))
+        return sanitize_error(str(exc))
 
 
 @mcp.tool
@@ -474,9 +388,9 @@ async def generate_skill(
     """
     logger.info("generate_skill module=%r install_to=%r", module_name, install_to)
     try:
-        _validate_fqcn(module_name)
+        validate_fqcn(module_name)
         if install_to:
-            _validate_install_path(install_to)
+            validate_install_path(install_to)
     except ValidationError as exc:
         return str(exc)
 
@@ -496,7 +410,7 @@ async def generate_skill(
             await ctx.report_progress(progress=50, total=100)
 
         skill_name = skills._module_to_skill_name(metadata["module_name"])
-        base_dir = _validate_install_path(install_to) if install_to else SKILLS_DIR
+        base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
         output_dir = base_dir / skill_name
 
         await _run_in_executor(skills.write_skill_package, output_dir, metadata)
@@ -505,13 +419,13 @@ async def generate_skill(
         if ctx:
             await ctx.report_progress(progress=100, total=100)
 
-        return _truncate_response(skills.render_skill(metadata))
+        return truncate_response(skills.render_skill(metadata))
     except ValidationError as exc:
         return str(exc)
     except Exception as exc:
         logger.warning("generate_skill failed: %s", exc)
         ns = ".".join(module_name.split(".")[:2]) if "." in module_name else None
-        return _maybe_add_hint(_sanitize_error(str(exc)), ns)
+        return _maybe_add_hint(sanitize_error(str(exc)), ns)
 
 
 @mcp.tool
@@ -527,9 +441,9 @@ async def generate_collection_skills(
     """
     logger.info("generate_collection_skills namespace=%r install_to=%r", collection_namespace, install_to)
     try:
-        _validate_namespace(collection_namespace)
+        validate_namespace(collection_namespace)
         if install_to:
-            _validate_install_path(install_to)
+            validate_install_path(install_to)
     except ValidationError as exc:
         return {"error": str(exc)}
 
@@ -549,7 +463,7 @@ async def generate_collection_skills(
         failed = 0
         metadata_list = []
 
-        base_dir = _validate_install_path(install_to) if install_to else SKILLS_DIR
+        base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
 
         for i, module_name in enumerate(sorted(modules)):
             if ctx:
@@ -584,7 +498,7 @@ async def generate_collection_skills(
         raise
     except Exception as exc:
         logger.warning("generate_collection_skills failed: %s", exc)
-        return {"error": _maybe_add_hint(_sanitize_error(str(exc)), collection_namespace)}
+        return {"error": _maybe_add_hint(sanitize_error(str(exc)), collection_namespace)}
 
 
 # --- Resources (read-only data) ---
@@ -613,19 +527,19 @@ def resource_skill_content(skill_name: str) -> str:
     from ansible_know.config import SKILLS_DIR
 
     try:
-        _validate_fqcn(skill_name)
+        validate_fqcn(skill_name)
     except ValidationError as exc:
         return str(exc)
 
     skill_path = (SKILLS_DIR / skill_name / "SKILL.md").resolve()
     try:
-        _validate_path_containment(skill_path, SKILLS_DIR)
+        validate_path_containment(skill_path, SKILLS_DIR)
     except ValidationError as exc:
         return str(exc)
 
     if not skill_path.exists():
         return f"Skill '{skill_name}' not found."
-    return _truncate_response(skill_path.read_text())
+    return truncate_response(skill_path.read_text())
 
 
 @mcp.resource(

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -15,7 +15,7 @@ from typing import Annotated, Any
 from fastmcp import FastMCP, Context
 from mcp.types import ToolAnnotations
 
-from ansible_know.errors import ValidationError
+from ansible_know.errors import AnsibleDocError, ValidationError
 from ansible_know.validation import (
     validate_fqcn,
     validate_namespace,
@@ -262,7 +262,7 @@ async def get_collection_manifest(
             try:
                 raw_doc = await _run_in_executor(parser.get_module_doc, module_name)
                 metadata_list.append(parser.extract_module_metadata(raw_doc))
-            except parser.AnsibleDocError:
+            except AnsibleDocError:
                 continue
 
         return collection_manifest.generate_manifest(collection_namespace, metadata_list)

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -27,7 +27,6 @@ from ansible_know.validation import (
     validate_path_containment,
     sanitize_error,
     truncate_response,
-    MAX_RESPONSE_SIZE,
 )
 
 logger = logging.getLogger("ansible_know")

--- a/src/ansible_know/validation.py
+++ b/src/ansible_know/validation.py
@@ -1,0 +1,99 @@
+"""Input validation, error sanitization, and response truncation utilities."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ansible_know.errors import ValidationError
+
+MAX_RESPONSE_SIZE = 500_000  # 500KB
+MAX_KEYWORD_LENGTH = 200
+MAX_QUERY_LENGTH = 500
+MAX_NAMESPACE_LENGTH = 128
+MAX_VERSION_LENGTH = 64
+MAX_TAGS_LENGTH = 500
+
+_FQCN_RE = re.compile(r"^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$")
+_NAMESPACE_RE = re.compile(r"^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$")
+_VERSION_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
+_TAGS_RE = re.compile(r"^[a-zA-Z0-9_,-]+$")
+_SENSITIVE_PREFIXES = ("/etc", "/usr", "/bin", "/sbin", "/boot", "/proc", "/sys", "/dev")
+_PATH_RE = re.compile(r"/(?:home|tmp|usr|etc|var|opt)/\S+")
+
+
+def validate_fqcn(name: str) -> None:
+    if not name or not _FQCN_RE.match(name):
+        raise ValidationError(
+            "Invalid module name: expected format 'namespace.collection.module' "
+            "with alphanumeric/underscore segments."
+        )
+
+
+def validate_namespace(ns: str) -> None:
+    if not ns or len(ns) > MAX_NAMESPACE_LENGTH or not _NAMESPACE_RE.match(ns):
+        raise ValidationError(
+            "Invalid collection namespace: expected format 'namespace.collection' "
+            "with alphanumeric/underscore segments."
+        )
+
+
+def validate_keyword(keyword: str) -> None:
+    if len(keyword) > MAX_KEYWORD_LENGTH:
+        raise ValidationError(
+            f"Keyword too long: {len(keyword)} chars (max {MAX_KEYWORD_LENGTH})."
+        )
+
+
+def validate_version(version: str) -> None:
+    if not version or len(version) > MAX_VERSION_LENGTH or not _VERSION_RE.match(version):
+        raise ValidationError(
+            "Invalid version format: use alphanumeric characters, dots, dashes only."
+        )
+
+
+def validate_query(query: str) -> None:
+    if not query or not query.strip():
+        raise ValidationError("Query must not be empty.")
+    if len(query) > MAX_QUERY_LENGTH:
+        raise ValidationError(
+            f"Query too long: {len(query)} chars (max {MAX_QUERY_LENGTH})."
+        )
+
+
+def validate_tags(tags: str) -> None:
+    if len(tags) > MAX_TAGS_LENGTH:
+        raise ValidationError(
+            f"Tags too long: {len(tags)} chars (max {MAX_TAGS_LENGTH})."
+        )
+    if not _TAGS_RE.match(tags):
+        raise ValidationError(
+            "Invalid tags: use alphanumeric characters, hyphens, underscores, and commas only."
+        )
+
+
+def validate_install_path(path_str: str) -> Path:
+    resolved = Path(path_str).resolve()
+    for prefix in _SENSITIVE_PREFIXES:
+        if str(resolved).startswith(prefix):
+            raise ValidationError(
+                "Install path not allowed: cannot write to system directories."
+            )
+    return resolved
+
+
+def validate_path_containment(child: Path, parent: Path) -> None:
+    try:
+        child.resolve().relative_to(parent.resolve())
+    except ValueError:
+        raise ValidationError("Path escapes the allowed directory.")
+
+
+def sanitize_error(msg: str) -> str:
+    return _PATH_RE.sub("<path>", str(msg))
+
+
+def truncate_response(text: str) -> str:
+    if len(text) > MAX_RESPONSE_SIZE:
+        return text[:MAX_RESPONSE_SIZE] + "\n\n[Truncated — response exceeded size limit]"
+    return text

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -6,8 +6,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+from ansible_know.errors import CollectionInstallError
 from ansible_know.collections import (
-    CollectionInstallError,
     ensure_collection,
     get_collections_path,
     list_installed,

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -5,11 +5,10 @@ from unittest.mock import AsyncMock, patch, MagicMock
 import httpx
 import pytest
 
+from ansible_know.errors import GalaxyError
 from ansible_know.galaxy import (
     GalaxyClient,
-    GalaxyError,
     clear_cache,
-    _validate_component,
     _get_version_cache,
     _put_version_cache,
     _get_blob_cache,
@@ -580,45 +579,6 @@ class TestParseFqcn:
         from ansible_know.galaxy import _parse_fqcn
         with pytest.raises(GalaxyError, match="not a fully-qualified"):
             _parse_fqcn("a.b.c.d")
-
-
-class TestValidateComponent:
-    def test_rejects_empty_string(self):
-        with pytest.raises(GalaxyError, match="Invalid namespace"):
-            _validate_component("", "namespace")
-
-    def test_rejects_special_characters(self):
-        with pytest.raises(GalaxyError, match="Invalid name"):
-            _validate_component("foo-bar", "name")
-
-    def test_rejects_dots(self):
-        with pytest.raises(GalaxyError, match="Invalid namespace"):
-            _validate_component("foo.bar", "namespace")
-
-    def test_rejects_path_traversal(self):
-        with pytest.raises(GalaxyError, match="Invalid namespace"):
-            _validate_component("../etc", "namespace")
-
-    def test_rejects_unicode(self):
-        with pytest.raises(GalaxyError, match="Invalid name"):
-            _validate_component("café", "name")
-
-    def test_rejects_spaces(self):
-        with pytest.raises(GalaxyError, match="Invalid namespace"):
-            _validate_component("foo bar", "namespace")
-
-    def test_rejects_shell_metacharacters(self):
-        with pytest.raises(GalaxyError, match="Invalid name"):
-            _validate_component("$(whoami)", "name")
-
-    def test_accepts_valid_alphanumeric(self):
-        _validate_component("netbox", "namespace")
-
-    def test_accepts_underscores(self):
-        _validate_component("my_collection", "name")
-
-    def test_accepts_numbers(self):
-        _validate_component("col2", "name")
 
 
 class TestResponseSizeLimit:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,8 +5,8 @@ import os
 
 import pytest
 
+from ansible_know.errors import AnsibleDocError
 from ansible_know.parser import (
-    AnsibleDocError,
     extract_examples,
     extract_module_metadata,
     extract_params,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,7 +5,7 @@ import os
 
 import pytest
 
-from ansible_know.errors import AnsibleDocError
+from ansible_know.errors import AnsibleDocError, CollectionNotFoundError
 from ansible_know.parser import (
     extract_examples,
     extract_module_metadata,
@@ -159,3 +159,48 @@ class TestRunAnsibleDocEnvInjection:
                     _run_ansible_doc("--list", "--json")
                     call_kwargs = mock_run.call_args[1]
                     assert call_kwargs.get("env") is None
+
+
+class TestCollectionNotFoundDetection:
+    def test_raises_collection_not_found_on_has_no_attribute(self):
+        with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
+            with patch("ansible_know.collections.get_collections_path", return_value=None):
+                with patch("subprocess.run", return_value=MagicMock(
+                    returncode=1, stdout='', stderr='netbox.netbox has no attribute',
+                )):
+                    from ansible_know.parser import _run_ansible_doc
+                    with pytest.raises(CollectionNotFoundError, match="has no attribute"):
+                        _run_ansible_doc("netbox.netbox.netbox_device", "--json")
+
+    def test_raises_collection_not_found_on_was_not_found(self):
+        with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
+            with patch("ansible_know.collections.get_collections_path", return_value=None):
+                with patch("subprocess.run", return_value=MagicMock(
+                    returncode=1, stdout='', stderr='netbox.netbox was not found',
+                )):
+                    from ansible_know.parser import _run_ansible_doc
+                    with pytest.raises(CollectionNotFoundError, match="was not found"):
+                        _run_ansible_doc("netbox.netbox.netbox_device", "--json")
+
+    def test_raises_collection_not_found_on_could_not_be_found(self):
+        with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
+            with patch("ansible_know.collections.get_collections_path", return_value=None):
+                with patch("subprocess.run", return_value=MagicMock(
+                    returncode=1, stdout='', stderr='module could not be found',
+                )):
+                    from ansible_know.parser import _run_ansible_doc
+                    with pytest.raises(CollectionNotFoundError, match="could not be found"):
+                        _run_ansible_doc("netbox.netbox.netbox_device", "--json")
+
+    def test_raises_ansible_doc_error_on_other_errors(self):
+        with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
+            with patch("ansible_know.collections.get_collections_path", return_value=None):
+                with patch("subprocess.run", return_value=MagicMock(
+                    returncode=1, stdout='', stderr='ansible-doc timed out',
+                )):
+                    from ansible_know.parser import _run_ansible_doc
+                    with pytest.raises(AnsibleDocError, match="timed out"):
+                        _run_ansible_doc("ansible.builtin.copy", "--json")
+
+    def test_collection_not_found_is_subclass_of_ansible_doc_error(self):
+        assert issubclass(CollectionNotFoundError, AnsibleDocError)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -253,33 +253,33 @@ class TestPathTraversal:
 class TestErrorSanitization:
     @pytest.mark.asyncio
     async def test_error_strips_paths(self):
-        from ansible_know.server import _sanitize_error
+        from ansible_know.validation import sanitize_error
         msg = "Failed at /home/user/.ansible/tmp/something: permission denied"
-        sanitized = _sanitize_error(msg)
+        sanitized = sanitize_error(msg)
         assert "/home/user" not in sanitized
         assert "<path>" in sanitized
 
     @pytest.mark.asyncio
     async def test_error_preserves_message(self):
-        from ansible_know.server import _sanitize_error
+        from ansible_know.validation import sanitize_error
         msg = "Module not found"
-        assert _sanitize_error(msg) == msg
+        assert sanitize_error(msg) == msg
 
 
 class TestOutputTruncation:
     @pytest.mark.asyncio
     async def test_truncates_large_response(self):
-        from ansible_know.server import _truncate_response, MAX_RESPONSE_SIZE
+        from ansible_know.validation import truncate_response, MAX_RESPONSE_SIZE
         large = "x" * (MAX_RESPONSE_SIZE + 100)
-        result = _truncate_response(large)
+        result = truncate_response(large)
         assert len(result) < len(large)
         assert "Truncated" in result
 
     @pytest.mark.asyncio
     async def test_preserves_small_response(self):
-        from ansible_know.server import _truncate_response
+        from ansible_know.validation import truncate_response
         small = "hello world"
-        assert _truncate_response(small) == small
+        assert truncate_response(small) == small
 
 
 class TestEnsureCollectionTool:
@@ -333,9 +333,8 @@ class TestEnsureCollectionTool:
 class TestMissingCollectionHints:
     @pytest.mark.asyncio
     async def test_get_module_doc_hint(self, mock_ansible_doc):
-        from ansible_know.parser import AnsibleDocError
-        from ansible_know.galaxy import GalaxyError
-        mock_ansible_doc.side_effect = AnsibleDocError(
+        from ansible_know.errors import CollectionNotFoundError, GalaxyError
+        mock_ansible_doc.side_effect = CollectionNotFoundError(
             "ansible-doc failed (exit 1): netbox.netbox.netbox_device has no attribute"
         )
         with patch(
@@ -349,8 +348,8 @@ class TestMissingCollectionHints:
 
     @pytest.mark.asyncio
     async def test_search_modules_hint(self, mock_ansible_doc):
-        from ansible_know.parser import AnsibleDocError
-        mock_ansible_doc.side_effect = AnsibleDocError(
+        from ansible_know.errors import CollectionNotFoundError
+        mock_ansible_doc.side_effect = CollectionNotFoundError(
             "ansible-doc failed (exit 1): netbox.netbox was not found"
         )
         from ansible_know.server import search_modules
@@ -359,9 +358,8 @@ class TestMissingCollectionHints:
 
     @pytest.mark.asyncio
     async def test_generate_skill_hint(self, mock_ansible_doc):
-        from ansible_know.parser import AnsibleDocError
-        from ansible_know.galaxy import GalaxyError
-        mock_ansible_doc.side_effect = AnsibleDocError(
+        from ansible_know.errors import CollectionNotFoundError, GalaxyError
+        mock_ansible_doc.side_effect = CollectionNotFoundError(
             "ansible-doc failed (exit 1): netbox.netbox.netbox_device could not be found"
         )
         with patch(
@@ -374,7 +372,7 @@ class TestMissingCollectionHints:
 
     @pytest.mark.asyncio
     async def test_no_hint_for_unrelated_errors(self, mock_ansible_doc):
-        from ansible_know.parser import AnsibleDocError
+        from ansible_know.errors import AnsibleDocError
         mock_ansible_doc.side_effect = AnsibleDocError("Some unrelated error")
         from ansible_know.server import get_module_doc
         result = await get_module_doc("ansible.builtin.copy")
@@ -417,8 +415,8 @@ class TestGalaxyDocsFallback:
 
     @pytest.mark.asyncio
     async def test_get_module_doc_falls_back_to_galaxy(self, mock_ansible_doc):
-        from ansible_know.parser import AnsibleDocError
-        mock_ansible_doc.side_effect = AnsibleDocError(
+        from ansible_know.errors import CollectionNotFoundError
+        mock_ansible_doc.side_effect = CollectionNotFoundError(
             "ansible-doc failed (exit 1): netbox.netbox.netbox_device has no attribute"
         )
 
@@ -453,7 +451,7 @@ class TestGalaxyDocsFallback:
 
     @pytest.mark.asyncio
     async def test_get_module_doc_no_fallback_for_non_missing_errors(self, mock_ansible_doc):
-        from ansible_know.parser import AnsibleDocError
+        from ansible_know.errors import AnsibleDocError
         mock_ansible_doc.side_effect = AnsibleDocError("ansible-doc timed out")
 
         with patch(
@@ -467,9 +465,8 @@ class TestGalaxyDocsFallback:
 
     @pytest.mark.asyncio
     async def test_get_module_doc_returns_error_when_both_fail(self, mock_ansible_doc):
-        from ansible_know.parser import AnsibleDocError
-        from ansible_know.galaxy import GalaxyError
-        mock_ansible_doc.side_effect = AnsibleDocError(
+        from ansible_know.errors import CollectionNotFoundError, GalaxyError
+        mock_ansible_doc.side_effect = CollectionNotFoundError(
             "ansible-doc failed (exit 1): some.col.mod was not found"
         )
 
@@ -484,8 +481,8 @@ class TestGalaxyDocsFallback:
 
     @pytest.mark.asyncio
     async def test_generate_skill_falls_back_to_galaxy(self, mock_ansible_doc, tmp_path, monkeypatch):
-        from ansible_know.parser import AnsibleDocError
-        mock_ansible_doc.side_effect = AnsibleDocError(
+        from ansible_know.errors import CollectionNotFoundError
+        mock_ansible_doc.side_effect = CollectionNotFoundError(
             "ansible-doc failed (exit 1): netbox.netbox.netbox_device has no attribute"
         )
 
@@ -521,7 +518,7 @@ class TestGalaxyDocsFallback:
 class TestResolveModuleDoc:
     @pytest.mark.asyncio
     async def test_non_missing_collection_error_not_retried(self, mock_ansible_doc):
-        from ansible_know.parser import AnsibleDocError
+        from ansible_know.errors import AnsibleDocError
         mock_ansible_doc.side_effect = AnsibleDocError("ansible-doc timed out")
 
         with patch(
@@ -534,9 +531,8 @@ class TestResolveModuleDoc:
 
     @pytest.mark.asyncio
     async def test_galaxy_fallback_raises_original_on_galaxy_failure(self, mock_ansible_doc):
-        from ansible_know.parser import AnsibleDocError
-        from ansible_know.galaxy import GalaxyError
-        mock_ansible_doc.side_effect = AnsibleDocError(
+        from ansible_know.errors import CollectionNotFoundError, GalaxyError
+        mock_ansible_doc.side_effect = CollectionNotFoundError(
             "ansible-doc failed (exit 1): some.col.mod has no attribute"
         )
 
@@ -545,7 +541,7 @@ class TestResolveModuleDoc:
             side_effect=GalaxyError("Module 'mod' not found in docs-blob"),
         ):
             from ansible_know.server import _resolve_module_doc
-            with pytest.raises(AnsibleDocError, match="has no attribute"):
+            with pytest.raises(CollectionNotFoundError, match="has no attribute"):
                 await _resolve_module_doc("some.col.mod")
 
 
@@ -664,7 +660,7 @@ class TestSearchCollectionsTool:
 
     @pytest.mark.asyncio
     async def test_handles_galaxy_error(self):
-        from ansible_know.galaxy import GalaxyError
+        from ansible_know.errors import GalaxyError
         with patch("ansible_know.galaxy.GalaxyClient.search_collections", side_effect=GalaxyError("timeout")):
             from ansible_know.server import search_collections
             result = await search_collections("netbox")


### PR DESCRIPTION
## Summary

Architecture cleanup addressing all 5 items from #15:

- **`errors.py`** — unified `AnsibleKnowError` base with typed subclasses: `AnsibleDocError`, `CollectionNotFoundError`, `GalaxyError`, `CollectionInstallError`, `ValidationError`
- **`CollectionNotFoundError`** — `parser.py` raises it for missing-collection errors so `_resolve_module_doc` catches explicitly instead of pattern-matching on bare `Exception`
- **`validation.py`** — extracted all validators, regex constants, `sanitize_error()`, and `truncate_response()` from `server.py`
- **DRY `sanitize_error`** — removed duplicate from `collections.py`; both modules now import from `validation.py`
- **Removed `_validate_component` from `galaxy.py`** — inputs are validated at the `server.py` API boundary; Galaxy methods trust their callers

Net -150 lines of production code. No behavior changes. 177 tests pass (10 removed with `TestValidateComponent`).

Closes #15

## Test plan

- [x] All 177 tests pass (`pytest tests/ -v`)
- [x] No import errors — all modules load cleanly
- [x] Exception hierarchy correct: `CollectionNotFoundError` is subclass of `AnsibleDocError` is subclass of `AnsibleKnowError`
- [x] Galaxy fallback still triggers on collection-not-found errors
- [x] Galaxy fallback does NOT trigger on unrelated errors (e.g. timeout)

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>