### PR TITLE
refactor: batch of trivial architecture fixes

### DIFF
--- a/src/ansible_know/collection_manifest.py
+++ b/src/ansible_know/collection_manifest.py
@@ -16,6 +16,11 @@ from ansible_know.config import SKILLS_DIR
 if TYPE_CHECKING:
     from ansible_know.types import ModuleMetadata
 
+__all__ = [
+    "generate_manifest",
+    "load_cached_manifest",
+]
+
 
 def _derive_tags(fqcn: str, params: list[dict[str, Any]]) -> list[str]:
     """Heuristically derive tags from module name segments and parameters."""

--- a/src/ansible_know/config.py
+++ b/src/ansible_know/config.py
@@ -11,10 +11,15 @@ _PKG_DIR = Path(__file__).resolve().parent
 
 TEMPLATE_DIR = _PKG_DIR / "templates"
 
-SKILLS_DIR = Path(os.environ.get(
-    "ANSIBLE_KNOW_SKILLS_DIR",
-    Path.cwd() / "skills",
-))
+def __getattr__(name: str):
+    if name == "SKILLS_DIR":
+        value = Path(os.environ.get(
+            "ANSIBLE_KNOW_SKILLS_DIR",
+            Path.cwd() / "skills",
+        ))
+        globals()["SKILLS_DIR"] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 DEFAULT_DOC_SOURCES: dict[str, dict[str, str]] = {
     "ansible-core": {

--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -16,6 +16,11 @@ from ansible_know.config import SEARCH_DOCS_LIMIT, get_doc_sources
 
 logger = logging.getLogger("ansible_know")
 
+__all__ = [
+    "clear_cache",
+    "search_docs",
+]
+
 MAX_MANIFEST_SIZE = 5_000_000  # 5MB
 CACHE_TTL_SECONDS = 3600
 

--- a/src/ansible_know/parser.py
+++ b/src/ansible_know/parser.py
@@ -23,6 +23,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("ansible_know")
 
+__all__ = [
+    "extract_examples",
+    "extract_module_metadata",
+    "extract_params",
+    "extract_role_metadata",
+    "extract_short_description",
+    "get_module_doc",
+    "get_role_doc",
+    "is_api_module",
+    "list_modules",
+    "list_roles",
+    "search_modules",
+]
+
 
 
 def _find_ansible_doc() -> str:

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -125,7 +125,7 @@ mcp = FastMCP(
 
 def _run_in_executor(func, *args, **kwargs):
     """Run a blocking function in the default executor."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return loop.run_in_executor(None, partial(func, *args, **kwargs))
 
 
@@ -166,6 +166,11 @@ async def _maybe_warn_upgrade(ctx: Context | None) -> None:
 # Skips retrying local resolution for known-missing collections,
 # going straight to Galaxy fallback. Cleared per-namespace on
 # successful ensure_collection().
+#
+# Thread safety: only mutated from the asyncio event loop thread
+# (add/discard in coroutines); executor callbacks (parser calls)
+# never touch it. Under CPython, set.add/discard/`in` are also
+# GIL-atomic, so even an accidental cross-thread read is safe.
 _missing_collections: set[str] = set()
 
 
@@ -754,7 +759,7 @@ async def generate_skill(
         if ctx:
             await ctx.report_progress(progress=50, total=100)
 
-        skill_name = skills._module_to_skill_name(metadata["module_name"])
+        skill_name = skills.module_to_skill_name(metadata["module_name"])
         base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
         output_dir = base_dir / skill_name
 
@@ -881,7 +886,7 @@ async def generate_collection_skills(
                 metadata = parser.extract_module_metadata(raw_doc)
                 metadata_list.append(metadata)
 
-                skill_name = skills._module_to_skill_name(metadata["module_name"])
+                skill_name = skills.module_to_skill_name(metadata["module_name"])
                 output_dir = base_dir / skill_name
                 await _run_in_executor(skills.write_skill_package, output_dir, metadata)
                 succeeded += 1

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -16,6 +16,14 @@ from ansible_know.config import TEMPLATE_DIR
 
 logger = logging.getLogger("ansible_know")
 
+__all__ = [
+    "module_to_skill_name",
+    "render_role_skill",
+    "render_skill",
+    "write_role_skill_package",
+    "write_skill_package",
+]
+
 
 @functools.lru_cache(maxsize=1)
 def _get_template_env():
@@ -30,7 +38,7 @@ def _get_template_env():
     )
 
 
-def _module_to_skill_name(module_name: str) -> str:
+def module_to_skill_name(module_name: str) -> str:
     """Convert a module FQCN to a skill directory name."""
     return module_name
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -5,8 +5,8 @@ from ansible_know.parser import extract_module_metadata
 from ansible_know.skills import (
     _build_example_args,
     _extract_example_values,
-    _module_to_skill_name,
     _role_template_context,
+    module_to_skill_name,
     render_role_skill,
     render_skill,
     write_role_skill_package,
@@ -16,10 +16,10 @@ from ansible_know.skills import (
 
 class TestModuleToSkillName:
     def test_uses_fqcn(self):
-        assert _module_to_skill_name("ansible.builtin.package") == "ansible.builtin.package"
+        assert module_to_skill_name("ansible.builtin.package") == "ansible.builtin.package"
 
     def test_preserves_collection_prefix(self):
-        assert _module_to_skill_name("netbox.netbox.netbox_device") == "netbox.netbox.netbox_device"
+        assert module_to_skill_name("netbox.netbox.netbox_device") == "netbox.netbox.netbox_device"
 
 
 class TestExtractExampleValues:


### PR DESCRIPTION
## Summary

- **V-T2**: Replace deprecated `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in `_run_in_executor()`
- **V-D1**: Rename `skills._module_to_skill_name()` to public `module_to_skill_name()` — called across module boundaries from `server.py`
- **V-F1**: Make `SKILLS_DIR` in `config.py` lazy via module `__getattr__` (PEP 562) — previously evaluated `Path.cwd()` at import time
- **V-S2**: Document GIL reliance for `_missing_collections` set thread safety
- **V-D2–D5**: Add `__all__` to `parser.py`, `skills.py`, `collection_manifest.py`, `docs.py` (PEP 8 §8.4)

Closes #67

## Test plan

- [x] All 428 unit tests pass
- [x] ruff lint clean
- [ ] Integration tests (require ansible-core + network)

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>