### PR TITLE
docs: expose server version, add upgrade instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ Together with [Ansible Devtools MCP](https://github.com/ansible/ansible-dev-tool
  | search_collections    |  | ansible_lint      |  | controller.*  |
  | search_modules        |  | ansible_navigator |  | eda.*         |
  | get_module_doc        |  | ansible_create_*  |  | gateway.*     |
- | get_collection_       |  | build_ee          |  | galaxy.*      |
- |   manifest            |  | zen_of_ansible    |  |               |
- | search_docs           |  | setup_environment |  |               |
- | ensure_collection     |  | environment_info  |  |               |
+ | get_role_doc          |  | build_ee          |  | galaxy.*      |
+ | get_collection_       |  | zen_of_ansible    |  |               |
+ |   manifest            |  | setup_environment |  |               |
+ | search_docs           |  | environment_info  |  |               |
+ | ensure_collection     |  |                   |  |               |
  | generate_skill        |  |                   |  |               |
+ | generate_role_skill   |  |                   |  |               |
  | generate_collection   |  |                   |  |               |
  | list_skills           |  |                   |  |               |
  | get_skill             |  |                   |  |               |
@@ -116,8 +118,9 @@ uvx ansible-know-mcp
 | `search_collections(query, tags?)` | Search Ansible Galaxy for collections by keyword. Returns results ranked by download count. |
 | `search_modules(keyword, namespace?)` | Find modules by keyword in name or description. Returns up to 50 matches. |
 | `get_module_doc(module_name)` | Get full structured docs: params, examples, API detection. Falls back to Galaxy if not installed locally. |
+| `get_role_doc(role_name)` | Get role documentation with three-tier resolution: local ansible-doc, Galaxy README, or graceful degradation. |
 | `search_docs(query, source?, topic?, audience?, core_only?)` | Search documentation manifests for conceptual guides. Returns up to 20 matches. |
-| `get_collection_manifest(collection_namespace)` | Get collection-level manifest with per-module summaries. |
+| `get_collection_manifest(collection_namespace)` | Get collection-level manifest with per-module and per-role summaries. |
 
 ### Collection management
 
@@ -132,6 +135,7 @@ uvx ansible-know-mcp
 | `list_skills()` | List all generated skills (read-only). |
 | `get_skill(skill_name)` | Read a skill's SKILL.md content (read-only). |
 | `generate_skill(module_name, install_to?)` | Generate a skill package for one module. Returns SKILL.md inline. |
+| `generate_role_skill(role_name, install_to?)` | Generate a skill package for one role. Returns SKILL.md inline. |
 | `generate_collection_skills(collection_namespace, install_to?)` | Batch generate skills for an entire collection. |
 
 ## Resources
@@ -151,6 +155,22 @@ uvx ansible-know-mcp
 | `explain_module(module_name)` | Get a detailed module explanation with usage examples |
 | `generate_role(role_purpose, modules)` | Generate a role skeleton using specified modules |
 | `find_collection(platform_or_use_case)` | Guide through search, install, and explore workflow |
+
+## Upgrading
+
+The server exposes its version via the MCP protocol. To upgrade to the latest release:
+
+| Installation method | Upgrade command |
+|---|---|
+| `uvx` | `uvx --upgrade ansible-know-mcp` |
+| `pip` | `pip install --upgrade ansible-know-mcp` |
+| Claude Code (`claude mcp add`) | `uvx --upgrade ansible-know-mcp` then restart Claude Code |
+| VS Code / Cursor | `uvx --upgrade ansible-know-mcp` then reload window |
+| Local dev | `git pull && uv sync` |
+
+> **Note:** `uvx` caches the installed version. It does not auto-upgrade on new releases.
+> To always run the latest version at the cost of slower startup, register with:
+> `claude mcp add ansible-know -- uvx --upgrade ansible-know-mcp`
 
 ## Development
 

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 from functools import partial
+from importlib.metadata import version as pkg_version
 from typing import Annotated, Any
 
 import httpx
@@ -44,8 +45,11 @@ async def app_lifespan(server):
         yield {"http_client": client}
 
 
+_VERSION = pkg_version("ansible-know-mcp")
+
 mcp = FastMCP(
     name="Ansible Know",
+    version=_VERSION,
     instructions=(
         "Ansible module and role discovery, documentation, and skill generation. "
         "Workflow: (1) search_collections to discover collections on Galaxy, "


### PR DESCRIPTION
## Summary

- Expose package version in MCP server metadata via `importlib.metadata`
- Add Upgrading section to README with per-installation-method instructions
- Add `get_role_doc` and `generate_role_skill` to README tools table (missed in v0.3.0)

## Test plan

- [x] `_VERSION` reads correctly from `pyproject.toml`
- [x] FastMCP constructor receives `version` parameter
- [x] 345 unit tests pass
- [x] Ruff clean

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>