### PR TITLE
feat: multi-server Galaxy support via ansible.cfg

### DIFF
--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -187,7 +187,7 @@ class GalaxyClient:
             "headers": self._auth_headers(),
             "timeout": timeout,
         }
-        if self._username and self._password:
+        if not self._token and self._username and self._password:
             kwargs["auth"] = httpx.BasicAuth(self._username, self._password)
         resp = await client.get(url, **kwargs)
         try:

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -11,12 +11,15 @@ import logging
 import threading
 import time
 from collections import OrderedDict
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
 from ansible_know.config import GALAXY_BASE_URL
 from ansible_know.errors import GalaxyError
+
+if TYPE_CHECKING:
+    from ansible_know.galaxy_config import GalaxyServerConfig
 
 logger = logging.getLogger("ansible_know")
 
@@ -107,10 +110,39 @@ def _parse_fqcn(module_name: str) -> tuple[str, str, str]:
 class GalaxyClient:
     """Async client for the Galaxy v3 API."""
 
-    def __init__(self, base_url: str | None = None, http_client: httpx.AsyncClient | None = None):
+    def __init__(
+        self,
+        base_url: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
+        token: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        verify: bool = True,
+        server_name: str | None = None,
+    ):
         self._base = (base_url or GALAXY_BASE_URL).rstrip("/")
         self._http_client = http_client
         self._owned_client: httpx.AsyncClient | None = None
+        self._token = token
+        self._username = username
+        self._password = password
+        self._verify = verify
+        self.server_name = server_name
+
+    @classmethod
+    def from_config(
+        cls, config: GalaxyServerConfig, http_client: httpx.AsyncClient | None = None,
+    ) -> GalaxyClient:
+        """Create a GalaxyClient from a GalaxyServerConfig."""
+        return cls(
+            base_url=config.url,
+            http_client=http_client,
+            token=config.token,
+            username=config.username,
+            password=config.password,
+            verify=config.validate_certs,
+            server_name=config.name,
+        )
 
     async def __aenter__(self) -> GalaxyClient:
         return self
@@ -131,9 +163,16 @@ class GalaxyClient:
         if self._owned_client is None:
             self._owned_client = httpx.AsyncClient(
                 timeout=httpx.Timeout(10.0, read=120.0),
-                verify=True,
+                verify=self._verify,
             )
         return self._owned_client
+
+    def _auth_headers(self) -> dict[str, str]:
+        """Build authentication headers based on configured credentials."""
+        headers: dict[str, str] = {"Accept": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"Token {self._token}"
+        return headers
 
     async def _api_get(
         self,
@@ -143,9 +182,14 @@ class GalaxyClient:
     ) -> dict[str, Any]:
         url = f"{self._base}{path}"
         client = self._get_client()
-        resp = await client.get(
-            url, params=params, headers={"Accept": "application/json"}, timeout=timeout,
-        )
+        kwargs: dict[str, Any] = {
+            "params": params,
+            "headers": self._auth_headers(),
+            "timeout": timeout,
+        }
+        if self._username and self._password:
+            kwargs["auth"] = httpx.BasicAuth(self._username, self._password)
+        resp = await client.get(url, **kwargs)
         try:
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:

--- a/src/ansible_know/galaxy_config.py
+++ b/src/ansible_know/galaxy_config.py
@@ -140,11 +140,15 @@ def load_galaxy_servers() -> list[GalaxyServerConfig]:
         if fallback_url != PUBLIC_GALAXY_URL:
             logger.info("Using custom Galaxy URL: %s", fallback_url)
 
-    seen_urls = {s.url.rstrip("/") for s in servers}
-    if PUBLIC_GALAXY_URL not in seen_urls:
-        servers.append(GalaxyServerConfig(
-            name="public_galaxy",
-            url=PUBLIC_GALAXY_URL,
-        ))
+    no_public = os.environ.get(
+        "ANSIBLE_KNOW_NO_PUBLIC_GALAXY", "",
+    ).strip().lower() in ("1", "true", "yes")
+    if not no_public:
+        seen_urls = {s.url.rstrip("/") for s in servers}
+        if PUBLIC_GALAXY_URL not in seen_urls:
+            servers.append(GalaxyServerConfig(
+                name="public_galaxy",
+                url=PUBLIC_GALAXY_URL,
+            ))
 
     return servers

--- a/src/ansible_know/galaxy_config.py
+++ b/src/ansible_know/galaxy_config.py
@@ -1,0 +1,140 @@
+"""Galaxy server configuration from ansible.cfg.
+
+Reads [galaxy_server.*] sections to support multiple Galaxy-compatible
+endpoints (public Galaxy, private Automation Hub, AAP Gateway) with
+per-server authentication.
+"""
+
+from __future__ import annotations
+
+import configparser
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from ansible_know.config import GALAXY_BASE_URL
+
+logger = logging.getLogger("ansible_know")
+
+PUBLIC_GALAXY_URL = "https://galaxy.ansible.com"
+
+
+@dataclass(frozen=True)
+class GalaxyServerConfig:
+    """Configuration for a single Galaxy-compatible server."""
+
+    name: str
+    url: str
+    token: str | None = None
+    username: str | None = None
+    password: str | None = None
+    auth_url: str | None = None
+    client_id: str | None = None
+    validate_certs: bool = True
+    timeout: int = 60
+
+
+def find_ansible_cfg() -> Path | None:
+    """Resolve ansible.cfg using Ansible's standard lookup order."""
+    env = os.environ.get("ANSIBLE_CONFIG")
+    if env:
+        p = Path(env)
+        if p.is_file():
+            return p
+        return None
+
+    candidates = [
+        Path.cwd() / "ansible.cfg",
+        Path.home() / ".ansible.cfg",
+        Path("/etc/ansible/ansible.cfg"),
+    ]
+    for p in candidates:
+        if p.is_file():
+            return p
+    return None
+
+
+def _env_override(server_name: str, key: str) -> str | None:
+    """Check for ANSIBLE_GALAXY_SERVER_{NAME}_{KEY} env var override."""
+    env_key = f"ANSIBLE_GALAXY_SERVER_{server_name.upper()}_{key.upper()}"
+    return os.environ.get(env_key)
+
+
+def _read_server(
+    cfg: configparser.ConfigParser, name: str,
+) -> GalaxyServerConfig | None:
+    """Read a single [galaxy_server.NAME] section with env var overrides."""
+    section = f"galaxy_server.{name}"
+
+    def _get(key: str, fallback: str | None = None) -> str | None:
+        return _env_override(name, key) or cfg.get(section, key, fallback=fallback)
+
+    url = _get("url")
+    if not url:
+        logger.warning("Galaxy server '%s' has no url, skipping", name)
+        return None
+
+    validate_raw = _get("validate_certs", "true")
+    validate_certs = validate_raw.lower() not in ("false", "0", "no")
+
+    timeout_raw = _get("timeout", "60")
+    try:
+        timeout = int(timeout_raw)
+    except (ValueError, TypeError):
+        timeout = 60
+
+    return GalaxyServerConfig(
+        name=name,
+        url=url.rstrip("/"),
+        token=_get("token"),
+        username=_get("username"),
+        password=_get("password"),
+        auth_url=_get("auth_url"),
+        client_id=_get("client_id"),
+        validate_certs=validate_certs,
+        timeout=timeout,
+    )
+
+
+def load_galaxy_servers() -> list[GalaxyServerConfig]:
+    """Load Galaxy server configurations from ansible.cfg.
+
+    Resolution order:
+    1. Parse ansible.cfg [galaxy] server_list + [galaxy_server.*] sections
+    2. Apply ANSIBLE_GALAXY_SERVER_{NAME}_{KEY} env var overrides
+    3. Fall back to ANSIBLE_KNOW_GALAXY_URL or public Galaxy
+    """
+    cfg_path = find_ansible_cfg()
+    servers: list[GalaxyServerConfig] = []
+
+    if cfg_path:
+        logger.info("Reading Galaxy config from %s", cfg_path)
+        cfg = configparser.ConfigParser()
+        cfg.read(str(cfg_path))
+
+        server_list_raw = cfg.get("galaxy", "server_list", fallback="")
+        server_names = [s.strip() for s in server_list_raw.split(",") if s.strip()]
+
+        for name in server_names:
+            server = _read_server(cfg, name)
+            if server:
+                servers.append(server)
+
+    if not servers:
+        fallback_url = GALAXY_BASE_URL
+        servers.append(GalaxyServerConfig(
+            name="galaxy",
+            url=fallback_url.rstrip("/"),
+        ))
+        if fallback_url != PUBLIC_GALAXY_URL:
+            logger.info("Using custom Galaxy URL: %s", fallback_url)
+
+    seen_urls = {s.url.rstrip("/") for s in servers}
+    if PUBLIC_GALAXY_URL not in seen_urls:
+        servers.append(GalaxyServerConfig(
+            name="public_galaxy",
+            url=PUBLIC_GALAXY_URL,
+        ))
+
+    return servers

--- a/src/ansible_know/galaxy_config.py
+++ b/src/ansible_know/galaxy_config.py
@@ -61,6 +61,16 @@ def _env_override(server_name: str, key: str) -> str | None:
     return os.environ.get(env_key)
 
 
+def _sanitize_credential(value: str | None) -> str | None:
+    """Strip control characters that could enable header injection."""
+    if value is None:
+        return None
+    sanitized = value.replace("\r", "").replace("\n", "").strip()
+    if sanitized != value.strip():
+        logger.warning("Stripped control characters from credential value")
+    return sanitized or None
+
+
 def _read_server(
     cfg: configparser.ConfigParser, name: str,
 ) -> GalaxyServerConfig | None:
@@ -76,7 +86,7 @@ def _read_server(
         return None
 
     validate_raw = _get("validate_certs", "true")
-    validate_certs = validate_raw.lower() not in ("false", "0", "no")
+    validate_certs = validate_raw.lower() not in ("false", "0", "no", "off")
 
     timeout_raw = _get("timeout", "60")
     try:
@@ -87,9 +97,9 @@ def _read_server(
     return GalaxyServerConfig(
         name=name,
         url=url.rstrip("/"),
-        token=_get("token"),
-        username=_get("username"),
-        password=_get("password"),
+        token=_sanitize_credential(_get("token")),
+        username=_sanitize_credential(_get("username")),
+        password=_sanitize_credential(_get("password")),
         auth_url=_get("auth_url"),
         client_id=_get("client_id"),
         validate_certs=validate_certs,

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import os
+from collections.abc import Awaitable, Callable
 from functools import partial
 from importlib.metadata import version as pkg_version
 from typing import Annotated, Any
@@ -38,7 +39,7 @@ logger = logging.getLogger("ansible_know")
 
 _VERSION = pkg_version("ansible-know-mcp")
 _version_info: dict[str, Any] | None = None
-_galaxy_servers: list | None = None
+_galaxy_servers: list[Any] | None = None
 
 
 def _is_stable(v: str) -> bool:
@@ -164,10 +165,10 @@ def _maybe_add_hint(error_msg: str, namespace: str | None) -> str:
 
 
 async def _try_galaxy_servers(
-    servers: list,
-    operation,
+    servers: list[Any],
+    operation: Callable[..., Awaitable[Any]],
     http_client: httpx.AsyncClient | None = None,
-):
+) -> tuple[Any, str]:
     """Try an operation across multiple Galaxy servers in priority order.
 
     Args:
@@ -198,7 +199,7 @@ async def _try_galaxy_servers(
 async def _resolve_module_doc(
     module_name: str,
     http_client: httpx.AsyncClient | None = None,
-    galaxy_servers: list | None = None,
+    galaxy_servers: list[Any] | None = None,
 ) -> tuple[dict, dict | None]:
     """Try local ansible-doc, fall back to Galaxy if the collection is missing.
 
@@ -248,7 +249,7 @@ async def _resolve_module_doc(
 async def _resolve_role_doc(
     role_name: str,
     http_client: httpx.AsyncClient | None = None,
-    galaxy_servers: list | None = None,
+    galaxy_servers: list[Any] | None = None,
 ) -> dict[str, Any]:
     """Try local ansible-doc -t role, fall back to Galaxy readme_html.
 

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -38,6 +38,7 @@ logger = logging.getLogger("ansible_know")
 
 _VERSION = pkg_version("ansible-know-mcp")
 _version_info: dict[str, Any] | None = None
+_galaxy_servers: list | None = None
 
 
 def _is_stable(v: str) -> bool:
@@ -80,10 +81,11 @@ async def _check_pypi_version(client: httpx.AsyncClient) -> dict[str, Any] | Non
 
 @lifespan
 async def app_lifespan(server):
-    global _version_info
+    global _version_info, _galaxy_servers
     from ansible_know.galaxy_config import load_galaxy_servers
 
     galaxy_servers = load_galaxy_servers()
+    _galaxy_servers = galaxy_servers
     for gs in galaxy_servers:
         auth_type = "token" if gs.token else ("basic" if gs.username else "none")
         logger.info("Galaxy server: %s (%s, auth=%s)", gs.name, gs.url, auth_type)
@@ -205,9 +207,9 @@ async def _resolve_module_doc(
     """
     from ansible_know import parser
     from ansible_know.errors import CollectionNotFoundError, GalaxyError
-    from ansible_know.galaxy_config import GalaxyServerConfig
+    from ansible_know.galaxy_config import load_galaxy_servers
 
-    servers = galaxy_servers or [GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")]
+    servers = galaxy_servers or load_galaxy_servers()
     namespace = ".".join(module_name.split(".")[:2]) if "." in module_name else None
 
     if namespace and namespace in _missing_collections:
@@ -255,9 +257,9 @@ async def _resolve_role_doc(
     """
     from ansible_know import parser
     from ansible_know.errors import CollectionNotFoundError, GalaxyError
-    from ansible_know.galaxy_config import GalaxyServerConfig
+    from ansible_know.galaxy_config import load_galaxy_servers
 
-    servers = galaxy_servers or [GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")]
+    servers = galaxy_servers or load_galaxy_servers()
     namespace = ".".join(role_name.split(".")[:2]) if "." in role_name else None
 
     local_doc: dict[str, Any] = {}
@@ -474,32 +476,41 @@ async def search_collections(
         return {"error": str(exc)}
 
     try:
-        from ansible_know.errors import GalaxyError
         from ansible_know.galaxy import GalaxyClient
-        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.galaxy_config import load_galaxy_servers
 
         http_client = ctx.lifespan_context.get("http_client") if ctx else None
         galaxy_servers = ctx.lifespan_context.get("galaxy_servers") if ctx else None
-        servers = galaxy_servers or [GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")]
+        servers = galaxy_servers or load_galaxy_servers()
+
+        async def _query_server(server):
+            client_kwarg = http_client if server.validate_certs else None
+            async with GalaxyClient.from_config(server, http_client=client_kwarg) as client:
+                result = await client.search_collections(query, tags=tags)
+            return server.name, result
+
+        tasks = [_query_server(s) for s in servers]
+        outcomes = await asyncio.gather(*tasks, return_exceptions=True)
 
         all_collections: list[dict[str, Any]] = []
         seen_namespaces: set[str] = set()
         errors: list[str] = []
 
-        for server in servers:
-            try:
-                client_kwarg = http_client if server.validate_certs else None
-                async with GalaxyClient.from_config(server, http_client=client_kwarg) as client:
-                    result = await client.search_collections(query, tags=tags)
-                for coll in result.get("collections", []):
-                    ns = coll.get("namespace", "")
-                    if ns not in seen_namespaces:
-                        coll["source"] = server.name
-                        all_collections.append(coll)
-                        seen_namespaces.add(ns)
-            except GalaxyError as exc:
-                logger.info("search_collections on '%s' failed: %s", server.name, exc)
-                errors.append(f"{server.name}: {exc}")
+        for i, outcome in enumerate(outcomes):
+            if isinstance(outcome, Exception):
+                logger.info(
+                    "search_collections on '%s' failed: %s",
+                    servers[i].name, outcome,
+                )
+                errors.append(f"{servers[i].name}: {outcome}")
+                continue
+            server_name, result = outcome
+            for coll in result.get("collections", []):
+                ns = coll.get("namespace", "")
+                if ns not in seen_namespaces:
+                    coll["source"] = server_name
+                    all_collections.append(coll)
+                    seen_namespaces.add(ns)
 
         if not all_collections and errors:
             return {"error": f"All Galaxy servers failed: {'; '.join(errors)}"}
@@ -973,7 +984,7 @@ def resource_server_version() -> str:
 def resource_galaxy_servers() -> str:
     from ansible_know.galaxy_config import load_galaxy_servers
 
-    servers = load_galaxy_servers()
+    servers = _galaxy_servers or load_galaxy_servers()
     return json.dumps([
         {
             "name": s.name,

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -212,12 +212,13 @@ async def _resolve_module_doc(
     servers = galaxy_servers or load_galaxy_servers()
     namespace = ".".join(module_name.split(".")[:2]) if "." in module_name else None
 
+    async def _fetch_from_galaxy(client):
+        return await client.fetch_module_doc(module_name)
+
     if namespace and namespace in _missing_collections:
         try:
-            async def _fetch(client):
-                return await client.fetch_module_doc(module_name)
             (galaxy_doc, galaxy_meta), server_name = await _try_galaxy_servers(
-                servers, _fetch, http_client,
+                servers, _fetch_from_galaxy, http_client,
             )
             galaxy_meta["doc_source_server"] = server_name
             return galaxy_doc, galaxy_meta
@@ -234,10 +235,8 @@ async def _resolve_module_doc(
             _missing_collections.add(namespace)
         logger.info("Collection not installed, trying Galaxy: %s", local_exc)
         try:
-            async def _fetch(client):
-                return await client.fetch_module_doc(module_name)
             (galaxy_doc, galaxy_meta), server_name = await _try_galaxy_servers(
-                servers, _fetch, http_client,
+                servers, _fetch_from_galaxy, http_client,
             )
             galaxy_meta["doc_source_server"] = server_name
             return galaxy_doc, galaxy_meta
@@ -979,7 +978,10 @@ def resource_server_version() -> str:
 @mcp.resource(
     "galaxy://servers",
     name="Galaxy Servers",
-    description="List configured Galaxy servers from ansible.cfg",
+    description=(
+        "List configured Galaxy servers from ansible.cfg. "
+        "Shows auth type (token/basic/none) for debugging; credentials are never exposed."
+    ),
 )
 def resource_galaxy_servers() -> str:
     from ansible_know.galaxy_config import load_galaxy_servers

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -81,12 +81,24 @@ async def _check_pypi_version(client: httpx.AsyncClient) -> dict[str, Any] | Non
 @lifespan
 async def app_lifespan(server):
     global _version_info
+    from ansible_know.galaxy_config import load_galaxy_servers
+
+    galaxy_servers = load_galaxy_servers()
+    for gs in galaxy_servers:
+        auth_type = "token" if gs.token else ("basic" if gs.username else "none")
+        logger.info("Galaxy server: %s (%s, auth=%s)", gs.name, gs.url, auth_type)
+
     async with httpx.AsyncClient(
         timeout=httpx.Timeout(10.0, read=120.0),
         verify=True,
     ) as client:
         _version_info = await _check_pypi_version(client)
-        yield {"http_client": client, "version_info": _version_info, "upgrade_warned": False}
+        yield {
+            "http_client": client,
+            "version_info": _version_info,
+            "upgrade_warned": False,
+            "galaxy_servers": galaxy_servers,
+        }
 
 mcp = FastMCP(
     name="Ansible Know",
@@ -149,8 +161,41 @@ def _maybe_add_hint(error_msg: str, namespace: str | None) -> str:
     return error_msg
 
 
+async def _try_galaxy_servers(
+    servers: list,
+    operation,
+    http_client: httpx.AsyncClient | None = None,
+):
+    """Try an operation across multiple Galaxy servers in priority order.
+
+    Args:
+        servers: List of GalaxyServerConfig objects.
+        operation: Async callable taking a GalaxyClient, returns result.
+        http_client: Shared httpx client.
+
+    Returns the first successful result. Raises the last GalaxyError if all fail.
+    """
+    from ansible_know.errors import GalaxyError
+    from ansible_know.galaxy import GalaxyClient
+
+    last_exc: GalaxyError | None = None
+    for server in servers:
+        try:
+            async with GalaxyClient.from_config(server, http_client=http_client) as client:
+                result = await operation(client)
+            return result, server.name
+        except GalaxyError as exc:
+            logger.info("Galaxy server '%s' failed: %s", server.name, exc)
+            last_exc = exc
+    if last_exc is not None:
+        raise last_exc
+    raise GalaxyError("No Galaxy servers configured")
+
+
 async def _resolve_module_doc(
-    module_name: str, http_client: httpx.AsyncClient | None = None,
+    module_name: str,
+    http_client: httpx.AsyncClient | None = None,
+    galaxy_servers: list | None = None,
 ) -> tuple[dict, dict | None]:
     """Try local ansible-doc, fall back to Galaxy if the collection is missing.
 
@@ -159,14 +204,19 @@ async def _resolve_module_doc(
     """
     from ansible_know import parser
     from ansible_know.errors import CollectionNotFoundError, GalaxyError
+    from ansible_know.galaxy_config import GalaxyServerConfig
 
+    servers = galaxy_servers or [GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")]
     namespace = ".".join(module_name.split(".")[:2]) if "." in module_name else None
 
     if namespace and namespace in _missing_collections:
         try:
-            from ansible_know.galaxy import GalaxyClient
-            async with GalaxyClient(http_client=http_client) as client:
-                galaxy_doc, galaxy_meta = await client.fetch_module_doc(module_name)
+            async def _fetch(client):
+                return await client.fetch_module_doc(module_name)
+            (galaxy_doc, galaxy_meta), server_name = await _try_galaxy_servers(
+                servers, _fetch, http_client,
+            )
+            galaxy_meta["doc_source_server"] = server_name
             return galaxy_doc, galaxy_meta
         except GalaxyError as galaxy_exc:
             raise CollectionNotFoundError(
@@ -181,10 +231,12 @@ async def _resolve_module_doc(
             _missing_collections.add(namespace)
         logger.info("Collection not installed, trying Galaxy: %s", local_exc)
         try:
-            from ansible_know.galaxy import GalaxyClient
-
-            async with GalaxyClient(http_client=http_client) as client:
-                galaxy_doc, galaxy_meta = await client.fetch_module_doc(module_name)
+            async def _fetch(client):
+                return await client.fetch_module_doc(module_name)
+            (galaxy_doc, galaxy_meta), server_name = await _try_galaxy_servers(
+                servers, _fetch, http_client,
+            )
+            galaxy_meta["doc_source_server"] = server_name
             return galaxy_doc, galaxy_meta
         except GalaxyError as galaxy_exc:
             logger.warning("Galaxy fallback also failed: %s", galaxy_exc)
@@ -192,7 +244,9 @@ async def _resolve_module_doc(
 
 
 async def _resolve_role_doc(
-    role_name: str, http_client: httpx.AsyncClient | None = None,
+    role_name: str,
+    http_client: httpx.AsyncClient | None = None,
+    galaxy_servers: list | None = None,
 ) -> dict[str, Any]:
     """Try local ansible-doc -t role, fall back to Galaxy readme_html.
 
@@ -200,7 +254,9 @@ async def _resolve_role_doc(
     """
     from ansible_know import parser
     from ansible_know.errors import CollectionNotFoundError, GalaxyError
+    from ansible_know.galaxy_config import GalaxyServerConfig
 
+    servers = galaxy_servers or [GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")]
     namespace = ".".join(role_name.split(".")[:2]) if "." in role_name else None
 
     local_doc: dict[str, Any] = {}
@@ -223,14 +279,16 @@ async def _resolve_role_doc(
         return metadata
 
     try:
-        from ansible_know.galaxy import GalaxyClient
-
-        async with GalaxyClient(http_client=http_client) as client:
-            galaxy_role_meta, galaxy_meta = await client.fetch_role_doc(role_name)
+        async def _fetch(client):
+            return await client.fetch_role_doc(role_name)
+        (galaxy_role_meta, galaxy_meta), server_name = await _try_galaxy_servers(
+            servers, _fetch, http_client,
+        )
 
         result = dict(galaxy_role_meta)
         result["content_type"] = "role"
         result["doc_source"] = "galaxy_readme"
+        result["doc_source_server"] = server_name
         result["doc_version"] = galaxy_meta.get("doc_version", "")
         if "doc_warning" in galaxy_meta:
             result["doc_warning"] = galaxy_meta["doc_warning"]
@@ -302,7 +360,10 @@ async def get_module_doc(
         from ansible_know import parser
 
         http_client = ctx.lifespan_context.get("http_client") if ctx else None
-        raw_doc, galaxy_meta = await _resolve_module_doc(module_name, http_client=http_client)
+        galaxy_servers = ctx.lifespan_context.get("galaxy_servers") if ctx else None
+        raw_doc, galaxy_meta = await _resolve_module_doc(
+            module_name, http_client=http_client, galaxy_servers=galaxy_servers,
+        )
         metadata = parser.extract_module_metadata(raw_doc)
         if galaxy_meta:
             metadata.update(galaxy_meta)
@@ -342,7 +403,10 @@ async def get_role_doc(
 
     try:
         http_client = ctx.lifespan_context.get("http_client") if ctx else None
-        return await _resolve_role_doc(role_name, http_client=http_client)
+        galaxy_servers = ctx.lifespan_context.get("galaxy_servers") if ctx else None
+        return await _resolve_role_doc(
+            role_name, http_client=http_client, galaxy_servers=galaxy_servers,
+        )
     except Exception as exc:
         logger.warning("get_role_doc failed: %s", exc)
         ns = ".".join(role_name.split(".")[:2]) if "." in role_name else None
@@ -409,11 +473,42 @@ async def search_collections(
         return {"error": str(exc)}
 
     try:
+        from ansible_know.errors import GalaxyError
         from ansible_know.galaxy import GalaxyClient
+        from ansible_know.galaxy_config import GalaxyServerConfig
 
         http_client = ctx.lifespan_context.get("http_client") if ctx else None
-        async with GalaxyClient(http_client=http_client) as client:
-            return await client.search_collections(query, tags=tags)
+        galaxy_servers = ctx.lifespan_context.get("galaxy_servers") if ctx else None
+        servers = galaxy_servers or [GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")]
+
+        all_collections: list[dict[str, Any]] = []
+        seen_namespaces: set[str] = set()
+        errors: list[str] = []
+
+        for server in servers:
+            try:
+                async with GalaxyClient.from_config(server, http_client=http_client) as client:
+                    result = await client.search_collections(query, tags=tags)
+                for coll in result.get("collections", []):
+                    ns = coll.get("namespace", "")
+                    if ns not in seen_namespaces:
+                        coll["source"] = server.name
+                        all_collections.append(coll)
+                        seen_namespaces.add(ns)
+            except GalaxyError as exc:
+                logger.info("search_collections on '%s' failed: %s", server.name, exc)
+                errors.append(f"{server.name}: {exc}")
+
+        if not all_collections and errors:
+            return {"error": f"All Galaxy servers failed: {'; '.join(errors)}"}
+
+        all_collections.sort(key=lambda c: c.get("download_count", 0), reverse=True)
+
+        return {
+            "query": query,
+            "count": len(all_collections),
+            "collections": all_collections,
+        }
     except Exception as exc:
         logger.warning("search_collections failed: %s", exc)
         return {"error": sanitize_error(str(exc))}
@@ -631,7 +726,10 @@ async def generate_skill(
             await ctx.report_progress(progress=0, total=100)
 
         http_client = ctx.lifespan_context.get("http_client") if ctx else None
-        raw_doc, galaxy_meta = await _resolve_module_doc(module_name, http_client=http_client)
+        galaxy_servers = ctx.lifespan_context.get("galaxy_servers") if ctx else None
+        raw_doc, galaxy_meta = await _resolve_module_doc(
+            module_name, http_client=http_client, galaxy_servers=galaxy_servers,
+        )
         metadata = parser.extract_module_metadata(raw_doc)
         if galaxy_meta:
             metadata.update(galaxy_meta)
@@ -689,7 +787,10 @@ async def generate_role_skill(
             await ctx.report_progress(progress=0, total=100)
 
         http_client = ctx.lifespan_context.get("http_client") if ctx else None
-        metadata = await _resolve_role_doc(role_name, http_client=http_client)
+        galaxy_servers = ctx.lifespan_context.get("galaxy_servers") if ctx else None
+        metadata = await _resolve_role_doc(
+            role_name, http_client=http_client, galaxy_servers=galaxy_servers,
+        )
 
         if metadata.get("doc_source") == "unavailable":
             return {"error": metadata.get("error", f"No documentation found for role '{role_name}'.")}
@@ -860,6 +961,26 @@ def resource_server_version() -> str:
         },
         indent=2,
     )
+
+
+@mcp.resource(
+    "galaxy://servers",
+    name="Galaxy Servers",
+    description="List configured Galaxy servers from ansible.cfg",
+)
+def resource_galaxy_servers() -> str:
+    from ansible_know.galaxy_config import load_galaxy_servers
+
+    servers = load_galaxy_servers()
+    return json.dumps([
+        {
+            "name": s.name,
+            "url": s.url,
+            "auth": "token" if s.token else ("basic" if s.username else "none"),
+            "validate_certs": s.validate_certs,
+        }
+        for s in servers
+    ], indent=2)
 
 
 @mcp.resource(

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -181,7 +181,8 @@ async def _try_galaxy_servers(
     last_exc: GalaxyError | None = None
     for server in servers:
         try:
-            async with GalaxyClient.from_config(server, http_client=http_client) as client:
+            client_kwarg = http_client if server.validate_certs else None
+            async with GalaxyClient.from_config(server, http_client=client_kwarg) as client:
                 result = await operation(client)
             return result, server.name
         except GalaxyError as exc:
@@ -487,7 +488,8 @@ async def search_collections(
 
         for server in servers:
             try:
-                async with GalaxyClient.from_config(server, http_client=http_client) as client:
+                client_kwarg = http_client if server.validate_certs else None
+                async with GalaxyClient.from_config(server, http_client=client_kwarg) as client:
                     result = await client.search_collections(query, tags=tags)
                 for coll in result.get("collections", []):
                     ns = coll.get("namespace", "")

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -1335,3 +1335,61 @@ class TestSearchCollectionsRoleCount:
         col = result["collections"][0]
         assert col["role_count"] == 2
         assert col["module_count"] == 1
+
+
+class TestGalaxyClientAuth:
+    def test_token_auth_headers(self):
+        gc = GalaxyClient(token="my_secret_token")
+        headers = gc._auth_headers()
+        assert headers["Authorization"] == "Token my_secret_token"
+        assert headers["Accept"] == "application/json"
+
+    def test_no_auth_headers(self):
+        gc = GalaxyClient()
+        headers = gc._auth_headers()
+        assert "Authorization" not in headers
+        assert headers["Accept"] == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_token_sent_in_request(self):
+        mock_client = _mock_client_get(SAMPLE_VERSIONS_RESPONSE)
+        gc = GalaxyClient(http_client=mock_client, token="test_token")
+        await gc.latest_version("netbox", "netbox")
+        call_kwargs = mock_client.get.call_args[1]
+        assert call_kwargs["headers"]["Authorization"] == "Token test_token"
+
+    @pytest.mark.asyncio
+    async def test_basic_auth_sent_in_request(self):
+        mock_client = _mock_client_get(SAMPLE_VERSIONS_RESPONSE)
+        gc = GalaxyClient(http_client=mock_client, username="admin", password="secret")
+        await gc.latest_version("netbox", "netbox")
+        call_kwargs = mock_client.get.call_args[1]
+        auth = call_kwargs.get("auth")
+        assert auth is not None
+        assert isinstance(auth, httpx.BasicAuth)
+
+    def test_verify_false_on_owned_client(self):
+        mock_client = AsyncMock()
+        with patch("ansible_know.galaxy.httpx.AsyncClient", return_value=mock_client) as mock_ctor:
+            gc = GalaxyClient(verify=False)
+            gc._get_client()
+        mock_ctor.assert_called_once()
+        assert mock_ctor.call_args[1]["verify"] is False
+
+    def test_server_name_stored(self):
+        gc = GalaxyClient(server_name="my_hub")
+        assert gc.server_name == "my_hub"
+
+    def test_from_config(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        config = GalaxyServerConfig(
+            name="test_hub",
+            url="https://hub.example.com/api/galaxy",
+            token="tok123",
+            validate_certs=False,
+        )
+        gc = GalaxyClient.from_config(config)
+        assert gc._base == "https://hub.example.com/api/galaxy"
+        assert gc._token == "tok123"
+        assert gc._verify is False
+        assert gc.server_name == "test_hub"

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -1380,6 +1380,20 @@ class TestGalaxyClientAuth:
         gc = GalaxyClient(server_name="my_hub")
         assert gc.server_name == "my_hub"
 
+    @pytest.mark.asyncio
+    async def test_token_takes_precedence_over_basic_auth(self):
+        mock_client = _mock_client_get(SAMPLE_VERSIONS_RESPONSE)
+        gc = GalaxyClient(
+            http_client=mock_client,
+            token="my_token",
+            username="admin",
+            password="secret",
+        )
+        await gc.latest_version("netbox", "netbox")
+        call_kwargs = mock_client.get.call_args[1]
+        assert call_kwargs["headers"]["Authorization"] == "Token my_token"
+        assert "auth" not in call_kwargs
+
     def test_from_config(self):
         from ansible_know.galaxy_config import GalaxyServerConfig
         config = GalaxyServerConfig(

--- a/tests/test_galaxy_config.py
+++ b/tests/test_galaxy_config.py
@@ -9,6 +9,7 @@ import pytest
 
 from ansible_know.galaxy_config import (
     GalaxyServerConfig,
+    _sanitize_credential,
     find_ansible_cfg,
     load_galaxy_servers,
 )
@@ -206,6 +207,96 @@ class TestLoadGalaxyServers:
             servers = load_galaxy_servers()
 
         assert servers[0].timeout == 120
+
+
+    def test_validate_certs_off(self, tmp_path):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text(textwrap.dedent("""\
+            [galaxy]
+            server_list = my_hub
+
+            [galaxy_server.my_hub]
+            url = https://hub.example.com/api/galaxy/
+            validate_certs = off
+        """))
+        with patch.dict(os.environ, {"ANSIBLE_CONFIG": str(cfg)}):
+            servers = load_galaxy_servers()
+
+        assert servers[0].validate_certs is False
+
+    def test_validate_certs_on(self, tmp_path):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text(textwrap.dedent("""\
+            [galaxy]
+            server_list = my_hub
+
+            [galaxy_server.my_hub]
+            url = https://hub.example.com/api/galaxy/
+            validate_certs = on
+        """))
+        with patch.dict(os.environ, {"ANSIBLE_CONFIG": str(cfg)}):
+            servers = load_galaxy_servers()
+
+        assert servers[0].validate_certs is True
+
+    def test_crlf_stripped_from_token(self, tmp_path):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text(textwrap.dedent("""\
+            [galaxy]
+            server_list = my_hub
+
+            [galaxy_server.my_hub]
+            url = https://hub.example.com/api/galaxy/
+        """))
+        with patch.dict(os.environ, {
+            "ANSIBLE_CONFIG": str(cfg),
+            "ANSIBLE_GALAXY_SERVER_MY_HUB_TOKEN": "secret\r\nX-Evil: true",
+        }):
+            servers = load_galaxy_servers()
+
+        assert servers[0].token == "secretX-Evil: true"
+        assert "\r" not in servers[0].token
+        assert "\n" not in servers[0].token
+
+    def test_crlf_stripped_from_username(self, tmp_path):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text(textwrap.dedent("""\
+            [galaxy]
+            server_list = my_hub
+
+            [galaxy_server.my_hub]
+            url = https://hub.example.com/api/galaxy/
+        """))
+        with patch.dict(os.environ, {
+            "ANSIBLE_CONFIG": str(cfg),
+            "ANSIBLE_GALAXY_SERVER_MY_HUB_USERNAME": "admin\r\n",
+        }):
+            servers = load_galaxy_servers()
+
+        assert servers[0].username == "admin"
+
+
+class TestSanitizeCredential:
+    def test_none_returns_none(self):
+        assert _sanitize_credential(None) is None
+
+    def test_clean_value_unchanged(self):
+        assert _sanitize_credential("my_token_123") == "my_token_123"
+
+    def test_strips_crlf(self):
+        assert _sanitize_credential("secret\r\nX-Evil: true") == "secretX-Evil: true"
+
+    def test_strips_lone_cr(self):
+        assert _sanitize_credential("secret\rvalue") == "secretvalue"
+
+    def test_strips_lone_lf(self):
+        assert _sanitize_credential("secret\nvalue") == "secretvalue"
+
+    def test_empty_after_strip_returns_none(self):
+        assert _sanitize_credential("\r\n") is None
+
+    def test_whitespace_stripped(self):
+        assert _sanitize_credential("  token  ") == "token"
 
 
 class TestGalaxyServerConfig:

--- a/tests/test_galaxy_config.py
+++ b/tests/test_galaxy_config.py
@@ -1,0 +1,225 @@
+"""Tests for ansible_know.galaxy_config."""
+
+import os
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ansible_know.galaxy_config import (
+    GalaxyServerConfig,
+    find_ansible_cfg,
+    load_galaxy_servers,
+)
+
+
+class TestFindAnsibleCfg:
+    def test_env_var_overrides_all(self, tmp_path):
+        cfg = tmp_path / "custom.cfg"
+        cfg.write_text("[galaxy]\n")
+        with patch.dict(os.environ, {"ANSIBLE_CONFIG": str(cfg)}):
+            assert find_ansible_cfg() == cfg
+
+    def test_env_var_nonexistent_returns_none(self):
+        with patch.dict(os.environ, {"ANSIBLE_CONFIG": "/nonexistent/ansible.cfg"}):
+            assert find_ansible_cfg() is None
+
+    def test_cwd_ansible_cfg(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text("[galaxy]\n")
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ANSIBLE_CONFIG", None)
+            assert find_ansible_cfg() == cfg
+
+    def test_no_cfg_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ANSIBLE_CONFIG", None)
+            with patch("ansible_know.galaxy_config.Path.home", return_value=tmp_path / "fakehome"):
+                result = find_ansible_cfg()
+                assert result is None or result == Path("/etc/ansible/ansible.cfg")
+
+
+class TestLoadGalaxyServers:
+    def test_no_ansible_cfg_returns_default(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ANSIBLE_CONFIG", None)
+            with patch("ansible_know.galaxy_config.find_ansible_cfg", return_value=None):
+                servers = load_galaxy_servers()
+        assert len(servers) >= 1
+        assert servers[0].url == "https://galaxy.ansible.com"
+
+    def test_parses_server_list(self, tmp_path):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text(textwrap.dedent("""\
+            [galaxy]
+            server_list = my_hub, public_galaxy
+
+            [galaxy_server.my_hub]
+            url = https://hub.example.com/api/galaxy/
+            token = secret123
+            validate_certs = false
+
+            [galaxy_server.public_galaxy]
+            url = https://galaxy.ansible.com/
+        """))
+        with patch.dict(os.environ, {"ANSIBLE_CONFIG": str(cfg)}):
+            servers = load_galaxy_servers()
+
+        assert len(servers) == 2
+        assert servers[0].name == "my_hub"
+        assert servers[0].url == "https://hub.example.com/api/galaxy"
+        assert servers[0].token == "secret123"
+        assert servers[0].validate_certs is False
+        assert servers[1].name == "public_galaxy"
+        assert servers[1].url == "https://galaxy.ansible.com"
+        assert servers[1].token is None
+        assert servers[1].validate_certs is True
+
+    def test_env_var_override_token(self, tmp_path):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text(textwrap.dedent("""\
+            [galaxy]
+            server_list = my_hub
+
+            [galaxy_server.my_hub]
+            url = https://hub.example.com/api/galaxy/
+            token = original_token
+        """))
+        with patch.dict(os.environ, {
+            "ANSIBLE_CONFIG": str(cfg),
+            "ANSIBLE_GALAXY_SERVER_MY_HUB_TOKEN": "override_token",
+        }):
+            servers = load_galaxy_servers()
+
+        assert servers[0].token == "override_token"
+
+    def test_env_var_override_url(self, tmp_path):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text(textwrap.dedent("""\
+            [galaxy]
+            server_list = my_hub
+
+            [galaxy_server.my_hub]
+            url = https://hub.example.com/api/galaxy/
+        """))
+        with patch.dict(os.environ, {
+            "ANSIBLE_CONFIG": str(cfg),
+            "ANSIBLE_GALAXY_SERVER_MY_HUB_URL": "https://override.example.com/api/galaxy/",
+        }):
+            servers = load_galaxy_servers()
+
+        assert servers[0].url == "https://override.example.com/api/galaxy"
+
+    def test_skips_server_without_url(self, tmp_path):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text(textwrap.dedent("""\
+            [galaxy]
+            server_list = bad_server, good_server
+
+            [galaxy_server.bad_server]
+            token = no_url_here
+
+            [galaxy_server.good_server]
+            url = https://galaxy.ansible.com/
+        """))
+        with patch.dict(os.environ, {"ANSIBLE_CONFIG": str(cfg)}):
+            servers = load_galaxy_servers()
+
+        names = [s.name for s in servers]
+        assert "bad_server" not in names
+        assert "good_server" in names
+
+    def test_public_galaxy_appended_if_missing(self, tmp_path):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text(textwrap.dedent("""\
+            [galaxy]
+            server_list = private_hub
+
+            [galaxy_server.private_hub]
+            url = https://hub.internal.com/api/galaxy/
+            token = secret
+        """))
+        with patch.dict(os.environ, {"ANSIBLE_CONFIG": str(cfg)}):
+            servers = load_galaxy_servers()
+
+        assert len(servers) == 2
+        assert servers[0].name == "private_hub"
+        assert servers[1].name == "public_galaxy"
+        assert servers[1].url == "https://galaxy.ansible.com"
+
+    def test_public_galaxy_not_duplicated(self, tmp_path):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text(textwrap.dedent("""\
+            [galaxy]
+            server_list = galaxy
+
+            [galaxy_server.galaxy]
+            url = https://galaxy.ansible.com/
+        """))
+        with patch.dict(os.environ, {"ANSIBLE_CONFIG": str(cfg)}):
+            servers = load_galaxy_servers()
+
+        assert len(servers) == 1
+        assert servers[0].url == "https://galaxy.ansible.com"
+
+    def test_basic_auth_fields(self, tmp_path):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text(textwrap.dedent("""\
+            [galaxy]
+            server_list = my_hub
+
+            [galaxy_server.my_hub]
+            url = https://hub.example.com/api/galaxy/
+            username = admin
+            password = secretpass
+        """))
+        with patch.dict(os.environ, {"ANSIBLE_CONFIG": str(cfg)}):
+            servers = load_galaxy_servers()
+
+        assert servers[0].username == "admin"
+        assert servers[0].password == "secretpass"
+        assert servers[0].token is None
+
+    def test_custom_galaxy_url_fallback(self, tmp_path, monkeypatch):
+        with patch("ansible_know.galaxy_config.find_ansible_cfg", return_value=None):
+            with patch("ansible_know.galaxy_config.GALAXY_BASE_URL", "https://custom.galaxy.example.com"):
+                servers = load_galaxy_servers()
+
+        assert servers[0].url == "https://custom.galaxy.example.com"
+        assert servers[-1].url == "https://galaxy.ansible.com"
+
+    def test_timeout_parsing(self, tmp_path):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text(textwrap.dedent("""\
+            [galaxy]
+            server_list = my_hub
+
+            [galaxy_server.my_hub]
+            url = https://hub.example.com/api/galaxy/
+            timeout = 120
+        """))
+        with patch.dict(os.environ, {"ANSIBLE_CONFIG": str(cfg)}):
+            servers = load_galaxy_servers()
+
+        assert servers[0].timeout == 120
+
+
+class TestGalaxyServerConfig:
+    def test_frozen_dataclass(self):
+        config = GalaxyServerConfig(name="test", url="https://example.com")
+        with pytest.raises(AttributeError):
+            config.name = "changed"
+
+    def test_defaults(self):
+        config = GalaxyServerConfig(name="test", url="https://example.com")
+        assert config.token is None
+        assert config.username is None
+        assert config.password is None
+        assert config.auth_url is None
+        assert config.client_id is None
+        assert config.validate_certs is True
+        assert config.timeout == 60

--- a/tests/test_galaxy_config.py
+++ b/tests/test_galaxy_config.py
@@ -244,7 +244,6 @@ class TestLoadGalaxyServers:
 
         assert servers[0].timeout == 120
 
-
     def test_validate_certs_off(self, tmp_path):
         cfg = tmp_path / "ansible.cfg"
         cfg.write_text(textwrap.dedent("""\

--- a/tests/test_galaxy_config.py
+++ b/tests/test_galaxy_config.py
@@ -152,6 +152,42 @@ class TestLoadGalaxyServers:
         assert servers[1].name == "public_galaxy"
         assert servers[1].url == "https://galaxy.ansible.com"
 
+    def test_no_public_galaxy_env_var(self, tmp_path):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text(textwrap.dedent("""\
+            [galaxy]
+            server_list = private_hub
+
+            [galaxy_server.private_hub]
+            url = https://hub.internal.com/api/galaxy/
+            token = secret
+        """))
+        with patch.dict(os.environ, {
+            "ANSIBLE_CONFIG": str(cfg),
+            "ANSIBLE_KNOW_NO_PUBLIC_GALAXY": "1",
+        }):
+            servers = load_galaxy_servers()
+
+        assert len(servers) == 1
+        assert servers[0].name == "private_hub"
+
+    def test_no_public_galaxy_env_var_true(self, tmp_path):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text(textwrap.dedent("""\
+            [galaxy]
+            server_list = private_hub
+
+            [galaxy_server.private_hub]
+            url = https://hub.internal.com/api/galaxy/
+        """))
+        with patch.dict(os.environ, {
+            "ANSIBLE_CONFIG": str(cfg),
+            "ANSIBLE_KNOW_NO_PUBLIC_GALAXY": "true",
+        }):
+            servers = load_galaxy_servers()
+
+        assert len(servers) == 1
+
     def test_public_galaxy_not_duplicated(self, tmp_path):
         cfg = tmp_path / "ansible.cfg"
         cfg.write_text(textwrap.dedent("""\

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -792,7 +792,10 @@ class TestMaybeWarnUpgrade:
 
         mock_ctx = MagicMock()
         mock_ctx.lifespan_context = {
-            "version_info": {"installed": "0.3.2", "latest": "0.4.0", "outdated": True, "upgrade_command": "uvx --upgrade ansible-know-mcp"},
+            "version_info": {
+                "installed": "0.3.2", "latest": "0.4.0",
+                "outdated": True, "upgrade_command": "uvx --upgrade ansible-know-mcp",
+            },
             "upgrade_warned": False,
         }
         mock_ctx.warning = AsyncMock()
@@ -808,7 +811,10 @@ class TestMaybeWarnUpgrade:
 
         mock_ctx = MagicMock()
         mock_ctx.lifespan_context = {
-            "version_info": {"installed": "0.3.2", "latest": "0.4.0", "outdated": True, "upgrade_command": "uvx --upgrade ansible-know-mcp"},
+            "version_info": {
+                "installed": "0.3.2", "latest": "0.4.0",
+                "outdated": True, "upgrade_command": "uvx --upgrade ansible-know-mcp",
+            },
             "upgrade_warned": False,
         }
         mock_ctx.warning = AsyncMock()
@@ -823,7 +829,10 @@ class TestMaybeWarnUpgrade:
 
         mock_ctx = MagicMock()
         mock_ctx.lifespan_context = {
-            "version_info": {"installed": "0.3.2", "latest": "0.3.2", "outdated": False, "upgrade_command": "uvx --upgrade ansible-know-mcp"},
+            "version_info": {
+                "installed": "0.3.2", "latest": "0.3.2",
+                "outdated": False, "upgrade_command": "uvx --upgrade ansible-know-mcp",
+            },
             "upgrade_warned": False,
         }
         mock_ctx.warning = AsyncMock()
@@ -955,7 +964,7 @@ class TestLifespanHttpClient:
         mock_ansible_doc.return_value = json.dumps(SAMPLE_MODULE_DOC)
         mock_client = AsyncMock()
         mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"http_client": mock_client}
+        mock_ctx.lifespan_context = {"http_client": mock_client, "galaxy_servers": None}
 
         with patch("ansible_know.server._resolve_module_doc") as mock_resolve:
             mock_resolve.return_value = (SAMPLE_MODULE_DOC, None)
@@ -963,22 +972,26 @@ class TestLifespanHttpClient:
             await get_module_doc("ansible.builtin.package", ctx=mock_ctx)
 
         mock_resolve.assert_called_once_with(
-            "ansible.builtin.package", http_client=mock_client,
+            "ansible.builtin.package", http_client=mock_client, galaxy_servers=None,
         )
 
     @pytest.mark.asyncio
     async def test_search_collections_passes_lifespan_http_client(self):
         mock_client = AsyncMock()
         mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"http_client": mock_client}
+        mock_ctx.lifespan_context = {"http_client": mock_client, "galaxy_servers": None}
 
         mock_result = {"query": "test", "count": 0, "collections": []}
-        with patch("ansible_know.galaxy.GalaxyClient.__init__", return_value=None) as mock_init:
-            with patch("ansible_know.galaxy.GalaxyClient.search_collections", return_value=mock_result):
-                from ansible_know.server import search_collections
-                await search_collections("test", ctx=mock_ctx)
+        with patch("ansible_know.galaxy.GalaxyClient.from_config") as mock_from_config:
+            mock_gc = AsyncMock()
+            mock_gc.search_collections.return_value = mock_result
+            mock_gc.__aenter__ = AsyncMock(return_value=mock_gc)
+            mock_gc.__aexit__ = AsyncMock(return_value=False)
+            mock_from_config.return_value = mock_gc
+            from ansible_know.server import search_collections
+            result = await search_collections("test", ctx=mock_ctx)
 
-        mock_init.assert_called_once_with(http_client=mock_client)
+        assert result["count"] == 0
 
     @pytest.mark.asyncio
     async def test_tools_work_without_ctx(self, mock_ansible_doc):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -994,6 +994,63 @@ class TestLifespanHttpClient:
         assert result["count"] == 0
 
     @pytest.mark.asyncio
+    async def test_validate_certs_false_skips_shared_client(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+
+        mock_client = AsyncMock()
+        mock_ctx = MagicMock()
+        server = GalaxyServerConfig(
+            name="private_hub",
+            url="https://hub.internal.com/api/galaxy",
+            token="secret",
+            validate_certs=False,
+        )
+        mock_ctx.lifespan_context = {
+            "http_client": mock_client,
+            "galaxy_servers": [server],
+        }
+
+        mock_result = {"query": "test", "count": 0, "collections": []}
+        with patch("ansible_know.galaxy.GalaxyClient.from_config") as mock_from_config:
+            mock_gc = AsyncMock()
+            mock_gc.search_collections.return_value = mock_result
+            mock_gc.__aenter__ = AsyncMock(return_value=mock_gc)
+            mock_gc.__aexit__ = AsyncMock(return_value=False)
+            mock_from_config.return_value = mock_gc
+            from ansible_know.server import search_collections
+            await search_collections("test", ctx=mock_ctx)
+
+        mock_from_config.assert_called_once_with(server, http_client=None)
+
+    @pytest.mark.asyncio
+    async def test_validate_certs_true_uses_shared_client(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+
+        mock_client = AsyncMock()
+        mock_ctx = MagicMock()
+        server = GalaxyServerConfig(
+            name="public_galaxy",
+            url="https://galaxy.ansible.com",
+            validate_certs=True,
+        )
+        mock_ctx.lifespan_context = {
+            "http_client": mock_client,
+            "galaxy_servers": [server],
+        }
+
+        mock_result = {"query": "test", "count": 0, "collections": []}
+        with patch("ansible_know.galaxy.GalaxyClient.from_config") as mock_from_config:
+            mock_gc = AsyncMock()
+            mock_gc.search_collections.return_value = mock_result
+            mock_gc.__aenter__ = AsyncMock(return_value=mock_gc)
+            mock_gc.__aexit__ = AsyncMock(return_value=False)
+            mock_from_config.return_value = mock_gc
+            from ansible_know.server import search_collections
+            await search_collections("test", ctx=mock_ctx)
+
+        mock_from_config.assert_called_once_with(server, http_client=mock_client)
+
+    @pytest.mark.asyncio
     async def test_tools_work_without_ctx(self, mock_ansible_doc):
         mock_ansible_doc.return_value = json.dumps(SAMPLE_MODULE_DOC)
         from ansible_know.server import get_module_doc


### PR DESCRIPTION
## Summary

- Read `[galaxy_server.*]` sections from `ansible.cfg` to support multiple Galaxy-compatible endpoints (public Galaxy, private Automation Hub, AAP Gateway) with per-server authentication
- New `galaxy_config.py` module: parses `ansible.cfg` using standard 4-step resolution (`ANSIBLE_CONFIG` env → `./ansible.cfg` → `~/.ansible.cfg` → `/etc/ansible/ansible.cfg`)
- `GalaxyClient` now supports token auth, basic auth, and TLS cert verification per server via `from_config()` factory
- `search_collections` queries all configured servers in parallel (`asyncio.gather`), merges results with `source` attribution and deduplication
- `get_module_doc` / `get_role_doc` Galaxy fallback tries servers in priority order with `doc_source_server` in metadata
- New `galaxy://servers` resource shows configured servers (names, URLs, auth type — never credentials)
- Public Galaxy appended as final fallback; opt out with `ANSIBLE_KNOW_NO_PUBLIC_GALAXY=1` for air-gapped deployments
- Env var overrides: `ANSIBLE_GALAXY_SERVER_{NAME}_{KEY}` (matches ansible-core behavior)
- SSO/Keycloak `auth_url` documented as future enhancement (not in scope for v1)

## Post-review fixes

Code review surfaced 10 findings, all resolved:

### Bugs fixed (#46)
- **validate_certs bypass**: shared lifespan http_client ignored per-server `validate_certs=false` — now skips shared client for servers with `validate_certs=false`
- **Boolean parsing**: `validate_certs = off` parsed as `True` — added `"off"` to falsy set
- **Dual auth**: token and basic auth sent simultaneously — token now takes precedence
- **CRLF injection**: unsanitized token values could inject HTTP headers — `_sanitize_credential()` strips control characters

### Improvements (#47)
- **Air-gapped opt-out**: `ANSIBLE_KNOW_NO_PUBLIC_GALAXY=1` suppresses auto-appending public Galaxy
- **DRY fallbacks**: extracted 3 hardcoded default fallbacks to `load_galaxy_servers()`
- **Resource caching**: `galaxy://servers` resource uses module-level cache instead of re-parsing ansible.cfg
- **Parallel search**: `search_collections` uses `asyncio.gather` across servers

### Polish (#48)
- Deduplicated `_fetch` closure in `_resolve_module_doc`
- Documented auth type exposure in `galaxy://servers` as intentional
- Added type annotations to `_try_galaxy_servers` and all `galaxy_servers` parameters
- PEP 8 compliance verified (0 errors, 0 warnings)

## Test plan

- [x] 22 unit tests for `galaxy_config.py` (config parsing, env var overrides, boolean parsing, CRLF sanitization, air-gapped opt-out)
- [x] 8 unit tests for `GalaxyClient` auth (token headers, basic auth, token precedence, verify, from_config)
- [x] 4 unit tests for `search_collections` (lifespan client, validate_certs branching)
- [x] Full suite: 410 passed, 57 skipped, ruff clean
- [x] Full PEP 8 review: 0 errors, 0 warnings
- [x] Full dimensional review (7 angles): 0 remaining issues
- [ ] Integration test with real private Automation Hub (if available)

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>