### PR TITLE
fix: quick wins from codebase review (#25, #26, #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ uvx ansible-know-mcp
 |-----|-------------|
 | `skills://list` | List all generated skill packages |
 | `skills://{skill_name}` | Read a skill's SKILL.md content by FQCN |
+| `galaxy://installed` | List collections installed in this session |
 | `docs://sources` | List configured documentation manifest sources |
 
 ## Prompts
@@ -149,6 +150,7 @@ uvx ansible-know-mcp
 | `review_playbook(playbook_yaml)` | Review a playbook against module docs and best practices |
 | `explain_module(module_name)` | Get a detailed module explanation with usage examples |
 | `generate_role(role_purpose, modules)` | Generate a role skeleton using specified modules |
+| `find_collection(platform_or_use_case)` | Guide through search, install, and explore workflow |
 
 ## Development
 

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -316,7 +316,7 @@ async def get_collection_manifest(
         return {"error": _maybe_add_hint(sanitize_error(str(exc)), collection_namespace)}
 
 
-@mcp.tool(annotations=ToolAnnotations(idempotentHint=True, readOnlyHint=False))
+@mcp.tool(annotations=ToolAnnotations(idempotentHint=True, readOnlyHint=False, destructiveHint=False))
 async def ensure_collection(
     collection_namespace: Annotated[str, "Collection namespace (e.g. 'netbox.netbox')"],
     version: Annotated[str | None, "Optional version (e.g. '4.1.0'). If omitted, installs latest and pins the resolved version."] = None,

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -78,7 +78,7 @@ def write_skill_package(output_dir: Path, metadata: dict[str, Any]) -> None:
         template = env.get_template(f"{script_name}.j2")
         script_path = scripts_dir / script_name
         script_path.write_text(template.render(**ctx))
-        script_path.chmod(script_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
 
     assets_dir = output_dir / "assets"
     assets_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary

Three quick fixes from the full codebase security/MCP/QA review:

- **#25** — Script permissions changed from world-executable (`S_IXUSR|S_IXGRP|S_IXOTH`) to owner-only (`S_IXUSR`)
- **#26** — README updated with `find_collection` prompt and `galaxy://installed` resource
- **#27** — `ensure_collection` gets explicit `destructiveHint=False` annotation

## Test plan

- [ ] All 206 tests pass
- [ ] `test_scripts_are_executable` still passes (verifies owner execute bit)

Closes #25
Closes #26
Closes #27

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>