### PR TITLE
fix: review follow-up for PR #51

### DIFF
--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -6,11 +6,14 @@ fetches them via HTTP, caches per-source, and provides cross-source search.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import httpx
 
 from ansible_know.config import SEARCH_DOCS_LIMIT, get_doc_sources
+
+logger = logging.getLogger("ansible_know")
 
 MAX_MANIFEST_SIZE = 5_000_000  # 5MB
 
@@ -77,6 +80,7 @@ async def search_docs(
             continue
 
         if "url" not in src_config:
+            logger.warning("Doc source '%s' missing 'url', skipping", src_name)
             continue
 
         try:

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -78,7 +78,7 @@ async def _check_pypi_version(client: httpx.AsyncClient) -> dict[str, Any] | Non
             "outdated": outdated,
             "upgrade_command": "uvx --upgrade ansible-know-mcp",
         }
-    except (httpx.HTTPError, ValueError):
+    except Exception:
         logger.debug("PyPI version check failed (non-blocking)")
         return None
 


### PR DESCRIPTION
## Summary

Post-merge review of PR #51 found two issues:

- **Restore broad `except Exception` in `_check_pypi_version`** — the narrowed `except (httpx.HTTPError, ValueError)` could let edge-case exceptions (e.g. `AttributeError` from malformed PyPI JSON) escape and crash server startup. This function is called from `app_lifespan` with no surrounding try/except, so it must never raise. The broad except is intentional for this non-critical best-effort check.
- **Add `logger.warning` when doc source config is missing `"url"` key** — the `if "url" not in src_config: continue` guard added in #51 was correct but silent. Misconfigured `ANSIBLE_KNOW_DOC_SOURCES` now produces a visible warning.
- Add module-level `logger` to `docs.py` (consistent with other modules).

## Test plan

- [x] `ruff check src/ tests/` — all checks passed
- [x] `pytest tests/ -v` — 410 passed, 57 skipped

Follow-up to #51, relates to #49

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>