### PR TITLE
refactor: move error-handling helpers to errors.py

### DIFF
--- a/src/ansible_know/errors.py
+++ b/src/ansible_know/errors.py
@@ -1,4 +1,4 @@
-"""Unified exception hierarchy for ansible-know."""
+"""Unified exception hierarchy and error helpers for ansible-know."""
 
 from __future__ import annotations
 
@@ -25,3 +25,26 @@ class CollectionInstallError(AnsibleKnowError):
 
 class ValidationError(AnsibleKnowError):
     """Raised when tool input fails validation."""
+
+
+_MISSING_COLLECTION_PATTERNS = ("has no attribute", "was not found", "could not be found")
+
+
+def collection_hint(namespace: str) -> str:
+    return (
+        f" Collection '{namespace}' not installed locally. "
+        f"Use ensure_collection('{namespace}') to install it from Ansible Galaxy "
+        f"(latest version, or specify version='X.Y.Z')."
+    )
+
+
+def is_missing_collection_error(error_msg: str) -> bool:
+    """Check if an error message indicates a missing/not-found collection or module."""
+    msg_lower = error_msg.lower()
+    return any(p in msg_lower for p in _MISSING_COLLECTION_PATTERNS)
+
+
+def maybe_add_hint(error_msg: str, namespace: str | None) -> str:
+    if namespace and is_missing_collection_error(error_msg):
+        return error_msg + collection_hint(namespace)
+    return error_msg

--- a/src/ansible_know/parser.py
+++ b/src/ansible_know/parser.py
@@ -14,12 +14,11 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from ansible_know.errors import AnsibleDocError, CollectionNotFoundError
+from ansible_know.errors import AnsibleDocError, CollectionNotFoundError, is_missing_collection_error
 
 if TYPE_CHECKING:
     from ansible_know.types import ModuleMetadata, RoleMetadata
 
-_MISSING_COLLECTION_PATTERNS = ("has no attribute", "was not found", "could not be found")
 
 
 def _find_ansible_doc() -> str:
@@ -67,14 +66,12 @@ def _run_ansible_doc(*args: str) -> str:
 
     if result.returncode != 0:
         msg = f"ansible-doc failed (exit {result.returncode}): {result.stderr.strip()}"
-        msg_lower = msg.lower()
-        if any(p in msg_lower for p in _MISSING_COLLECTION_PATTERNS):
+        if is_missing_collection_error(msg):
             raise CollectionNotFoundError(msg)
         raise AnsibleDocError(msg)
 
     if result.stdout.strip() in ("", "{}"):
-        stderr_lower = result.stderr.lower()
-        if any(p in stderr_lower for p in _MISSING_COLLECTION_PATTERNS):
+        if is_missing_collection_error(result.stderr):
             raise CollectionNotFoundError(
                 f"ansible-doc returned empty output: {result.stderr.strip()}"
             )

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -25,7 +25,7 @@ from fastmcp import Context, FastMCP
 from fastmcp.server.lifespan import lifespan
 from mcp.types import ToolAnnotations
 
-from ansible_know.errors import AnsibleDocError, ValidationError
+from ansible_know.errors import AnsibleDocError, ValidationError, collection_hint, maybe_add_hint
 from ansible_know.validation import (
     sanitize_error,
     truncate_response,
@@ -162,28 +162,7 @@ async def _maybe_warn_upgrade(ctx: Context | None) -> None:
     lc["upgrade_warned"] = True
 
 
-_MISSING_COLLECTION_PATTERNS = ("has no attribute", "was not found", "could not be found")
 _missing_collections: set[str] = set()
-
-
-def _collection_hint(namespace: str) -> str:
-    return (
-        f" Collection '{namespace}' not installed locally. "
-        f"Use ensure_collection('{namespace}') to install it from Ansible Galaxy "
-        f"(latest version, or specify version='X.Y.Z')."
-    )
-
-
-def _is_missing_collection_error(error_msg: str) -> bool:
-    """Check if an error message indicates a missing/not-found collection or module."""
-    msg_lower = error_msg.lower()
-    return any(p in msg_lower for p in _MISSING_COLLECTION_PATTERNS)
-
-
-def _maybe_add_hint(error_msg: str, namespace: str | None) -> str:
-    if namespace and _is_missing_collection_error(error_msg):
-        return error_msg + _collection_hint(namespace)
-    return error_msg
 
 
 async def _try_galaxy_servers(
@@ -354,7 +333,7 @@ async def search_modules(
         return results
     except Exception as exc:
         logger.warning("search_modules failed: %s", exc)
-        return {"error": _maybe_add_hint(sanitize_error(str(exc)), namespace)}
+        return {"error": maybe_add_hint(sanitize_error(str(exc)), namespace)}
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -396,7 +375,7 @@ async def get_module_doc(
         from ansible_know.errors import GalaxyError
         if isinstance(exc.__cause__, GalaxyError):
             return {"error": sanitize_error(str(exc))}
-        return {"error": _maybe_add_hint(sanitize_error(str(exc)), ns)}
+        return {"error": maybe_add_hint(sanitize_error(str(exc)), ns)}
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -429,7 +408,7 @@ async def get_role_doc(
     except Exception as exc:
         logger.warning("get_role_doc failed: %s", exc)
         ns = ".".join(role_name.split(".")[:2]) if "." in role_name else None
-        return {"error": _maybe_add_hint(sanitize_error(str(exc)), ns)}
+        return {"error": maybe_add_hint(sanitize_error(str(exc)), ns)}
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -584,7 +563,7 @@ async def get_collection_manifest(
         if not modules and not roles_raw:
             return {"error": (
                 f"No modules or roles found in collection '{collection_namespace}'."
-                + _collection_hint(collection_namespace)
+                + collection_hint(collection_namespace)
             )}
 
         metadata_list = []
@@ -615,7 +594,7 @@ async def get_collection_manifest(
         raise
     except Exception as exc:
         logger.warning("get_collection_manifest failed: %s", exc)
-        return {"error": _maybe_add_hint(sanitize_error(str(exc)), collection_namespace)}
+        return {"error": maybe_add_hint(sanitize_error(str(exc)), collection_namespace)}
 
 
 @mcp.tool(annotations=ToolAnnotations(idempotentHint=True, readOnlyHint=False, destructiveHint=False))
@@ -790,7 +769,7 @@ async def generate_skill(
         from ansible_know.errors import GalaxyError
         if isinstance(exc.__cause__, GalaxyError):
             return {"error": sanitize_error(str(exc))}
-        return {"error": _maybe_add_hint(sanitize_error(str(exc)), ns)}
+        return {"error": maybe_add_hint(sanitize_error(str(exc)), ns)}
 
 
 @mcp.tool(annotations=ToolAnnotations(idempotentHint=True))
@@ -846,7 +825,7 @@ async def generate_role_skill(
     except Exception as exc:
         logger.warning("generate_role_skill failed: %s", exc)
         ns = ".".join(role_name.split(".")[:2]) if "." in role_name else None
-        return {"error": _maybe_add_hint(sanitize_error(str(exc)), ns)}
+        return {"error": maybe_add_hint(sanitize_error(str(exc)), ns)}
 
 
 @mcp.tool(annotations=ToolAnnotations(idempotentHint=True))
@@ -880,7 +859,7 @@ async def generate_collection_skills(
         if not modules:
             return {"error": (
                 f"No modules found in collection '{collection_namespace}'."
-                + _collection_hint(collection_namespace)
+                + collection_hint(collection_namespace)
             )}
 
         total = len(modules)
@@ -924,7 +903,7 @@ async def generate_collection_skills(
         raise
     except Exception as exc:
         logger.warning("generate_collection_skills failed: %s", exc)
-        return {"error": _maybe_add_hint(sanitize_error(str(exc)), collection_namespace)}
+        return {"error": maybe_add_hint(sanitize_error(str(exc)), collection_namespace)}
 
 
 # --- Resources (read-only data) ---

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -407,28 +407,28 @@ class TestMissingCollectionHints:
 
 class TestIsMissingCollectionError:
     def test_has_no_attribute(self):
-        from ansible_know.server import _is_missing_collection_error
-        assert _is_missing_collection_error("netbox.netbox has no attribute") is True
+        from ansible_know.errors import is_missing_collection_error
+        assert is_missing_collection_error("netbox.netbox has no attribute") is True
 
     def test_was_not_found(self):
-        from ansible_know.server import _is_missing_collection_error
-        assert _is_missing_collection_error("module was not found") is True
+        from ansible_know.errors import is_missing_collection_error
+        assert is_missing_collection_error("module was not found") is True
 
     def test_could_not_be_found(self):
-        from ansible_know.server import _is_missing_collection_error
-        assert _is_missing_collection_error("could not be found in Galaxy") is True
+        from ansible_know.errors import is_missing_collection_error
+        assert is_missing_collection_error("could not be found in Galaxy") is True
 
     def test_unrelated_error(self):
-        from ansible_know.server import _is_missing_collection_error
-        assert _is_missing_collection_error("ansible-doc timed out") is False
+        from ansible_know.errors import is_missing_collection_error
+        assert is_missing_collection_error("ansible-doc timed out") is False
 
     def test_empty_string(self):
-        from ansible_know.server import _is_missing_collection_error
-        assert _is_missing_collection_error("") is False
+        from ansible_know.errors import is_missing_collection_error
+        assert is_missing_collection_error("") is False
 
     def test_case_insensitive(self):
-        from ansible_know.server import _is_missing_collection_error
-        assert _is_missing_collection_error("HAS NO ATTRIBUTE") is True
+        from ansible_know.errors import is_missing_collection_error
+        assert is_missing_collection_error("HAS NO ATTRIBUTE") is True
 
 
 class TestGalaxyDocsFallback:


### PR DESCRIPTION
## Summary

- Move `collection_hint()`, `is_missing_collection_error()`, and `maybe_add_hint()` from `server.py` to `errors.py`
- Remove duplicated `_MISSING_COLLECTION_PATTERNS` constant from `parser.py` — use shared `is_missing_collection_error()` instead
- Functions are now public (no underscore prefix) as part of the `errors` module API
- Update tests to import from `errors` instead of `server`

No behavioral changes — pure separation of concerns cleanup.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/ -v` — 410 passed, 57 skipped
- [x] Code review (3 angles) — no issues found

Closes #56

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>