### PR TITLE
fix: tighten type annotations and except clauses

### DIFF
--- a/src/ansible_know/collections.py
+++ b/src/ansible_know/collections.py
@@ -63,7 +63,7 @@ def _parse_version(stdout: str, namespace: str, tmpdir: str) -> str:
             version = manifest.get("collection_info", {}).get("version")
             if version:
                 return version
-        except (json.JSONDecodeError, KeyError):
+        except json.JSONDecodeError:
             pass
 
     logger.warning("Could not parse installed version for %s", namespace)

--- a/src/ansible_know/config.py
+++ b/src/ansible_know/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 
@@ -33,13 +34,11 @@ def get_doc_sources() -> dict[str, dict[str, str]]:
         try:
             parsed = json.loads(env_val)
         except (json.JSONDecodeError, ValueError):
-            import logging
             logging.getLogger("ansible_know").warning(
                 "Invalid JSON in ANSIBLE_KNOW_DOC_SOURCES, using defaults"
             )
             return DEFAULT_DOC_SOURCES
         if not isinstance(parsed, dict):
-            import logging
             logging.getLogger("ansible_know").warning(
                 "ANSIBLE_KNOW_DOC_SOURCES must be a JSON object, using defaults"
             )

--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -29,7 +29,7 @@ async def _fetch_manifest(source_name: str, url: str) -> list[dict[str, Any]]:
         if content_length:
             try:
                 size = int(content_length)
-            except (ValueError, OverflowError):
+            except ValueError:
                 size = None
             if size is not None and size > MAX_MANIFEST_SIZE:
                 raise ValueError(f"Manifest too large: {content_length} bytes (max {MAX_MANIFEST_SIZE})")
@@ -76,9 +76,12 @@ async def search_docs(
         if source and src_name != source:
             continue
 
+        if "url" not in src_config:
+            continue
+
         try:
             entries = await _fetch_manifest(src_name, src_config["url"])
-        except (httpx.HTTPError, KeyError, ValueError):
+        except (httpx.HTTPError, ValueError):
             continue
 
         for entry in entries:

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -14,7 +14,10 @@ import os
 from collections.abc import Awaitable, Callable
 from functools import partial
 from importlib.metadata import version as pkg_version
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
+
+if TYPE_CHECKING:
+    from ansible_know.galaxy_config import GalaxyServerConfig
 
 import httpx
 from fastmcp import Context, FastMCP
@@ -39,7 +42,7 @@ logger = logging.getLogger("ansible_know")
 
 _VERSION = pkg_version("ansible-know-mcp")
 _version_info: dict[str, Any] | None = None
-_galaxy_servers: list[Any] | None = None
+_galaxy_servers: list[GalaxyServerConfig] | None = None
 
 
 def _is_stable(v: str) -> bool:
@@ -75,7 +78,7 @@ async def _check_pypi_version(client: httpx.AsyncClient) -> dict[str, Any] | Non
             "outdated": outdated,
             "upgrade_command": "uvx --upgrade ansible-know-mcp",
         }
-    except Exception:
+    except (httpx.HTTPError, ValueError):
         logger.debug("PyPI version check failed (non-blocking)")
         return None
 
@@ -165,7 +168,7 @@ def _maybe_add_hint(error_msg: str, namespace: str | None) -> str:
 
 
 async def _try_galaxy_servers(
-    servers: list[Any],
+    servers: list[GalaxyServerConfig],
     operation: Callable[..., Awaitable[Any]],
     http_client: httpx.AsyncClient | None = None,
 ) -> tuple[Any, str]:
@@ -199,7 +202,7 @@ async def _try_galaxy_servers(
 async def _resolve_module_doc(
     module_name: str,
     http_client: httpx.AsyncClient | None = None,
-    galaxy_servers: list[Any] | None = None,
+    galaxy_servers: list[GalaxyServerConfig] | None = None,
 ) -> tuple[dict, dict | None]:
     """Try local ansible-doc, fall back to Galaxy if the collection is missing.
 
@@ -249,7 +252,7 @@ async def _resolve_module_doc(
 async def _resolve_role_doc(
     role_name: str,
     http_client: httpx.AsyncClient | None = None,
-    galaxy_servers: list[Any] | None = None,
+    galaxy_servers: list[GalaxyServerConfig] | None = None,
 ) -> dict[str, Any]:
     """Try local ansible-doc -t role, fall back to Galaxy readme_html.
 
@@ -342,7 +345,7 @@ async def search_modules(
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def get_module_doc(
     module_name: Annotated[str, "Fully-qualified collection name (e.g. 'ansible.builtin.copy')"],
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Get full structured documentation for one module.
 
@@ -385,7 +388,7 @@ async def get_module_doc(
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def get_role_doc(
     role_name: Annotated[str, "Fully-qualified role name (e.g. 'fedora.linux_system_roles.timesync')"],
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Get full structured documentation for one role.
 
@@ -450,7 +453,7 @@ async def search_docs(
 async def search_collections(
     query: Annotated[str, "Search keyword (e.g., 'netbox', 'cisco ios', 'vmware')"],
     tags: Annotated[str | None, "Optional comma-separated Galaxy tags to filter (e.g., 'networking,cloud')"] = None,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Search Ansible Galaxy for collections by keyword.
 
@@ -715,7 +718,7 @@ async def get_skill(
 async def generate_skill(
     module_name: Annotated[str, "Fully-qualified module name (e.g. 'ansible.builtin.copy')"],
     install_to: Annotated[str | None, "Optional absolute path to install the skill to"] = None,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str | dict[str, str]:
     """Generate a skill package for one module.
 
@@ -776,7 +779,7 @@ async def generate_skill(
 async def generate_role_skill(
     role_name: Annotated[str, "Fully-qualified role name (e.g. 'fedora.linux_system_roles.timesync')"],
     install_to: Annotated[str | None, "Optional absolute path to install the skill to"] = None,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str | dict[str, str]:
     """Generate a skill package for one role.
 
@@ -833,7 +836,7 @@ async def generate_role_skill(
 async def generate_collection_skills(
     collection_namespace: Annotated[str, "Collection namespace (e.g. 'netbox.netbox')"],
     install_to: Annotated[str | None, "Optional absolute path to install skills to"] = None,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Batch generate skills for an entire collection.
 
@@ -880,7 +883,8 @@ async def generate_collection_skills(
                 output_dir = base_dir / skill_name
                 await _run_in_executor(skills.write_skill_package, output_dir, metadata)
                 succeeded += 1
-            except Exception:
+            except Exception as exc:
+                logger.warning("Skill generation failed for %s: %s", module_name, exc)
                 failed += 1
 
         manifest = collection_manifest.generate_manifest(


### PR DESCRIPTION
## Summary

- Replace `list[Any]` with `list[GalaxyServerConfig]` for galaxy server parameters (4 locations in server.py) using `TYPE_CHECKING` import
- Fix `ctx: Context = None` → `ctx: Context | None = None` across 6 tool functions
- Narrow broad `except Exception` in `_check_pypi_version` to `except (httpx.HTTPError, ValueError)`
- Add `logger.warning` for silent batch failures in `generate_collection_skills`
- Remove dead `OverflowError` from `docs.py` `int()` parse
- Remove dead `KeyError` from `collections.py` `.get()` chain
- Fix `KeyError` by-catch in `docs.py` `search_docs` — validate config has `"url"` key before try block
- Move lazy `import logging` to module level in `config.py`

## Test plan

- [x] `ruff check src/ tests/` — all checks passed
- [x] `pytest tests/ -v` — 410 passed, 57 skipped

Closes #49

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>