### PR TITLE
ci: add integration tests to PR workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,29 @@ jobs:
 
       - name: Run tests with coverage
         run: uv run pytest tests/ -v --cov=ansible_know --cov-report=term-missing
+
+  integration:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python 3.13
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Install ansible-core
+        run: uv pip install ansible-core
+
+      - name: Run ansible-doc integration tests
+        run: uv run pytest tests/integration/test_ansible_doc.py -v --run-integration
+
+      - name: Run network integration tests (Galaxy API + e2e)
+        continue-on-error: true
+        run: uv run pytest tests/integration/test_galaxy_api.py tests/integration/test_mcp_e2e.py -v --run-integration


### PR DESCRIPTION
## Summary

- Add `integration` job to CI workflow, gated on unit tests passing (`needs: test`)
- **ansible-doc tests** run as a hard gate — deterministic, no network dependency
- **Galaxy API + e2e tests** run with `continue-on-error: true` — visible in PR checks but won't block merge (network-dependent tests may flake)
- Runs on Python 3.13 only (no matrix) to keep CI fast
- Installs `ansible-core` via `uv pip install` for real `ansible-doc` invocation

## Test plan

- [ ] Verify GitHub parses the workflow YAML without errors
- [ ] Verify `integration` job appears in PR checks after unit tests pass
- [ ] Verify ansible-doc tests run and pass
- [ ] Verify network tests run (pass or soft-fail without blocking)

Closes #42

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>