### PR TITLE
refactor: architecture improvements from review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 build/
 .pytest_cache/
 skills/
+docs/research/

--- a/src/ansible_know/cache.py
+++ b/src/ansible_know/cache.py
@@ -1,0 +1,61 @@
+"""Shared bounded cache with optional TTL.
+
+Provides a single thread-safe cache implementation to replace the ad-hoc
+caching patterns spread across galaxy.py, docs.py, collections.py,
+and server.py.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from typing import Generic, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class BoundedCache(Generic[K, V]):
+    """Thread-safe LRU cache with optional TTL expiry.
+
+    Args:
+        max_size: Maximum number of entries before LRU eviction.
+        ttl: Time-to-live in seconds. None means entries never expire.
+    """
+
+    def __init__(self, max_size: int, ttl: float | None = None) -> None:
+        self._max_size = max_size
+        self._ttl = ttl
+        self._data: OrderedDict[K, tuple[V, float]] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def get(self, key: K) -> V | None:
+        with self._lock:
+            entry = self._data.get(key)
+            if entry is None:
+                return None
+            value, timestamp = entry
+            if self._ttl is not None and time.monotonic() - timestamp > self._ttl:
+                del self._data[key]
+                return None
+            self._data.move_to_end(key)
+            return value
+
+    def put(self, key: K, value: V) -> None:
+        with self._lock:
+            self._data[key] = (value, time.monotonic())
+            self._data.move_to_end(key)
+            while len(self._data) > self._max_size:
+                self._data.popitem(last=False)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._data.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._data)
+
+    def __contains__(self, key: K) -> bool:
+        return self.get(key) is not None

--- a/src/ansible_know/cache.py
+++ b/src/ansible_know/cache.py
@@ -30,13 +30,16 @@ class BoundedCache(Generic[K, V]):
         self._data: OrderedDict[K, tuple[V, float]] = OrderedDict()
         self._lock = threading.Lock()
 
+    def _is_expired(self, timestamp: float) -> bool:
+        return self._ttl is not None and time.monotonic() - timestamp > self._ttl
+
     def get(self, key: K) -> V | None:
         with self._lock:
             entry = self._data.get(key)
             if entry is None:
                 return None
             value, timestamp = entry
-            if self._ttl is not None and time.monotonic() - timestamp > self._ttl:
+            if self._is_expired(timestamp):
                 del self._data[key]
                 return None
             self._data.move_to_end(key)
@@ -66,6 +69,4 @@ class BoundedCache(Generic[K, V]):
             entry = self._data.get(key)
             if entry is None:
                 return False
-            if self._ttl is not None and time.monotonic() - entry[1] > self._ttl:
-                return False
-            return True
+            return not self._is_expired(entry[1])

--- a/src/ansible_know/cache.py
+++ b/src/ansible_know/cache.py
@@ -45,10 +45,19 @@ class BoundedCache(Generic[K, V]):
             self._data.move_to_end(key)
             return value
 
+    def _purge_expired(self) -> None:
+        if self._ttl is None:
+            return
+        expired = [k for k, (_, ts) in self._data.items() if self._is_expired(ts)]
+        for k in expired:
+            del self._data[k]
+
     def put(self, key: K, value: V) -> None:
         with self._lock:
             self._data[key] = (value, time.monotonic())
             self._data.move_to_end(key)
+            if len(self._data) > self._max_size:
+                self._purge_expired()
             while len(self._data) > self._max_size:
                 self._data.popitem(last=False)
 
@@ -65,6 +74,7 @@ class BoundedCache(Generic[K, V]):
             return len(self._data)
 
     def __contains__(self, key: K) -> bool:
+        # Non-mutating: expired entries are left for get()/put() to clean up.
         with self._lock:
             entry = self._data.get(key)
             if entry is None:

--- a/src/ansible_know/cache.py
+++ b/src/ansible_know/cache.py
@@ -53,9 +53,19 @@ class BoundedCache(Generic[K, V]):
         with self._lock:
             self._data.clear()
 
+    @property
+    def max_size(self) -> int:
+        return self._max_size
+
     def __len__(self) -> int:
         with self._lock:
             return len(self._data)
 
     def __contains__(self, key: K) -> bool:
-        return self.get(key) is not None
+        with self._lock:
+            entry = self._data.get(key)
+            if entry is None:
+                return False
+            if self._ttl is not None and time.monotonic() - entry[1] > self._ttl:
+                return False
+            return True

--- a/src/ansible_know/collections.py
+++ b/src/ansible_know/collections.py
@@ -17,6 +17,7 @@ import threading
 from pathlib import Path
 
 from ansible_know.errors import CollectionInstallError
+from ansible_know.types import EnsureCollectionResult
 from ansible_know.validation import sanitize_error
 
 logger = logging.getLogger("ansible_know")
@@ -73,7 +74,7 @@ def _parse_version(stdout: str, collection_fqcn: str, tmpdir: str) -> str:
 MAX_TRACKED_COLLECTIONS = 100
 
 
-def ensure_collection(collection_fqcn: str, version: str | None = None) -> dict:
+def ensure_collection(collection_fqcn: str, version: str | None = None) -> EnsureCollectionResult:
     """Install a collection to the temp directory (thread-safe).
 
     Args:

--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -11,19 +11,21 @@ from typing import Any
 
 import httpx
 
+from ansible_know.cache import BoundedCache
 from ansible_know.config import SEARCH_DOCS_LIMIT, get_doc_sources
 
 logger = logging.getLogger("ansible_know")
 
 MAX_MANIFEST_SIZE = 5_000_000  # 5MB
 
-_manifest_cache: dict[str, list[dict[str, Any]]] = {}
+_manifest_cache: BoundedCache[str, list[dict[str, Any]]] = BoundedCache(max_size=50)
 
 
 async def _fetch_manifest(source_name: str, url: str) -> list[dict[str, Any]]:
     """Fetch and cache a manifest from a URL."""
-    if source_name in _manifest_cache:
-        return _manifest_cache[source_name]
+    cached = _manifest_cache.get(source_name)
+    if cached is not None:
+        return cached
 
     async with httpx.AsyncClient(timeout=httpx.Timeout(10.0, read=30.0)) as client:
         resp = await client.get(url)
@@ -48,7 +50,7 @@ async def _fetch_manifest(source_name: str, url: str) -> list[dict[str, Any]]:
         if "url" not in entry and "path" in entry and base_url:
             entry["url"] = f"{base_url.rstrip('/')}/{entry['path'].lstrip('/')}"
 
-    _manifest_cache[source_name] = entries
+    _manifest_cache.put(source_name, entries)
     return entries
 
 
@@ -130,3 +132,4 @@ async def search_docs(
 def clear_cache() -> None:
     """Clear the manifest cache (useful for testing)."""
     _manifest_cache.clear()
+

--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -17,8 +17,11 @@ from ansible_know.config import SEARCH_DOCS_LIMIT, get_doc_sources
 logger = logging.getLogger("ansible_know")
 
 MAX_MANIFEST_SIZE = 5_000_000  # 5MB
+CACHE_TTL_SECONDS = 3600
 
-_manifest_cache: BoundedCache[str, list[dict[str, Any]]] = BoundedCache(max_size=50)
+_manifest_cache: BoundedCache[str, list[dict[str, Any]]] = BoundedCache(
+    max_size=50, ttl=CACHE_TTL_SECONDS,
+)
 
 
 async def _fetch_manifest(source_name: str, url: str) -> list[dict[str, Any]]:

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -8,13 +8,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import threading
-import time
-from collections import OrderedDict
 from typing import TYPE_CHECKING, Any
 
 import httpx
 
+from ansible_know.cache import BoundedCache
 from ansible_know.config import GALAXY_BASE_URL
 from ansible_know.errors import GalaxyError
 
@@ -25,8 +23,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger("ansible_know")
 
 MAX_GALAXY_RESPONSE_SIZE = 5_000_000  # 5MB
-MAX_VERSION_CACHE_SIZE = 500
-MAX_BLOB_CACHE_SIZE = 50
 CACHE_TTL_SECONDS = 3600
 
 TIMEOUT_FAST = httpx.Timeout(10.0)
@@ -47,57 +43,19 @@ def _get_enrichment_semaphore() -> asyncio.Semaphore:
 
 # Module-level caches shared across all GalaxyClient instances.
 # Keys include enough context (namespace, name, version) to avoid
-# cross-instance collisions. Thread-safe via dedicated locks.
-_version_cache: OrderedDict[tuple[str, str], tuple[str, float]] = OrderedDict()
-_version_lock = threading.Lock()
-_blob_cache: OrderedDict[tuple[str, str, str], tuple[dict[str, Any], float]] = OrderedDict()
-_blob_lock = threading.Lock()
-
-
-def _get_version_cache(key: tuple[str, str]) -> str | None:
-    with _version_lock:
-        cached = _version_cache.get(key)
-        if cached is None:
-            return None
-        value, timestamp = cached
-        if time.monotonic() - timestamp > CACHE_TTL_SECONDS:
-            del _version_cache[key]
-            return None
-        return value
-
-
-def _put_version_cache(key: tuple[str, str], value: str) -> None:
-    with _version_lock:
-        _version_cache[key] = (value, time.monotonic())
-        while len(_version_cache) > MAX_VERSION_CACHE_SIZE:
-            _version_cache.popitem(last=False)
-
-
-def _get_blob_cache(key: tuple[str, str, str]) -> dict[str, Any] | None:
-    with _blob_lock:
-        cached = _blob_cache.get(key)
-        if cached is None:
-            return None
-        value, timestamp = cached
-        if time.monotonic() - timestamp > CACHE_TTL_SECONDS:
-            del _blob_cache[key]
-            return None
-        return value
-
-
-def _put_blob_cache(key: tuple[str, str, str], value: dict[str, Any]) -> None:
-    with _blob_lock:
-        _blob_cache[key] = (value, time.monotonic())
-        while len(_blob_cache) > MAX_BLOB_CACHE_SIZE:
-            _blob_cache.popitem(last=False)
+# cross-instance collisions. Thread-safe via BoundedCache.
+_version_cache: BoundedCache[tuple[str, str], str] = BoundedCache(
+    max_size=500, ttl=CACHE_TTL_SECONDS,
+)
+_blob_cache: BoundedCache[tuple[str, str, str], dict[str, Any]] = BoundedCache(
+    max_size=50, ttl=CACHE_TTL_SECONDS,
+)
 
 
 def clear_cache() -> None:
     """Clear Galaxy caches (useful for testing)."""
-    with _version_lock:
-        _version_cache.clear()
-    with _blob_lock:
-        _blob_cache.clear()
+    _version_cache.clear()
+    _blob_cache.clear()
 
 
 def _parse_fqcn(module_name: str) -> tuple[str, str, str]:
@@ -239,7 +197,7 @@ class GalaxyClient:
             GalaxyError: If the collection is not found or the API fails.
         """
         cache_key = (namespace, name)
-        cached = _get_version_cache(cache_key)
+        cached = _version_cache.get(cache_key)
         if cached is not None:
             return cached
         path = (
@@ -254,7 +212,7 @@ class GalaxyClient:
                 f"No versions found for {namespace}.{name} on Galaxy."
             )
         version = versions[0]["version"]
-        _put_version_cache(cache_key, version)
+        _version_cache.put(cache_key, version)
         return version
 
     async def _get_collection_detail(
@@ -343,7 +301,7 @@ class GalaxyClient:
         self, namespace: str, name: str, version: str,
     ) -> dict[str, Any]:
         cache_key = (namespace, name, version)
-        cached = _get_blob_cache(cache_key)
+        cached = _blob_cache.get(cache_key)
         if cached is not None:
             return cached
         path = (
@@ -353,7 +311,7 @@ class GalaxyClient:
         params = {"format": "json"}
         data = await self._safe_api_get(path, params=params, timeout=TIMEOUT_SLOW)
         blob = data.get("docs_blob", data)
-        _put_blob_cache(cache_key, blob)
+        _blob_cache.put(cache_key, blob)
         return blob
 
     @staticmethod

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -45,6 +45,9 @@ def _get_enrichment_semaphore() -> asyncio.Semaphore:
         _enrichment_semaphore_loop = loop
     return _enrichment_semaphore
 
+# Module-level caches shared across all GalaxyClient instances.
+# Keys include enough context (namespace, name, version) to avoid
+# cross-instance collisions. Thread-safe via dedicated locks.
 _version_cache: OrderedDict[tuple[str, str], tuple[str, float]] = OrderedDict()
 _version_lock = threading.Lock()
 _blob_cache: OrderedDict[tuple[str, str, str], tuple[dict[str, Any], float]] = OrderedDict()

--- a/src/ansible_know/parser.py
+++ b/src/ansible_know/parser.py
@@ -7,6 +7,7 @@ for skill generation and module discovery.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import shutil
 import subprocess
@@ -18,6 +19,8 @@ from ansible_know.errors import AnsibleDocError, CollectionNotFoundError, is_mis
 
 if TYPE_CHECKING:
     from ansible_know.types import ModuleMetadata, RoleMetadata
+
+logger = logging.getLogger("ansible_know")
 
 
 
@@ -41,6 +44,7 @@ def _run_ansible_doc(*args: str) -> str:
 
     from ansible_know import collections
     collections_path = collections.get_collections_path()
+    logger.debug("Running: %s (collections_path=%s)", " ".join(cmd), collections_path)
     env = None
     if collections_path:
         env = os.environ.copy()
@@ -58,10 +62,12 @@ def _run_ansible_doc(*args: str) -> str:
             env=env,
         )
     except FileNotFoundError as exc:
+        logger.debug("ansible-doc binary not found")
         raise AnsibleDocError(
             "ansible-doc not found. Install ansible-core: pip install ansible-core"
         ) from exc
     except subprocess.TimeoutExpired as exc:
+        logger.debug("ansible-doc timed out: %s", " ".join(cmd))
         raise AnsibleDocError(f"ansible-doc timed out: {' '.join(cmd)}") from exc
 
     if result.returncode != 0:
@@ -208,6 +214,7 @@ def is_api_module(module_doc: dict[str, Any]) -> bool:
 def extract_module_metadata(module_doc: dict[str, Any]) -> ModuleMetadata:
     """Extract all metadata needed for skill generation."""
     module_name = _get_module_name(module_doc)
+    logger.debug("Extracting module metadata for %s", module_name)
     return {
         "module_name": module_name,
         "short_description": extract_short_description(module_doc),
@@ -263,6 +270,7 @@ def extract_role_metadata(role_doc: dict[str, Any]) -> RoleMetadata:
         return {"role_name": "", "short_description": "", "entry_points": {}}
 
     role_name = next(iter(role_doc))
+    logger.debug("Extracting role metadata for %s", role_name)
     role_data = role_doc[role_name]
     raw_entry_points = role_data.get("entry_points", {})
 

--- a/src/ansible_know/parser.py
+++ b/src/ansible_know/parser.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from ansible_know import collections
 from ansible_know.errors import AnsibleDocError, CollectionNotFoundError, is_missing_collection_error
 
 if TYPE_CHECKING:
@@ -42,7 +43,6 @@ def _run_ansible_doc(*args: str) -> str:
     ansible_doc = _find_ansible_doc()
     cmd = [ansible_doc, *args]
 
-    from ansible_know import collections
     collections_path = collections.get_collections_path()
     logger.debug("Running: %s (collections_path=%s)", " ".join(cmd), collections_path)
     env = None

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -162,6 +162,10 @@ async def _maybe_warn_upgrade(ctx: Context | None) -> None:
     lc["upgrade_warned"] = True
 
 
+# Negative cache: namespaces that failed local ansible-doc lookup.
+# Skips retrying local resolution for known-missing collections,
+# going straight to Galaxy fallback. Cleared per-namespace on
+# successful ensure_collection().
 _missing_collections: set[str] = set()
 
 

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -16,13 +16,6 @@ from functools import partial
 from importlib.metadata import version as pkg_version
 from typing import TYPE_CHECKING, Annotated, Any
 
-from ansible_know.types import (
-    CollectionSearchResult,
-    EnsureCollectionResult,
-    ErrorResponse,
-    SkillEntry,
-)
-
 if TYPE_CHECKING:
     from ansible_know.galaxy_config import GalaxyServerConfig
     from ansible_know.types import DocProvenance
@@ -457,7 +450,7 @@ async def search_collections(
     query: Annotated[str, "Search keyword (e.g., 'netbox', 'cisco ios', 'vmware')"],
     tags: Annotated[str | None, "Optional comma-separated Galaxy tags to filter (e.g., 'networking,cloud')"] = None,
     ctx: Context | None = None,
-) -> CollectionSearchResult | ErrorResponse:
+) -> dict[str, Any]:
     """Search Ansible Galaxy for collections by keyword.
 
     Returns non-deprecated collections ranked by download count.
@@ -615,7 +608,7 @@ async def ensure_collection(
         str | None,
         "Optional version (e.g. '4.1.0'). If omitted, installs latest and pins the resolved version.",
     ] = None,
-) -> EnsureCollectionResult | ErrorResponse:
+) -> dict[str, Any]:
     """Install a collection to a temporary directory for this session.
 
     Installs once and pins the resolved version. Subsequent calls with the
@@ -660,7 +653,7 @@ async def ensure_collection(
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-async def list_skills() -> list[SkillEntry] | ErrorResponse:
+async def list_skills() -> list[dict[str, str]] | dict[str, str]:
     """List all available generated skills. Returns name, description, path for each.
 
     Returns: [{"name": str, "description": str, "path": str}, ...] or {"error": str} on failure.

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -16,6 +16,13 @@ from functools import partial
 from importlib.metadata import version as pkg_version
 from typing import TYPE_CHECKING, Annotated, Any
 
+from ansible_know.types import (
+    CollectionSearchResult,
+    EnsureCollectionResult,
+    ErrorResponse,
+    SkillEntry,
+)
+
 if TYPE_CHECKING:
     from ansible_know.galaxy_config import GalaxyServerConfig
     from ansible_know.types import DocProvenance
@@ -450,7 +457,7 @@ async def search_collections(
     query: Annotated[str, "Search keyword (e.g., 'netbox', 'cisco ios', 'vmware')"],
     tags: Annotated[str | None, "Optional comma-separated Galaxy tags to filter (e.g., 'networking,cloud')"] = None,
     ctx: Context | None = None,
-) -> dict[str, Any]:
+) -> CollectionSearchResult | ErrorResponse:
     """Search Ansible Galaxy for collections by keyword.
 
     Returns non-deprecated collections ranked by download count.
@@ -608,7 +615,7 @@ async def ensure_collection(
         str | None,
         "Optional version (e.g. '4.1.0'). If omitted, installs latest and pins the resolved version.",
     ] = None,
-) -> dict[str, Any]:
+) -> EnsureCollectionResult | ErrorResponse:
     """Install a collection to a temporary directory for this session.
 
     Installs once and pins the resolved version. Subsequent calls with the
@@ -653,7 +660,7 @@ async def ensure_collection(
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-async def list_skills() -> list[dict[str, str]] | dict[str, str]:
+async def list_skills() -> list[SkillEntry] | ErrorResponse:
     """List all available generated skills. Returns name, description, path for each.
 
     Returns: [{"name": str, "description": str, "path": str}, ...] or {"error": str} on failure.

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -16,16 +16,22 @@ from ansible_know.config import TEMPLATE_DIR
 logger = logging.getLogger("ansible_know")
 
 
-def _get_template_env():
-    """Create a Jinja2 environment pointed at the templates directory."""
-    from jinja2 import Environment, FileSystemLoader
+_template_env = None
 
-    return Environment(
-        loader=FileSystemLoader(str(TEMPLATE_DIR)),
-        keep_trailing_newline=True,
-        trim_blocks=True,
-        lstrip_blocks=True,
-    )
+
+def _get_template_env():
+    """Return the cached Jinja2 environment, creating it on first call."""
+    global _template_env
+    if _template_env is None:
+        from jinja2 import Environment, FileSystemLoader
+
+        _template_env = Environment(
+            loader=FileSystemLoader(str(TEMPLATE_DIR)),
+            keep_trailing_newline=True,
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
+    return _template_env
 
 
 def _module_to_skill_name(module_name: str) -> str:

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -6,11 +6,14 @@ from Ansible module metadata.
 
 from __future__ import annotations
 
+import logging
 import stat
 from pathlib import Path
 from typing import Any
 
 from ansible_know.config import TEMPLATE_DIR
+
+logger = logging.getLogger("ansible_know")
 
 
 def _get_template_env():
@@ -55,6 +58,7 @@ def _examples_contain_play(examples: str) -> bool:
 
 def render_skill(metadata: dict[str, Any]) -> str:
     """Render the SKILL.md template with the given module metadata."""
+    logger.debug("Rendering skill for module %s", metadata.get("module_name", "?"))
     env = _get_template_env()
     template = env.get_template("SKILL.md.j2")
     return template.render(**_template_context(metadata))
@@ -62,6 +66,7 @@ def render_skill(metadata: dict[str, Any]) -> str:
 
 def write_skill_package(output_dir: Path, metadata: dict[str, Any]) -> None:
     """Write the full skill package: SKILL.md + scripts + assets."""
+    logger.debug("Writing skill package to %s for %s", output_dir, metadata.get("module_name", "?"))
     env = _get_template_env()
     ctx = _template_context(metadata)
 
@@ -150,6 +155,7 @@ def _role_template_context(metadata: dict[str, Any]) -> dict[str, Any]:
 
 def render_role_skill(metadata: dict[str, Any]) -> str:
     """Render the ROLE_SKILL.md.j2 template with role metadata."""
+    logger.debug("Rendering role skill for %s", metadata.get("role_name", "?"))
     env = _get_template_env()
     template = env.get_template("ROLE_SKILL.md.j2")
     return template.render(**_role_template_context(metadata))
@@ -157,6 +163,7 @@ def render_role_skill(metadata: dict[str, Any]) -> str:
 
 def write_role_skill_package(output_dir: Path, metadata: dict[str, Any]) -> None:
     """Write the role skill package: SKILL.md + assets/playbook.yml (no scripts/)."""
+    logger.debug("Writing role skill package to %s for %s", output_dir, metadata.get("role_name", "?"))
     env = _get_template_env()
     ctx = _role_template_context(metadata)
 

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -6,6 +6,7 @@ from Ansible module metadata.
 
 from __future__ import annotations
 
+import functools
 import logging
 import stat
 from pathlib import Path
@@ -16,22 +17,17 @@ from ansible_know.config import TEMPLATE_DIR
 logger = logging.getLogger("ansible_know")
 
 
-_template_env = None
-
-
+@functools.lru_cache(maxsize=1)
 def _get_template_env():
     """Return the cached Jinja2 environment, creating it on first call."""
-    global _template_env
-    if _template_env is None:
-        from jinja2 import Environment, FileSystemLoader
+    from jinja2 import Environment, FileSystemLoader
 
-        _template_env = Environment(
-            loader=FileSystemLoader(str(TEMPLATE_DIR)),
-            keep_trailing_newline=True,
-            trim_blocks=True,
-            lstrip_blocks=True,
-        )
-    return _template_env
+    return Environment(
+        loader=FileSystemLoader(str(TEMPLATE_DIR)),
+        keep_trailing_newline=True,
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
 
 
 def _module_to_skill_name(module_name: str) -> str:

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -33,3 +33,34 @@ class DocProvenance(_DocProvenanceBase, total=False):
 
     doc_warning: str
     doc_source_server: str
+
+
+class ErrorResponse(TypedDict):
+    """Standard error shape returned by all tools on failure."""
+
+    error: str
+
+
+class EnsureCollectionResult(TypedDict):
+    """Result of ensure_collection tool."""
+
+    namespace: str
+    version: str
+    status: str
+    message: str
+
+
+class SkillEntry(TypedDict):
+    """Single entry in list_skills output."""
+
+    name: str
+    description: str
+    path: str
+
+
+class CollectionSearchResult(TypedDict):
+    """Result of search_collections tool."""
+
+    query: str
+    count: int
+    collections: list[dict[str, Any]]

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -58,9 +58,33 @@ class SkillEntry(TypedDict):
     path: str
 
 
+class _CollectionInfoBase(TypedDict):
+    """Required fields for a collection search result entry."""
+
+    namespace: str
+    description: str
+    tags: list[str]
+    latest_version: str
+    module_count: int
+    deprecated: bool
+    signed: bool
+
+
+class CollectionInfo(_CollectionInfoBase, total=False):
+    """Single collection entry from search_collections.
+
+    Optional fields are populated during enrichment (download_count,
+    role_count) or added by server.py (source).
+    """
+
+    role_count: int
+    download_count: int
+    source: str
+
+
 class CollectionSearchResult(TypedDict):
     """Result of search_collections tool."""
 
     query: str
     count: int
-    collections: list[dict[str, Any]]
+    collections: list[CollectionInfo]

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -66,6 +66,7 @@ class _CollectionInfoBase(TypedDict):
     tags: list[str]
     latest_version: str
     module_count: int
+    role_count: int
     deprecated: bool
     signed: bool
 
@@ -73,11 +74,10 @@ class _CollectionInfoBase(TypedDict):
 class CollectionInfo(_CollectionInfoBase, total=False):
     """Single collection entry from search_collections.
 
-    Optional fields are populated during enrichment (download_count,
-    role_count) or added by server.py (source).
+    Optional fields are populated during enrichment (download_count)
+    or added by server.py (source).
     """
 
-    role_count: int
     download_count: int
     source: str
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -100,6 +100,23 @@ class TestBoundedCache:
             assert "a" not in cache
         assert len(cache) == 1
 
+    def test_expired_entries_purged_on_pressure(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=3, ttl=0.5)
+        cache.put("a", 1)
+        cache.put("b", 2)
+        cache.put("c", 3)
+        with patch("ansible_know.cache.time.monotonic", return_value=time.monotonic() + 1.0):
+            cache.put("d", 4)
+            assert cache.get("d") == 4
+            assert len(cache) == 1
+
+    def test_no_purge_when_below_capacity(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=10, ttl=0.5)
+        cache.put("a", 1)
+        with patch("ansible_know.cache.time.monotonic", return_value=time.monotonic() + 1.0):
+            cache.put("b", 2)
+        assert len(cache) == 2
+
     def test_max_size_property(self):
         cache: BoundedCache[str, int] = BoundedCache(max_size=42)
         assert cache.max_size == 42

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,111 @@
+"""Tests for ansible_know.cache."""
+
+import threading
+import time
+from unittest.mock import patch
+
+from ansible_know.cache import BoundedCache
+
+
+class TestBoundedCache:
+    def test_get_put_basic(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=10)
+        cache.put("a", 1)
+        assert cache.get("a") == 1
+
+    def test_get_missing_returns_none(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=10)
+        assert cache.get("missing") is None
+
+    def test_lru_eviction(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=3)
+        cache.put("a", 1)
+        cache.put("b", 2)
+        cache.put("c", 3)
+        cache.put("d", 4)
+        assert cache.get("a") is None
+        assert cache.get("b") == 2
+        assert cache.get("d") == 4
+
+    def test_lru_access_refreshes(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=3)
+        cache.put("a", 1)
+        cache.put("b", 2)
+        cache.put("c", 3)
+        cache.get("a")
+        cache.put("d", 4)
+        assert cache.get("a") == 1
+        assert cache.get("b") is None
+
+    def test_ttl_expiry(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=10, ttl=0.5)
+        cache.put("a", 1)
+        assert cache.get("a") == 1
+        with patch("ansible_know.cache.time.monotonic", return_value=time.monotonic() + 1.0):
+            assert cache.get("a") is None
+
+    def test_ttl_not_expired(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=10, ttl=10.0)
+        cache.put("a", 1)
+        assert cache.get("a") == 1
+
+    def test_no_ttl_never_expires(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=10)
+        cache.put("a", 1)
+        with patch("ansible_know.cache.time.monotonic", return_value=time.monotonic() + 999999):
+            assert cache.get("a") == 1
+
+    def test_overwrite_value(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=10)
+        cache.put("a", 1)
+        cache.put("a", 2)
+        assert cache.get("a") == 2
+
+    def test_clear(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=10)
+        cache.put("a", 1)
+        cache.put("b", 2)
+        cache.clear()
+        assert cache.get("a") is None
+        assert cache.get("b") is None
+        assert len(cache) == 0
+
+    def test_len(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=10)
+        assert len(cache) == 0
+        cache.put("a", 1)
+        assert len(cache) == 1
+        cache.put("b", 2)
+        assert len(cache) == 2
+
+    def test_contains(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=10)
+        cache.put("a", 1)
+        assert "a" in cache
+        assert "b" not in cache
+
+    def test_tuple_keys(self):
+        cache: BoundedCache[tuple[str, str], str] = BoundedCache(max_size=10)
+        cache.put(("ns", "name"), "1.0.0")
+        assert cache.get(("ns", "name")) == "1.0.0"
+        assert cache.get(("ns", "other")) is None
+
+    def test_thread_safety(self):
+        cache: BoundedCache[int, int] = BoundedCache(max_size=1000)
+        errors: list[Exception] = []
+
+        def writer(start: int) -> None:
+            try:
+                for i in range(start, start + 100):
+                    cache.put(i, i * 2)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer, args=(i * 100,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert len(cache) <= 1000

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -84,6 +84,26 @@ class TestBoundedCache:
         assert "a" in cache
         assert "b" not in cache
 
+    def test_contains_does_not_refresh_lru(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=3)
+        cache.put("a", 1)
+        cache.put("b", 2)
+        cache.put("c", 3)
+        assert "a" in cache
+        cache.put("d", 4)
+        assert "a" not in cache
+
+    def test_contains_expired_does_not_delete(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=10, ttl=0.5)
+        cache.put("a", 1)
+        with patch("ansible_know.cache.time.monotonic", return_value=time.monotonic() + 1.0):
+            assert "a" not in cache
+        assert len(cache) == 1
+
+    def test_max_size_property(self):
+        cache: BoundedCache[str, int] = BoundedCache(max_size=42)
+        assert cache.max_size == 42
+
     def test_tuple_keys(self):
         cache: BoundedCache[tuple[str, str], str] = BoundedCache(max_size=10)
         cache.put(("ns", "name"), "1.0.0")

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -661,7 +661,7 @@ class TestResponseSizeLimit:
 
 class TestCacheEviction:
     def test_version_cache_evicts_oldest(self):
-        max_size = _version_cache._max_size
+        max_size = _version_cache.max_size
         for i in range(max_size + 5):
             _version_cache.put(("ns", f"col{i}"), f"1.0.{i}")
         assert _version_cache.get(("ns", "col0")) is None
@@ -669,7 +669,7 @@ class TestCacheEviction:
         assert _version_cache.get(("ns", f"col{max_size + 4}")) == f"1.0.{max_size + 4}"
 
     def test_blob_cache_evicts_oldest(self):
-        max_size = _blob_cache._max_size
+        max_size = _blob_cache.max_size
         for i in range(max_size + 5):
             _blob_cache.put(("ns", f"col{i}", "1.0.0"), {"idx": i})
         assert _blob_cache.get(("ns", "col0", "1.0.0")) is None
@@ -677,7 +677,7 @@ class TestCacheEviction:
         assert _blob_cache.get(("ns", f"col{max_size + 4}", "1.0.0")) == {"idx": max_size + 4}
 
     def test_version_cache_stays_at_max_size(self):
-        max_size = _version_cache._max_size
+        max_size = _version_cache.max_size
         for i in range(max_size + 10):
             _version_cache.put(("ns", f"c{i}"), f"v{i}")
         assert len(_version_cache) <= max_size

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -10,17 +10,13 @@ import pytest
 from ansible_know.errors import GalaxyError
 from ansible_know.galaxy import (
     CACHE_TTL_SECONDS,
-    MAX_BLOB_CACHE_SIZE,
     MAX_GALAXY_RESPONSE_SIZE,
-    MAX_VERSION_CACHE_SIZE,
     TIMEOUT_DEFAULT,
     TIMEOUT_FAST,
     TIMEOUT_SLOW,
     GalaxyClient,
-    _get_blob_cache,
-    _get_version_cache,
-    _put_blob_cache,
-    _put_version_cache,
+    _blob_cache,
+    _version_cache,
     clear_cache,
 )
 from tests.conftest import SAMPLE_DOCS_BLOB_WITH_ROLES
@@ -665,25 +661,26 @@ class TestResponseSizeLimit:
 
 class TestCacheEviction:
     def test_version_cache_evicts_oldest(self):
-        for i in range(MAX_VERSION_CACHE_SIZE + 5):
-            _put_version_cache(("ns", f"col{i}"), f"1.0.{i}")
-        assert _get_version_cache(("ns", "col0")) is None
-        assert _get_version_cache(("ns", "col1")) is None
-        assert _get_version_cache(("ns", f"col{MAX_VERSION_CACHE_SIZE + 4}")) == f"1.0.{MAX_VERSION_CACHE_SIZE + 4}"
+        max_size = _version_cache._max_size
+        for i in range(max_size + 5):
+            _version_cache.put(("ns", f"col{i}"), f"1.0.{i}")
+        assert _version_cache.get(("ns", "col0")) is None
+        assert _version_cache.get(("ns", "col1")) is None
+        assert _version_cache.get(("ns", f"col{max_size + 4}")) == f"1.0.{max_size + 4}"
 
     def test_blob_cache_evicts_oldest(self):
-        for i in range(MAX_BLOB_CACHE_SIZE + 5):
-            _put_blob_cache(("ns", f"col{i}", "1.0.0"), {"idx": i})
-        assert _get_blob_cache(("ns", "col0", "1.0.0")) is None
-        assert _get_blob_cache(("ns", "col1", "1.0.0")) is None
-        assert _get_blob_cache(("ns", f"col{MAX_BLOB_CACHE_SIZE + 4}", "1.0.0")) == {"idx": MAX_BLOB_CACHE_SIZE + 4}
+        max_size = _blob_cache._max_size
+        for i in range(max_size + 5):
+            _blob_cache.put(("ns", f"col{i}", "1.0.0"), {"idx": i})
+        assert _blob_cache.get(("ns", "col0", "1.0.0")) is None
+        assert _blob_cache.get(("ns", "col1", "1.0.0")) is None
+        assert _blob_cache.get(("ns", f"col{max_size + 4}", "1.0.0")) == {"idx": max_size + 4}
 
     def test_version_cache_stays_at_max_size(self):
-        from ansible_know.galaxy import _version_cache, _version_lock
-        for i in range(MAX_VERSION_CACHE_SIZE + 10):
-            _put_version_cache(("ns", f"c{i}"), f"v{i}")
-        with _version_lock:
-            assert len(_version_cache) <= MAX_VERSION_CACHE_SIZE
+        max_size = _version_cache._max_size
+        for i in range(max_size + 10):
+            _version_cache.put(("ns", f"c{i}"), f"v{i}")
+        assert len(_version_cache) <= max_size
 
 
 class TestNetworkErrors:
@@ -735,7 +732,7 @@ class TestNetworkErrors:
 class TestCacheHitPaths:
     @pytest.mark.asyncio
     async def test_version_cache_hit_skips_api(self):
-        _put_version_cache(("netbox", "netbox"), "3.23.0")
+        _version_cache.put(("netbox", "netbox"), "3.23.0")
         mock_client = _mock_client_get({})
         with patch("ansible_know.galaxy.httpx.AsyncClient", return_value=mock_client):
             client = GalaxyClient()
@@ -745,8 +742,8 @@ class TestCacheHitPaths:
 
     @pytest.mark.asyncio
     async def test_blob_cache_hit_skips_api(self):
-        _put_version_cache(("netbox", "netbox"), "3.23.0")
-        _put_blob_cache(("netbox", "netbox", "3.23.0"), SAMPLE_DOCS_BLOB["docs_blob"])
+        _version_cache.put(("netbox", "netbox"), "3.23.0")
+        _blob_cache.put(("netbox", "netbox", "3.23.0"), SAMPLE_DOCS_BLOB["docs_blob"])
 
         with patch.object(GalaxyClient, "_api_get", side_effect=AssertionError("should not call API")):
             client = GalaxyClient()
@@ -949,30 +946,30 @@ class TestUnicodeQueries:
 
 class TestCacheTTL:
     def test_version_cache_returns_none_after_ttl(self):
-        _put_version_cache(("ns", "col"), "1.0.0")
-        assert _get_version_cache(("ns", "col")) == "1.0.0"
-        with stdlib_patch("ansible_know.galaxy.time") as mock_time:
+        _version_cache.put(("ns", "col"), "1.0.0")
+        assert _version_cache.get(("ns", "col")) == "1.0.0"
+        with stdlib_patch("ansible_know.cache.time") as mock_time:
             mock_time.monotonic.return_value = time.monotonic() + CACHE_TTL_SECONDS + 1
-            assert _get_version_cache(("ns", "col")) is None
+            assert _version_cache.get(("ns", "col")) is None
 
     def test_blob_cache_returns_none_after_ttl(self):
-        _put_blob_cache(("ns", "col", "1.0.0"), {"data": "test"})
-        assert _get_blob_cache(("ns", "col", "1.0.0")) == {"data": "test"}
-        with stdlib_patch("ansible_know.galaxy.time") as mock_time:
+        _blob_cache.put(("ns", "col", "1.0.0"), {"data": "test"})
+        assert _blob_cache.get(("ns", "col", "1.0.0")) == {"data": "test"}
+        with stdlib_patch("ansible_know.cache.time") as mock_time:
             mock_time.monotonic.return_value = time.monotonic() + CACHE_TTL_SECONDS + 1
-            assert _get_blob_cache(("ns", "col", "1.0.0")) is None
+            assert _blob_cache.get(("ns", "col", "1.0.0")) is None
 
     def test_version_cache_returns_value_before_ttl(self):
-        _put_version_cache(("ns", "col"), "2.0.0")
-        with stdlib_patch("ansible_know.galaxy.time") as mock_time:
+        _version_cache.put(("ns", "col"), "2.0.0")
+        with stdlib_patch("ansible_know.cache.time") as mock_time:
             mock_time.monotonic.return_value = time.monotonic() + CACHE_TTL_SECONDS - 10
-            assert _get_version_cache(("ns", "col")) == "2.0.0"
+            assert _version_cache.get(("ns", "col")) == "2.0.0"
 
     def test_blob_cache_returns_value_before_ttl(self):
-        _put_blob_cache(("ns", "col", "1.0.0"), {"data": "fresh"})
-        with stdlib_patch("ansible_know.galaxy.time") as mock_time:
+        _blob_cache.put(("ns", "col", "1.0.0"), {"data": "fresh"})
+        with stdlib_patch("ansible_know.cache.time") as mock_time:
             mock_time.monotonic.return_value = time.monotonic() + CACHE_TTL_SECONDS - 10
-            assert _get_blob_cache(("ns", "col", "1.0.0")) == {"data": "fresh"}
+            assert _blob_cache.get(("ns", "col", "1.0.0")) == {"data": "fresh"}
 
 
 class TestConcurrentCacheAccess:
@@ -984,8 +981,8 @@ class TestConcurrentCacheAccess:
         def write_batch(start):
             try:
                 for i in range(100):
-                    _put_version_cache(("ns", f"col_{start}_{i}"), f"v{i}")
-                    _get_version_cache(("ns", f"col_{start}_{i}"))
+                    _version_cache.put(("ns", f"col_{start}_{i}"), f"v{i}")
+                    _version_cache.get(("ns", f"col_{start}_{i}"))
             except Exception as e:
                 errors.append(e)
 
@@ -1005,8 +1002,8 @@ class TestConcurrentCacheAccess:
         def write_batch(start):
             try:
                 for i in range(50):
-                    _put_blob_cache(("ns", f"col_{start}_{i}", "1.0"), {"v": i})
-                    _get_blob_cache(("ns", f"col_{start}_{i}", "1.0"))
+                    _blob_cache.put(("ns", f"col_{start}_{i}", "1.0"), {"v": i})
+                    _blob_cache.get(("ns", f"col_{start}_{i}", "1.0"))
             except Exception as e:
                 errors.append(e)
 
@@ -1051,7 +1048,7 @@ class TestTimeoutPassthrough:
 
     @pytest.mark.asyncio
     async def test_fetch_docs_blob_uses_slow_timeout(self):
-        _put_version_cache(("netbox", "netbox"), "3.23.0")
+        _version_cache.put(("netbox", "netbox"), "3.23.0")
         mock_client = _mock_client_get(SAMPLE_DOCS_BLOB)
         with patch("ansible_know.galaxy.httpx.AsyncClient", return_value=mock_client):
             client = GalaxyClient()

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "ansible-know-mcp"
-version = "0.1.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -44,7 +44,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=3.0" },
+    { name = "fastmcp", specifier = ">=3.2,<4" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },


### PR DESCRIPTION
## Summary

Three improvements identified during the architecture review (docs/research/architecture-report.md):

- **Add logging to parser.py and skills.py** — establishes convention that every module logs its work, matching the existing pattern in galaxy.py, docs.py, collections.py, and server.py. All at debug level. (Closes #59)
- **Tighten TypedDicts and document internal state** — adds `ErrorResponse`, `EnsureCollectionResult`, `SkillEntry`, and `CollectionSearchResult` TypedDicts; moves lazy import in parser.py to top-level; documents `_missing_collections` negative cache and shared Galaxy caches. (Closes #57)
- **Introduce shared cache abstraction** — adds `BoundedCache` class replacing ad-hoc OrderedDict+Lock+TTL patterns in galaxy.py (~40 lines removed) and gives docs.py thread-safety and bounded size. Includes 14 unit tests. (Closes #58)

## Test plan

- [x] All 423 unit tests pass
- [x] ruff check clean
- [ ] Verify debug logging appears when `ANSIBLE_KNOW_LOG_LEVEL=DEBUG` is set
- [ ] Verify Galaxy cache behavior unchanged (TTL expiry, LRU eviction)

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>