### PR TITLE
feat: MCP UX polish and best practices (#17, #10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Runtime requirement: `ansible-core` must be installed in the same environment (f
 
 ```
 src/ansible_know/
-├── server.py              # FastMCP server: 10 tools, 3 resources, 3 prompts (entrypoint)
+├── server.py              # FastMCP server: 10 tools, 4 resources, 4 prompts (entrypoint)
 ├── parser.py              # ansible-doc wrapper — module discovery and metadata extraction
 ├── skills.py              # skill rendering + package writing (Jinja2)
 ├── config.py              # paths, constants, doc source registry
@@ -40,8 +40,8 @@ src/ansible_know/
 | `ensure_collection` | idempotent write | Install a collection for this session |
 | `list_skills` | read-only | List generated skills |
 | `get_skill` | read-only | Read a skill's content |
-| `generate_skill` | write | Generate a skill package for one module |
-| `generate_collection_skills` | write | Batch generate skills for a collection |
+| `generate_skill` | idempotent write | Generate a skill package for one module |
+| `generate_collection_skills` | idempotent write | Batch generate skills for a collection |
 
 ## MCP Resources
 
@@ -49,6 +49,7 @@ src/ansible_know/
 |-----|-------------|
 | `skills://list` | List all generated skill packages |
 | `skills://{skill_name}` | Read a skill's SKILL.md by FQCN |
+| `galaxy://installed` | List collections installed in this session |
 | `docs://sources` | List configured doc manifest sources |
 
 ## MCP Prompts
@@ -58,6 +59,7 @@ src/ansible_know/
 | `review_playbook` | Review a playbook against module docs |
 | `explain_module` | Detailed module explanation with examples |
 | `generate_role` | Generate a role skeleton using specified modules |
+| `find_collection` | Guide through search, install, and explore workflow |
 
 ## Key Patterns
 

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -173,6 +173,7 @@ async def get_module_doc(
     examples (raw YAML), is_api_module, doc_source ('local' or 'galaxy').
     When doc_source is 'galaxy', also includes doc_version and optionally doc_warning.
     Falls back to Galaxy if collection is not installed locally.
+    On failure returns {"error": str}.
     """
     logger.info("get_module_doc module=%r", module_name)
     try:
@@ -207,10 +208,11 @@ async def search_docs(
     topic: Annotated[str | None, "Filter by topic tag"] = None,
     audience: Annotated[str | None, "Filter by audience tag"] = None,
     core_only: Annotated[bool, "If true, only return entries marked as core"] = False,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | dict[str, str]:
     """Search documentation manifests for conceptual guides.
 
     Returns up to 20 matching entries with title, summary, topic, audience, lines, source, and raw URL.
+    On failure returns {"error": str}.
     """
     logger.info("search_docs query=%r", query)
     try:
@@ -247,6 +249,7 @@ async def search_collections(
     Returns: {"query": str, "count": int, "collections": [{"namespace": str,
     "description": str, "tags": [str], "latest_version": str, "module_count": int,
     "download_count": int, "deprecated": bool, "signed": bool}, ...]}
+    On failure returns {"error": str}.
     """
     logger.info("search_collections query=%r tags=%r", query, tags)
     try:
@@ -275,6 +278,7 @@ async def get_collection_manifest(
 
     Returns cached MANIFEST.json if available, otherwise generates on-demand
     (metadata extraction only, no skill generation).
+    On failure returns {"error": str}.
     """
     logger.info("get_collection_manifest namespace=%r", collection_namespace)
     try:
@@ -330,6 +334,7 @@ async def ensure_collection(
     - status: 'installed' (freshly installed or upgraded) or
       'already_installed' (same version already present, no action taken)
     - message: str — human-readable summary including the active version
+    On failure returns {"error": str}.
     """
     logger.info("ensure_collection namespace=%r version=%r", collection_namespace, version)
     try:
@@ -358,7 +363,7 @@ async def ensure_collection(
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-async def list_skills() -> list[dict[str, str]]:
+async def list_skills() -> list[dict[str, str]] | dict[str, str]:
     """List all available generated skills. Returns name, description, path for each.
 
     Returns: [{"name": str, "description": str, "path": str}, ...] or {"error": str} on failure.
@@ -395,7 +400,7 @@ async def list_skills() -> list[dict[str, str]]:
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def get_skill(
     skill_name: Annotated[str, "Skill name (usually the module FQCN)"],
-) -> str:
+) -> str | dict[str, str]:
     """Read a specific skill's SKILL.md content by name.
 
     Returns: SKILL.md content as str, or {"error": str} on failure/not found.
@@ -426,7 +431,7 @@ async def generate_skill(
     module_name: Annotated[str, "Fully-qualified module name (e.g. 'ansible.builtin.copy')"],
     install_to: Annotated[str | None, "Optional absolute path to install the skill to"] = None,
     ctx: Context = None,
-) -> str:
+) -> str | dict[str, str]:
     """Generate a skill package for one module.
 
     Writes SKILL.md + scripts + playbook to disk.
@@ -487,7 +492,8 @@ async def generate_collection_skills(
     """Batch generate skills for an entire collection.
 
     Generates/updates the collection MANIFEST.json as a byproduct.
-    Returns summary (succeeded/failed counts) + manifest content.
+    Returns {"succeeded": int, "failed": int, "total": int, "manifest": dict},
+    or {"error": str} on failure.
     """
     logger.info("generate_collection_skills namespace=%r install_to=%r", collection_namespace, install_to)
     try:

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1,7 +1,8 @@
 """Ansible Know MCP Server.
 
-Provides 10 tools for module discovery, documentation search,
-Galaxy collection discovery, and skill generation via the Model Context Protocol.
+Provides 10 tools, 4 resources, and 4 prompts for module discovery,
+documentation search, Galaxy collection discovery, and skill generation
+via the Model Context Protocol.
 """
 
 from __future__ import annotations
@@ -136,7 +137,10 @@ async def search_modules(
     keyword: Annotated[str, "Search term to match against module names and descriptions"],
     namespace: Annotated[str | None, "Optional collection namespace filter (e.g. 'community.docker')"] = None,
 ) -> dict[str, str]:
-    """Find Ansible modules by keyword in name or description. Returns up to 50 matches as {fqcn: short_description}."""
+    """Find Ansible modules by keyword in name or description. Returns up to 50 matches as {fqcn: short_description}.
+
+    Returns: {"module.fqcn": "short description", ...} or {"error": str} on failure.
+    """
     logger.info("search_modules keyword=%r namespace=%r", keyword, namespace)
     try:
         validate_keyword(keyword)
@@ -190,6 +194,9 @@ async def get_module_doc(
     except Exception as exc:
         logger.warning("get_module_doc failed: %s", exc)
         ns = ".".join(module_name.split(".")[:2]) if "." in module_name else None
+        from ansible_know.errors import GalaxyError
+        if isinstance(exc.__cause__, GalaxyError):
+            return {"error": sanitize_error(str(exc))}
         return {"error": _maybe_add_hint(sanitize_error(str(exc)), ns)}
 
 
@@ -209,7 +216,7 @@ async def search_docs(
     try:
         validate_query(query)
     except ValidationError as exc:
-        return [{"error": str(exc)}]
+        return {"error": str(exc)}
 
     try:
         from ansible_know import docs
@@ -219,7 +226,7 @@ async def search_docs(
         )
     except Exception as exc:
         logger.warning("search_docs failed: %s", exc)
-        return [{"error": sanitize_error(str(exc))}]
+        return {"error": sanitize_error(str(exc))}
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -352,7 +359,10 @@ async def ensure_collection(
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def list_skills() -> list[dict[str, str]]:
-    """List all available generated skills. Returns name, description, path for each."""
+    """List all available generated skills. Returns name, description, path for each.
+
+    Returns: [{"name": str, "description": str, "path": str}, ...] or {"error": str} on failure.
+    """
     logger.info("list_skills")
     try:
         from ansible_know.config import SKILLS_DIR
@@ -379,19 +389,22 @@ async def list_skills() -> list[dict[str, str]]:
         return results
     except Exception as exc:
         logger.warning("list_skills failed: %s", exc)
-        return [{"error": sanitize_error(str(exc))}]
+        return {"error": sanitize_error(str(exc))}
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def get_skill(
     skill_name: Annotated[str, "Skill name (usually the module FQCN)"],
 ) -> str:
-    """Read a specific skill's SKILL.md content by name."""
+    """Read a specific skill's SKILL.md content by name.
+
+    Returns: SKILL.md content as str, or {"error": str} on failure/not found.
+    """
     logger.info("get_skill name=%r", skill_name)
     try:
         validate_fqcn(skill_name)
     except ValidationError as exc:
-        return str(exc)
+        return {"error": str(exc)}
 
     try:
         from ansible_know.config import SKILLS_DIR
@@ -399,16 +412,16 @@ async def get_skill(
         skill_path = (SKILLS_DIR / skill_name / "SKILL.md").resolve()
         validate_path_containment(skill_path, SKILLS_DIR)
         if not skill_path.exists():
-            return f"Skill '{skill_name}' not found."
+            return {"error": f"Skill '{skill_name}' not found."}
         return truncate_response(skill_path.read_text())
     except ValidationError as exc:
-        return str(exc)
+        return {"error": str(exc)}
     except Exception as exc:
         logger.warning("get_skill failed: %s", exc)
-        return sanitize_error(str(exc))
+        return {"error": sanitize_error(str(exc))}
 
 
-@mcp.tool
+@mcp.tool(annotations=ToolAnnotations(idempotentHint=True))
 async def generate_skill(
     module_name: Annotated[str, "Fully-qualified module name (e.g. 'ansible.builtin.copy')"],
     install_to: Annotated[str | None, "Optional absolute path to install the skill to"] = None,
@@ -417,7 +430,7 @@ async def generate_skill(
     """Generate a skill package for one module.
 
     Writes SKILL.md + scripts + playbook to disk.
-    Returns the SKILL.md content inline so the agent can use it immediately.
+    Returns the SKILL.md content as str, or {"error": str} on failure.
     """
     logger.info("generate_skill module=%r install_to=%r", module_name, install_to)
     try:
@@ -425,7 +438,7 @@ async def generate_skill(
         if install_to:
             validate_install_path(install_to)
     except ValidationError as exc:
-        return str(exc)
+        return {"error": str(exc)}
 
     try:
         from ansible_know import parser, skills
@@ -455,14 +468,17 @@ async def generate_skill(
 
         return truncate_response(skills.render_skill(metadata))
     except ValidationError as exc:
-        return str(exc)
+        return {"error": str(exc)}
     except Exception as exc:
         logger.warning("generate_skill failed: %s", exc)
         ns = ".".join(module_name.split(".")[:2]) if "." in module_name else None
-        return _maybe_add_hint(sanitize_error(str(exc)), ns)
+        from ansible_know.errors import GalaxyError
+        if isinstance(exc.__cause__, GalaxyError):
+            return {"error": sanitize_error(str(exc))}
+        return {"error": _maybe_add_hint(sanitize_error(str(exc)), ns)}
 
 
-@mcp.tool
+@mcp.tool(annotations=ToolAnnotations(idempotentHint=True))
 async def generate_collection_skills(
     collection_namespace: Annotated[str, "Collection namespace (e.g. 'netbox.netbox')"],
     install_to: Annotated[str | None, "Optional absolute path to install skills to"] = None,
@@ -577,6 +593,17 @@ def resource_skill_content(skill_name: str) -> str:
 
 
 @mcp.resource(
+    "galaxy://installed",
+    name="Installed Collections",
+    description="List collections installed in this session via ensure_collection",
+)
+def resource_installed_collections() -> str:
+    from ansible_know import collections
+
+    return json.dumps(collections.list_installed(), indent=2)
+
+
+@mcp.resource(
     "docs://sources",
     name="Documentation Sources",
     description="List configured documentation manifest sources",
@@ -634,6 +661,20 @@ def generate_role(role_purpose: str, modules: str) -> str:
         "- Include meta/argument_specs.yml for validation\n"
         "- Ensure idempotency with changed_when on command/shell tasks\n"
         "- Add a README.md with example playbooks"
+    )
+
+
+@mcp.prompt
+def find_collection(platform_or_use_case: str) -> str:
+    """Guide the agent through discovering, installing, and exploring a collection."""
+    return (
+        f"Find an Ansible collection for: {platform_or_use_case}\n\n"
+        "Follow these steps:\n"
+        "1. Use search_collections to find relevant collections on Galaxy\n"
+        "2. Pick the best match (prefer high download count, non-deprecated)\n"
+        "3. Use ensure_collection to install it for this session\n"
+        "4. Use get_collection_manifest to see all available modules\n"
+        "5. Use get_module_doc on the most relevant modules to understand their usage"
     )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -116,7 +116,8 @@ class TestGetSkillTool:
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
         from ansible_know.server import get_skill
         result = await get_skill("ansible.builtin.nonexistent")
-        assert "not found" in result.lower()
+        assert "error" in result
+        assert "not found" in result["error"].lower()
 
 
 class TestGenerateSkillTool:
@@ -234,8 +235,7 @@ class TestQueryValidation:
     async def test_rejects_long_query(self):
         from ansible_know.server import search_docs
         result = await search_docs("a" * 501)
-        assert len(result) == 1
-        assert "error" in result[0]
+        assert "error" in result
 
 
 class TestPathTraversal:
@@ -244,19 +244,19 @@ class TestPathTraversal:
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
         from ansible_know.server import get_skill
         result = await get_skill("../../etc/passwd")
-        assert "invalid" in result.lower() or "error" in result.lower()
+        assert "error" in result
 
     @pytest.mark.asyncio
     async def test_generate_skill_blocks_etc(self):
         from ansible_know.server import generate_skill
         result = await generate_skill("ansible.builtin.copy", install_to="/etc/evil")
-        assert "not allowed" in result.lower() or "error" in result.lower()
+        assert "error" in result
 
     @pytest.mark.asyncio
     async def test_generate_skill_blocks_usr(self):
         from ansible_know.server import generate_skill
         result = await generate_skill("ansible.builtin.copy", install_to="/usr/local/evil")
-        assert "not allowed" in result.lower() or "error" in result.lower()
+        assert "error" in result
 
 
 class TestErrorSanitization:
@@ -341,7 +341,7 @@ class TestEnsureCollectionTool:
 
 class TestMissingCollectionHints:
     @pytest.mark.asyncio
-    async def test_get_module_doc_hint(self, mock_ansible_doc):
+    async def test_get_module_doc_hint_suppressed_on_double_failure(self, mock_ansible_doc):
         from ansible_know.errors import CollectionNotFoundError, GalaxyError
         mock_ansible_doc.side_effect = CollectionNotFoundError(
             "ansible-doc failed (exit 1): netbox.netbox.netbox_device has no attribute"
@@ -352,8 +352,18 @@ class TestMissingCollectionHints:
         ):
             from ansible_know.server import get_module_doc
             result = await get_module_doc("netbox.netbox.netbox_device")
+        assert "error" in result
+        assert "ensure_collection" not in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_module_doc_hint_on_local_only_failure(self, mock_ansible_doc):
+        from ansible_know.errors import AnsibleDocError
+        mock_ansible_doc.side_effect = AnsibleDocError(
+            "ansible-doc failed (exit 1): netbox.netbox was not found"
+        )
+        from ansible_know.server import get_module_doc
+        result = await get_module_doc("netbox.netbox.netbox_device")
         assert "ensure_collection" in result["error"]
-        assert "netbox.netbox" in result["error"]
 
     @pytest.mark.asyncio
     async def test_search_modules_hint(self, mock_ansible_doc):
@@ -366,7 +376,7 @@ class TestMissingCollectionHints:
         assert "ensure_collection" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_generate_skill_hint(self, mock_ansible_doc):
+    async def test_generate_skill_hint_suppressed_on_double_failure(self, mock_ansible_doc):
         from ansible_know.errors import CollectionNotFoundError, GalaxyError
         mock_ansible_doc.side_effect = CollectionNotFoundError(
             "ansible-doc failed (exit 1): netbox.netbox.netbox_device could not be found"
@@ -377,7 +387,8 @@ class TestMissingCollectionHints:
         ):
             from ansible_know.server import generate_skill
             result = await generate_skill("netbox.netbox.netbox_device")
-        assert "ensure_collection" in result
+        assert "error" in result
+        assert "ensure_collection" not in result["error"]
 
     @pytest.mark.asyncio
     async def test_no_hint_for_unrelated_errors(self, mock_ansible_doc):
@@ -582,6 +593,19 @@ class TestResourceFunctions:
         result = resource_skill_content("../../etc/passwd")
         assert "invalid" in result.lower() or "expected" in result.lower()
 
+    def test_resource_installed_collections_empty(self):
+        with patch("ansible_know.collections.list_installed", return_value={}):
+            from ansible_know.server import resource_installed_collections
+            result = json.loads(resource_installed_collections())
+        assert result == {}
+
+    def test_resource_installed_collections_with_data(self):
+        installed = {"netbox.netbox": "4.1.0", "ansible.utils": "5.0.0"}
+        with patch("ansible_know.collections.list_installed", return_value=installed):
+            from ansible_know.server import resource_installed_collections
+            result = json.loads(resource_installed_collections())
+        assert result == installed
+
     def test_resource_doc_sources(self):
         from ansible_know.server import resource_doc_sources
         result = json.loads(resource_doc_sources())
@@ -607,6 +631,13 @@ class TestPromptFunctions:
         result = generate_role("Install nginx", "ansible.builtin.package, ansible.builtin.service")
         assert "Install nginx" in result
         assert "ansible.builtin.package" in result
+
+    def test_find_collection_prompt(self):
+        from ansible_know.server import find_collection
+        result = find_collection("NetBox DCIM")
+        assert "NetBox DCIM" in result
+        assert "search_collections" in result
+        assert "ensure_collection" in result
 
 
 class TestSearchCollectionsTool:


### PR DESCRIPTION
## Summary

Addresses remaining items from #17 (MCP UX polish) and #10 (MCP best practices):

- Add `galaxy://installed` resource — wraps `collections.list_installed()` to expose session-installed collections
- Add `find_collection` prompt — guides agents through the search → install → explore workflow
- Fix double-failure error hint — when both local ansible-doc AND Galaxy fail, stop suggesting `ensure_collection` (since Galaxy already failed, installing won't help)
- Standardize error returns — all tools now return `{"error": str}` dicts instead of mixed `[{"error":...}]` or bare strings
- Add `idempotentHint=True` to `generate_skill` and `generate_collection_skills` annotations
- Add return value documentation to `search_modules`, `list_skills`, `get_skill`, `generate_skill` docstrings

## Test plan

- [ ] All 206 tests pass (`pytest tests/ -v`)
- [ ] New tests: `test_resource_installed_collections_empty`, `test_resource_installed_collections_with_data`, `test_find_collection_prompt`
- [ ] Updated tests: double-failure hint tests now verify hint is suppressed, error return tests check for `{"error": ...}` dicts
- [ ] No regressions in existing Galaxy fallback, negative cache, or validation tests

Closes #17
Closes #10

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>