### PR TITLE
refactor: clean up External Access layer contracts

### DIFF
--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -158,8 +158,8 @@ the process boundary: the Galaxy REST API, the `ansible-doc` CLI, the
 
 | External Access Module | Consumers | File |
 |------------------------|-----------|------|
-| `galaxy.py` (`GalaxyClient`) | `server.py` (directly, bypassing Domain) | `galaxy.py` |
-| `collections.py` | `server.py`, `parser.py` | `collections.py` |
+| `galaxy.py` (`GalaxyClient`) | `resolution.py` (via `GalaxyDocClient` Protocol) | `galaxy.py` |
+| `collections.py` | `server.py`, `resolution.py` | `collections.py` |
 | `readme_parser.py` | `galaxy.py` | `readme_parser.py` |
 
 `GalaxyClient` is the primary class in the codebase. It acts as an async HTTP
@@ -193,8 +193,8 @@ layer and `_ReadmeParser` in `readme_parser.py` are the other classes.)
 | ID | Severity | Description | Location |
 |----|----------|-------------|----------|
 | ~~V-E1~~ | ~~Error~~ | ~~`server.py` calls `GalaxyClient` directly in `search_collections()` and `_try_galaxy_servers()`, bypassing the Domain layer entirely. Galaxy access should be mediated through a domain-level service.~~ **Fixed in PR #66** — Galaxy access is now mediated through `resolution.py`. | ~~`server.py:168-192`, `server.py:480-486`~~ |
-| ~~V-E2~~ | ~~Warning~~ | ~~`GalaxyClient` has no abstract base class or Protocol.~~ **Partially fixed in PR #66:** `GalaxyDocClient` Protocol and `GalaxyClientFactory` Protocol defined in `types.py`. `resolution.py` depends on the Protocol, not the concrete class. `GalaxyClient` satisfies the Protocol structurally. | ~~`galaxy.py:111`~~ → `types.py` |
-| V-E3 | Warning | `GalaxyClient._transform_to_ansible_doc_format()` is a static method that converts Galaxy format to ansible-doc format. This is a data transformation that belongs in the Domain layer (parser), not the External Access layer. | `galaxy.py:381-417` |
+| ~~V-E2~~ | ~~Warning~~ | ~~`GalaxyClient` has no abstract base class or Protocol.~~ **Fixed in PR #66:** `GalaxyDocClient` Protocol and `GalaxyClientFactory` Protocol defined in `types.py`. `resolution.py` depends on the Protocol, not the concrete class. `GalaxyClient` satisfies the Protocol structurally. | ~~`galaxy.py:111`~~ → `types.py` |
+| ~~V-E3~~ | ~~Warning~~ | ~~`GalaxyClient._transform_to_ansible_doc_format()` is a static method that converts Galaxy format to ansible-doc format. This is a data transformation that belongs in the Domain layer (parser), not the External Access layer.~~ **Fixed in PR #69** — Moved to `parser.transform_galaxy_to_ansible_doc_format()`. `galaxy.py` lazy-imports it. | ~~`galaxy.py:381-417`~~ → `parser.py` |
 | V-E4 | Warning | `collections.py` module-level mutable state (`_tmp_dir`, `_installed`, `_install_locks`) makes the module impossible to test in isolation without monkeypatching globals. Should be encapsulated in a class. | `collections.py:26-29` |
 | V-E5 | Info | `galaxy.py` uses `asyncio.Semaphore` for enrichment throttling but creates it lazily with event-loop detection (`_get_enrichment_semaphore`). This is fragile if the event loop changes. | `galaxy.py:40-46` |
 
@@ -326,8 +326,8 @@ Foundation   → (no internal dependencies)
 |----|----------|-------------|
 | ~~V-L1~~ | ~~Error~~ | ~~Orchestration (`server.py`) imports and calls External Access (`galaxy.py:GalaxyClient`) directly, bypassing the Domain layer.~~ **Fixed in PR #66** — Orchestration delegates to `resolution.py` (Domain). | 
 | ~~V-L2~~ | ~~Warning~~ | ~~Orchestration (`server.py`) contains domain logic in `_resolve_module_doc()` and `_resolve_role_doc()` — these are domain-level resolution strategies, not orchestration.~~ **Fixed in PR #66** — Moved to `resolution.py`. |
-| V-L3 | Info | External Access (`galaxy.py`) calls Domain (`readme_parser.py`) for `fetch_role_doc()`. This is arguably acceptable as `readme_parser` is a pure data transformer, but it means `galaxy.py` depends upward. |
-| V-L4 | Warning | Domain (`parser.py`) imports External Access (`collections.py`) at the top level to get the collections path. This permanently couples the parser to the collection installation mechanism. (Was a lazy import before PR #60; now a top-level `from ansible_know import collections`.) |
+| V-L3 | Info | External Access (`galaxy.py`) lazy-imports Domain modules (`readme_parser.py` for `fetch_role_doc()`, `parser.py` for `transform_galaxy_to_ansible_doc_format()` in `fetch_module_doc()`). Both are pure data transformers — acceptable cross-layer calls that avoid duplicating domain logic. |
+| ~~V-L4~~ | ~~Warning~~ | ~~Domain (`parser.py`) imports External Access (`collections.py`) at the top level to get the collections path.~~ **Fixed in PR #69** — `parser.py` accepts `collections_path` as a parameter; callers (server.py, resolution.py) inject it from `collections.get_collections_path()`. |
 
 ---
 
@@ -353,8 +353,9 @@ Foundation   → (no internal dependencies)
    domain-level resolution module.~~ **Fixed in PR #66**.
 8. **V-D8**: Split `generate_manifest()` into generation and persistence.
 9. ~~**V-E2**: Define a `GalaxyClientProtocol` for the Galaxy client interface.~~
-   **Partially fixed in PR #66** — `GalaxyDocClient` Protocol in `types.py`.
-10. **V-E3**: Move `_transform_to_ansible_doc_format()` to `parser.py`.
+   **Fixed in PR #66** — `GalaxyDocClient` Protocol in `types.py`.
+10. ~~**V-E3**: Move `_transform_to_ansible_doc_format()` to `parser.py`.~~
+    **Fixed in PR #69** — now `parser.transform_galaxy_to_ansible_doc_format()`.
 11. **V-E4**: Encapsulate `collections.py` state in a `CollectionManager` class.
 12. **V-S2**: Use `asyncio.Lock` or explicit synchronization for `_missing_collections`.
 13. **V-S3**: Design a `ServerState` or session context that encapsulates all

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -338,45 +338,6 @@ class GalaxyClient:
                 return item
         return None
 
-    @staticmethod
-    def _transform_to_ansible_doc_format(
-        fqcn: str, entry: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Convert a Galaxy docs-blob content entry to ansible-doc --json format."""
-        ds = entry.get("doc_strings", {})
-        raw_doc = ds.get("doc", {})
-
-        raw_options = raw_doc.get("options", [])
-        if isinstance(raw_options, list):
-            options_dict: dict[str, Any] = {}
-            for opt in raw_options:
-                if not isinstance(opt, dict):
-                    continue
-                opt_copy = dict(opt)
-                opt_name = opt_copy.pop("name", None)
-                if opt_name:
-                    options_dict[opt_name] = opt_copy
-        else:
-            options_dict = raw_options
-
-        doc_section = {
-            "short_description": raw_doc.get("short_description", ""),
-            "description": raw_doc.get("description", []),
-            "options": options_dict,
-            "author": raw_doc.get("author", []),
-            "notes": raw_doc.get("notes", []),
-            "version_added": raw_doc.get("version_added", ""),
-        }
-
-        return {
-            fqcn: {
-                "doc": doc_section,
-                "examples": ds.get("examples", ""),
-                "return": ds.get("return", []),
-                "metadata": ds.get("metadata", {}),
-            }
-        }
-
     async def fetch_module_doc(
         self, module_name: str, version: str | None = None,
     ) -> tuple[dict[str, Any], DocProvenance]:
@@ -397,7 +358,8 @@ class GalaxyClient:
                 f"{namespace}.{name} {resolved_version} docs-blob."
             )
 
-        doc = self._transform_to_ansible_doc_format(module_name, module_entry)
+        from ansible_know.parser import transform_galaxy_to_ansible_doc_format
+        doc = transform_galaxy_to_ansible_doc_format(module_name, module_entry)
 
         meta: DocProvenance = {
             "doc_source": "galaxy",

--- a/src/ansible_know/parser.py
+++ b/src/ansible_know/parser.py
@@ -15,7 +15,6 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from ansible_know import collections
 from ansible_know.errors import AnsibleDocError, CollectionNotFoundError, is_missing_collection_error
 
 if TYPE_CHECKING:
@@ -35,6 +34,7 @@ __all__ = [
     "list_modules",
     "list_roles",
     "search_modules",
+    "transform_galaxy_to_ansible_doc_format",
 ]
 
 
@@ -52,12 +52,13 @@ def _find_ansible_doc() -> str:
     )
 
 
-def _run_ansible_doc(*args: str) -> str:
+def _run_ansible_doc(
+    *args: str, collections_path: str | None = None,
+) -> str:
     """Execute ansible-doc with the given arguments and return stdout."""
     ansible_doc = _find_ansible_doc()
     cmd = [ansible_doc, *args]
 
-    collections_path = collections.get_collections_path()
     logger.debug("Running: %s (collections_path=%s)", " ".join(cmd), collections_path)
     env = None
     if collections_path:
@@ -99,13 +100,15 @@ def _run_ansible_doc(*args: str) -> str:
     return result.stdout
 
 
-def get_module_doc(module_name: str) -> dict[str, Any]:
+def get_module_doc(
+    module_name: str, *, collections_path: str | None = None,
+) -> dict[str, Any]:
     """Fetch full documentation for a single module.
 
     Returns the parsed JSON from `ansible-doc <module> --json`.
     The top-level dict is keyed by the fully-qualified module name.
     """
-    raw = _run_ansible_doc(module_name, "--json")
+    raw = _run_ansible_doc(module_name, "--json", collections_path=collections_path)
     try:
         doc = json.loads(raw)
     except json.JSONDecodeError as exc:
@@ -113,12 +116,15 @@ def get_module_doc(module_name: str) -> dict[str, Any]:
     return doc
 
 
-def list_modules(collection_filter: str | None = None) -> dict[str, str]:
+def list_modules(
+    collection_filter: str | None = None, *, collections_path: str | None = None,
+) -> dict[str, str]:
     """List available modules with short descriptions.
 
     Args:
         collection_filter: Optional collection filter passed to ansible-doc
                            (e.g., "community.docker"). If None, lists all modules.
+        collections_path: Optional path to prepend to ANSIBLE_COLLECTIONS_PATH.
 
     Returns:
         Dict mapping fully-qualified module names to their short descriptions.
@@ -126,7 +132,7 @@ def list_modules(collection_filter: str | None = None) -> dict[str, str]:
     args = ["--list", "--json"]
     if collection_filter:
         args.append(collection_filter)
-    raw = _run_ansible_doc(*args)
+    raw = _run_ansible_doc(*args, collections_path=collections_path)
     try:
         modules = json.loads(raw)
     except json.JSONDecodeError as exc:
@@ -134,17 +140,23 @@ def list_modules(collection_filter: str | None = None) -> dict[str, str]:
     return modules
 
 
-def search_modules(keyword: str, collection_filter: str | None = None) -> dict[str, str]:
+def search_modules(
+    keyword: str,
+    collection_filter: str | None = None,
+    *,
+    collections_path: str | None = None,
+) -> dict[str, str]:
     """Search modules by keyword in name or description.
 
     Args:
         keyword: Search term (case-insensitive).
         collection_filter: Optional collection to restrict the search.
+        collections_path: Optional path to prepend to ANSIBLE_COLLECTIONS_PATH.
 
     Returns:
         Filtered dict of matching module names -> descriptions.
     """
-    all_modules = list_modules(collection_filter)
+    all_modules = list_modules(collection_filter, collections_path=collections_path)
     keyword_lower = keyword.lower()
     return {
         name: desc
@@ -238,12 +250,54 @@ def extract_module_metadata(module_doc: dict[str, Any]) -> ModuleMetadata:
     }
 
 
-def list_roles(collection_filter: str | None = None) -> dict[str, dict[str, Any]]:
+def transform_galaxy_to_ansible_doc_format(
+    fqcn: str, entry: dict[str, Any],
+) -> dict[str, Any]:
+    """Convert a Galaxy docs-blob content entry to ansible-doc --json format."""
+    ds = entry.get("doc_strings", {})
+    raw_doc = ds.get("doc", {})
+
+    raw_options = raw_doc.get("options", [])
+    if isinstance(raw_options, list):
+        options_dict: dict[str, Any] = {}
+        for opt in raw_options:
+            if not isinstance(opt, dict):
+                continue
+            opt_copy = dict(opt)
+            opt_name = opt_copy.pop("name", None)
+            if opt_name:
+                options_dict[opt_name] = opt_copy
+    else:
+        options_dict = raw_options
+
+    doc_section = {
+        "short_description": raw_doc.get("short_description", ""),
+        "description": raw_doc.get("description", []),
+        "options": options_dict,
+        "author": raw_doc.get("author", []),
+        "notes": raw_doc.get("notes", []),
+        "version_added": raw_doc.get("version_added", ""),
+    }
+
+    return {
+        fqcn: {
+            "doc": doc_section,
+            "examples": ds.get("examples", ""),
+            "return": ds.get("return", []),
+            "metadata": ds.get("metadata", {}),
+        }
+    }
+
+
+def list_roles(
+    collection_filter: str | None = None, *, collections_path: str | None = None,
+) -> dict[str, dict[str, Any]]:
     """List available roles with descriptions and entry points.
 
     Args:
         collection_filter: Optional collection filter passed to ansible-doc
                            (e.g., "fedora.linux_system_roles"). If None, lists all roles.
+        collections_path: Optional path to prepend to ANSIBLE_COLLECTIONS_PATH.
 
     Returns:
         Dict mapping FQCNs to {collection, description, entry_points}.
@@ -251,7 +305,7 @@ def list_roles(collection_filter: str | None = None) -> dict[str, dict[str, Any]
     args = ["--list", "-t", "role", "--json"]
     if collection_filter:
         args.append(collection_filter)
-    raw = _run_ansible_doc(*args)
+    raw = _run_ansible_doc(*args, collections_path=collections_path)
     try:
         roles = json.loads(raw)
     except json.JSONDecodeError as exc:
@@ -259,13 +313,15 @@ def list_roles(collection_filter: str | None = None) -> dict[str, dict[str, Any]
     return roles
 
 
-def get_role_doc(role_name: str) -> dict[str, Any]:
+def get_role_doc(
+    role_name: str, *, collections_path: str | None = None,
+) -> dict[str, Any]:
     """Fetch full documentation for a single role.
 
     Returns parsed JSON from ansible-doc. Returns {} if the role
     lacks argument_specs.yml (same as ansible-doc behavior).
     """
-    raw = _run_ansible_doc("-t", "role", role_name, "--json")
+    raw = _run_ansible_doc("-t", "role", role_name, "--json", collections_path=collections_path)
     try:
         doc = json.loads(raw)
     except json.JSONDecodeError as exc:

--- a/src/ansible_know/resolution.py
+++ b/src/ansible_know/resolution.py
@@ -104,11 +104,12 @@ async def resolve_module_doc(
     Returns (raw_doc, galaxy_meta_or_none). Raises on non-missing-collection
     errors and when both local and Galaxy lookups fail.
     """
-    from ansible_know import parser
+    from ansible_know import collections, parser
     from ansible_know.errors import CollectionNotFoundError, GalaxyError
 
     servers = _get_servers(galaxy_servers)
     namespace = ".".join(module_name.split(".")[:2]) if "." in module_name else None
+    cpath = collections.get_collections_path()
 
     async def _fetch_from_galaxy(client):
         return await client.fetch_module_doc(module_name)
@@ -129,7 +130,9 @@ async def resolve_module_doc(
             ) from galaxy_exc
 
     try:
-        raw_doc = await run_in_executor(parser.get_module_doc, module_name)
+        raw_doc = await run_in_executor(
+            parser.get_module_doc, module_name, collections_path=cpath,
+        )
         return raw_doc, None
     except CollectionNotFoundError as local_exc:
         if namespace:
@@ -157,17 +160,20 @@ async def resolve_role_doc(
 
     Returns the complete tool response dict including doc_source and content_type.
     """
-    from ansible_know import parser
+    from ansible_know import collections, parser
     from ansible_know.errors import CollectionNotFoundError, GalaxyError
 
     servers = _get_servers(galaxy_servers)
     namespace = ".".join(role_name.split(".")[:2]) if "." in role_name else None
+    cpath = collections.get_collections_path()
 
     local_doc: dict[str, Any] = {}
 
     if not (namespace and namespace in _missing_collections):
         try:
-            local_doc = await run_in_executor(parser.get_role_doc, role_name)
+            local_doc = await run_in_executor(
+                parser.get_role_doc, role_name, collections_path=cpath,
+            )
         except CollectionNotFoundError:
             if namespace:
                 _missing_collections.add(namespace)

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -172,11 +172,12 @@ async def search_modules(
         return {"error": str(exc)}
 
     try:
-        from ansible_know import parser
+        from ansible_know import collections, parser
         from ansible_know.config import SEARCH_MODULES_LIMIT
 
         results = await run_in_executor(
             parser.search_modules, keyword, collection_filter=namespace,
+            collections_path=collections.get_collections_path(),
         )
         if len(results) > SEARCH_MODULES_LIMIT:
             results = dict(list(results.items())[:SEARCH_MODULES_LIMIT])
@@ -363,14 +364,18 @@ async def get_collection_manifest(
         if cached:
             return cached
 
+        cpath = collections.get_collections_path()
+
         modules = await run_in_executor(
             parser.search_modules, "", collection_filter=collection_namespace,
+            collections_path=cpath,
         )
 
         roles_raw = {}
         try:
             roles_raw = await run_in_executor(
                 parser.list_roles, collection_filter=collection_namespace,
+                collections_path=cpath,
             )
         except Exception as exc:
             logger.warning("list_roles failed for %s: %s", collection_namespace, exc)
@@ -384,7 +389,9 @@ async def get_collection_manifest(
         metadata_list = []
         for module_name in sorted(modules):
             try:
-                raw_doc = await run_in_executor(parser.get_module_doc, module_name)
+                raw_doc = await run_in_executor(
+                    parser.get_module_doc, module_name, collections_path=cpath,
+                )
                 metadata_list.append(parser.extract_module_metadata(raw_doc))
             except AnsibleDocError:
                 continue
@@ -667,11 +674,13 @@ async def generate_collection_skills(
         return {"error": str(exc)}
 
     try:
-        from ansible_know import collection_manifest, parser, skills
+        from ansible_know import collection_manifest, collections, parser, skills
         from ansible_know.config import SKILLS_DIR
 
+        cpath = collections.get_collections_path()
         modules = await run_in_executor(
             parser.search_modules, "", collection_filter=collection_namespace,
+            collections_path=cpath,
         )
         if not modules:
             return {"error": (
@@ -690,7 +699,9 @@ async def generate_collection_skills(
             if ctx:
                 await ctx.report_progress(progress=i, total=total)
             try:
-                raw_doc = await run_in_executor(parser.get_module_doc, module_name)
+                raw_doc = await run_in_executor(
+                    parser.get_module_doc, module_name, collections_path=cpath,
+                )
                 metadata = parser.extract_module_metadata(raw_doc)
                 metadata_list.append(metadata)
 

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -868,65 +868,6 @@ class TestModuleWithoutDocStrings:
         assert modules["test.col.has_docs"] == "Has docs"
 
 
-class TestTransformEdgeCases:
-    def test_missing_doc_strings(self):
-        entry = {"content_type": "module", "content_name": "test"}
-        result = GalaxyClient._transform_to_ansible_doc_format("ns.col.test", entry)
-        doc = result["ns.col.test"]["doc"]
-        assert doc["short_description"] == ""
-        assert doc["options"] == {}
-
-    def test_missing_short_description(self):
-        entry = {
-            "doc_strings": {
-                "doc": {"description": ["Some desc"], "options": []},
-                "examples": "",
-                "return": [],
-                "metadata": {},
-            }
-        }
-        result = GalaxyClient._transform_to_ansible_doc_format("ns.col.mod", entry)
-        assert result["ns.col.mod"]["doc"]["short_description"] == ""
-
-    def test_options_list_with_non_dict_items(self):
-        entry = {
-            "doc_strings": {
-                "doc": {
-                    "short_description": "Test",
-                    "options": [
-                        {"name": "valid", "type": "str"},
-                        "not_a_dict",
-                        42,
-                    ],
-                },
-                "examples": "",
-                "return": [],
-                "metadata": {},
-            }
-        }
-        result = GalaxyClient._transform_to_ansible_doc_format("ns.col.mod", entry)
-        opts = result["ns.col.mod"]["doc"]["options"]
-        assert "valid" in opts
-        assert len(opts) == 1
-
-    def test_option_without_name_key(self):
-        entry = {
-            "doc_strings": {
-                "doc": {
-                    "short_description": "Test",
-                    "options": [
-                        {"type": "str", "required": True},
-                    ],
-                },
-                "examples": "",
-                "return": [],
-                "metadata": {},
-            }
-        }
-        result = GalaxyClient._transform_to_ansible_doc_format("ns.col.mod", entry)
-        assert result["ns.col.mod"]["doc"]["options"] == {}
-
-
 class TestUnicodeQueries:
     @pytest.mark.asyncio
     async def test_unicode_search_collections(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -17,6 +17,7 @@ from ansible_know.parser import (
     list_modules,
     list_roles,
     search_modules,
+    transform_galaxy_to_ansible_doc_format,
 )
 
 
@@ -37,12 +38,12 @@ class TestListModules:
         with patch("ansible_know.parser._run_ansible_doc", return_value=sample_module_list_json) as mock:
             result = list_modules()
         assert len(result) == 4
-        mock.assert_called_once_with("--list", "--json")
+        mock.assert_called_once_with("--list", "--json", collections_path=None)
 
     def test_passes_collection_filter(self, sample_module_list_json):
         with patch("ansible_know.parser._run_ansible_doc", return_value=sample_module_list_json) as mock:
             list_modules(collection_filter="community.general")
-        mock.assert_called_once_with("--list", "--json", "community.general")
+        mock.assert_called_once_with("--list", "--json", "community.general", collections_path=None)
 
 
 class TestSearchModules:
@@ -129,110 +130,100 @@ class TestExtractModuleMetadata:
 class TestRunAnsibleDocEnvInjection:
     def test_injects_collections_path(self):
         with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
-            with patch("ansible_know.collections.get_collections_path", return_value="/tmp/ansible_know_abc123"):
-                with patch("subprocess.run", return_value=MagicMock(
-                    returncode=0, stdout='{}', stderr='',
-                )) as mock_run:
-                    from ansible_know.parser import _run_ansible_doc
-                    _run_ansible_doc("--list", "--json")
-                    env = mock_run.call_args[1]["env"]
-                    assert "/tmp/ansible_know_abc123" in env["ANSIBLE_COLLECTIONS_PATH"]
+            with patch("subprocess.run", return_value=MagicMock(
+                returncode=0, stdout='{}', stderr='',
+            )) as mock_run:
+                from ansible_know.parser import _run_ansible_doc
+                _run_ansible_doc("--list", "--json", collections_path="/tmp/ansible_know_abc123")
+                env = mock_run.call_args[1]["env"]
+                assert "/tmp/ansible_know_abc123" in env["ANSIBLE_COLLECTIONS_PATH"]
 
     def test_prepends_to_existing_collections_path(self):
         with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
-            with patch("ansible_know.collections.get_collections_path", return_value="/tmp/ansible_know_abc123"):
-                with patch.dict("os.environ", {"ANSIBLE_COLLECTIONS_PATH": "/existing/path"}):
-                    with patch("subprocess.run", return_value=MagicMock(
-                        returncode=0, stdout='{}', stderr='',
-                    )) as mock_run:
-                        from ansible_know.parser import _run_ansible_doc
-                        _run_ansible_doc("--list", "--json")
-                        env = mock_run.call_args[1]["env"]
-                        assert env["ANSIBLE_COLLECTIONS_PATH"].startswith("/tmp/ansible_know_abc123")
-                        assert "/existing/path" in env["ANSIBLE_COLLECTIONS_PATH"]
-
-    def test_no_injection_when_no_collections(self):
-        with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
-            with patch("ansible_know.collections.get_collections_path", return_value=None):
+            with patch.dict("os.environ", {"ANSIBLE_COLLECTIONS_PATH": "/existing/path"}):
                 with patch("subprocess.run", return_value=MagicMock(
                     returncode=0, stdout='{}', stderr='',
                 )) as mock_run:
                     from ansible_know.parser import _run_ansible_doc
-                    _run_ansible_doc("--list", "--json")
-                    call_kwargs = mock_run.call_args[1]
-                    assert call_kwargs.get("env") is None
+                    _run_ansible_doc("--list", "--json", collections_path="/tmp/ansible_know_abc123")
+                    env = mock_run.call_args[1]["env"]
+                    assert env["ANSIBLE_COLLECTIONS_PATH"].startswith("/tmp/ansible_know_abc123")
+                    assert "/existing/path" in env["ANSIBLE_COLLECTIONS_PATH"]
+
+    def test_no_injection_when_no_collections(self):
+        with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
+            with patch("subprocess.run", return_value=MagicMock(
+                returncode=0, stdout='{}', stderr='',
+            )) as mock_run:
+                from ansible_know.parser import _run_ansible_doc
+                _run_ansible_doc("--list", "--json")
+                call_kwargs = mock_run.call_args[1]
+                assert call_kwargs.get("env") is None
 
 
 class TestCollectionNotFoundDetection:
     def test_raises_collection_not_found_on_has_no_attribute(self):
         with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
-            with patch("ansible_know.collections.get_collections_path", return_value=None):
-                with patch("subprocess.run", return_value=MagicMock(
-                    returncode=1, stdout='', stderr='netbox.netbox has no attribute',
-                )):
-                    from ansible_know.parser import _run_ansible_doc
-                    with pytest.raises(CollectionNotFoundError, match="has no attribute"):
-                        _run_ansible_doc("netbox.netbox.netbox_device", "--json")
+            with patch("subprocess.run", return_value=MagicMock(
+                returncode=1, stdout='', stderr='netbox.netbox has no attribute',
+            )):
+                from ansible_know.parser import _run_ansible_doc
+                with pytest.raises(CollectionNotFoundError, match="has no attribute"):
+                    _run_ansible_doc("netbox.netbox.netbox_device", "--json")
 
     def test_raises_collection_not_found_on_was_not_found(self):
         with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
-            with patch("ansible_know.collections.get_collections_path", return_value=None):
-                with patch("subprocess.run", return_value=MagicMock(
-                    returncode=1, stdout='', stderr='netbox.netbox was not found',
-                )):
-                    from ansible_know.parser import _run_ansible_doc
-                    with pytest.raises(CollectionNotFoundError, match="was not found"):
-                        _run_ansible_doc("netbox.netbox.netbox_device", "--json")
+            with patch("subprocess.run", return_value=MagicMock(
+                returncode=1, stdout='', stderr='netbox.netbox was not found',
+            )):
+                from ansible_know.parser import _run_ansible_doc
+                with pytest.raises(CollectionNotFoundError, match="was not found"):
+                    _run_ansible_doc("netbox.netbox.netbox_device", "--json")
 
     def test_raises_collection_not_found_on_could_not_be_found(self):
         with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
-            with patch("ansible_know.collections.get_collections_path", return_value=None):
-                with patch("subprocess.run", return_value=MagicMock(
-                    returncode=1, stdout='', stderr='module could not be found',
-                )):
-                    from ansible_know.parser import _run_ansible_doc
-                    with pytest.raises(CollectionNotFoundError, match="could not be found"):
-                        _run_ansible_doc("netbox.netbox.netbox_device", "--json")
+            with patch("subprocess.run", return_value=MagicMock(
+                returncode=1, stdout='', stderr='module could not be found',
+            )):
+                from ansible_know.parser import _run_ansible_doc
+                with pytest.raises(CollectionNotFoundError, match="could not be found"):
+                    _run_ansible_doc("netbox.netbox.netbox_device", "--json")
 
     def test_raises_ansible_doc_error_on_other_errors(self):
         with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
-            with patch("ansible_know.collections.get_collections_path", return_value=None):
-                with patch("subprocess.run", return_value=MagicMock(
-                    returncode=1, stdout='', stderr='ansible-doc timed out',
-                )):
-                    from ansible_know.parser import _run_ansible_doc
-                    with pytest.raises(AnsibleDocError, match="timed out"):
-                        _run_ansible_doc("ansible.builtin.copy", "--json")
+            with patch("subprocess.run", return_value=MagicMock(
+                returncode=1, stdout='', stderr='ansible-doc timed out',
+            )):
+                from ansible_know.parser import _run_ansible_doc
+                with pytest.raises(AnsibleDocError, match="timed out"):
+                    _run_ansible_doc("ansible.builtin.copy", "--json")
 
     def test_raises_collection_not_found_on_exit_0_with_empty_json(self):
         with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
-            with patch("ansible_know.collections.get_collections_path", return_value=None):
-                with patch("subprocess.run", return_value=MagicMock(
-                    returncode=0, stdout='{}', stderr='[WARNING]: kubernetes.core.k8s was not found',
-                )):
-                    from ansible_know.parser import _run_ansible_doc
-                    with pytest.raises(CollectionNotFoundError, match="was not found"):
-                        _run_ansible_doc("kubernetes.core.k8s", "--json")
+            with patch("subprocess.run", return_value=MagicMock(
+                returncode=0, stdout='{}', stderr='[WARNING]: kubernetes.core.k8s was not found',
+            )):
+                from ansible_know.parser import _run_ansible_doc
+                with pytest.raises(CollectionNotFoundError, match="was not found"):
+                    _run_ansible_doc("kubernetes.core.k8s", "--json")
 
     def test_raises_collection_not_found_on_exit_0_with_empty_stdout(self):
         with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
-            with patch("ansible_know.collections.get_collections_path", return_value=None):
-                with patch("subprocess.run", return_value=MagicMock(
-                    returncode=0, stdout='', stderr='[WARNING]: some.col.mod was not found',
-                )):
-                    from ansible_know.parser import _run_ansible_doc
-                    with pytest.raises(CollectionNotFoundError, match="was not found"):
-                        _run_ansible_doc("some.col.mod", "--json")
+            with patch("subprocess.run", return_value=MagicMock(
+                returncode=0, stdout='', stderr='[WARNING]: some.col.mod was not found',
+            )):
+                from ansible_know.parser import _run_ansible_doc
+                with pytest.raises(CollectionNotFoundError, match="was not found"):
+                    _run_ansible_doc("some.col.mod", "--json")
 
     def test_returns_normally_on_exit_0_with_valid_json(self):
         with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
-            with patch("ansible_know.collections.get_collections_path", return_value=None):
-                with patch("subprocess.run", return_value=MagicMock(
-                    returncode=0, stdout='{"ansible.builtin.copy": {}}', stderr='',
-                )):
-                    from ansible_know.parser import _run_ansible_doc
-                    result = _run_ansible_doc("ansible.builtin.copy", "--json")
-                    assert "ansible.builtin.copy" in result
+            with patch("subprocess.run", return_value=MagicMock(
+                returncode=0, stdout='{"ansible.builtin.copy": {}}', stderr='',
+            )):
+                from ansible_know.parser import _run_ansible_doc
+                result = _run_ansible_doc("ansible.builtin.copy", "--json")
+                assert "ansible.builtin.copy" in result
 
     def test_collection_not_found_is_subclass_of_ansible_doc_error(self):
         assert issubclass(CollectionNotFoundError, AnsibleDocError)
@@ -244,12 +235,15 @@ class TestListRoles:
             result = list_roles()
         assert "fedora.linux_system_roles.timesync" in result
         assert "fedora.linux_system_roles.gfs2" in result
-        mock.assert_called_once_with("--list", "-t", "role", "--json")
+        mock.assert_called_once_with("--list", "-t", "role", "--json", collections_path=None)
 
     def test_passes_collection_filter(self, sample_role_list_json):
         with patch("ansible_know.parser._run_ansible_doc", return_value=sample_role_list_json) as mock:
             list_roles(collection_filter="fedora.linux_system_roles")
-        mock.assert_called_once_with("--list", "-t", "role", "--json", "fedora.linux_system_roles")
+        mock.assert_called_once_with(
+            "--list", "-t", "role", "--json", "fedora.linux_system_roles",
+            collections_path=None,
+        )
 
 
 class TestGetRoleDoc:
@@ -266,7 +260,7 @@ class TestGetRoleDoc:
     def test_passes_role_type_flag(self, sample_role_doc_json):
         with patch("ansible_know.parser._run_ansible_doc", return_value=sample_role_doc_json) as mock:
             get_role_doc("fedora.linux_system_roles.gfs2")
-        mock.assert_called_once_with("-t", "role", "fedora.linux_system_roles.gfs2", "--json")
+        mock.assert_called_once_with("-t", "role", "fedora.linux_system_roles.gfs2", "--json", collections_path=None)
 
 
 class TestExtractRoleMetadata:
@@ -324,3 +318,62 @@ class TestExtractRoleMetadata:
         assert "main" in meta["entry_points"]
         assert "configure" in meta["entry_points"]
         assert len(meta["entry_points"]["configure"]["options"]) == 1
+
+
+class TestTransformGalaxyToAnsibleDocFormat:
+    def test_missing_doc_strings(self):
+        entry = {"content_type": "module", "content_name": "test"}
+        result = transform_galaxy_to_ansible_doc_format("ns.col.test", entry)
+        doc = result["ns.col.test"]["doc"]
+        assert doc["short_description"] == ""
+        assert doc["options"] == {}
+
+    def test_missing_short_description(self):
+        entry = {
+            "doc_strings": {
+                "doc": {"description": ["Some desc"], "options": []},
+                "examples": "",
+                "return": [],
+                "metadata": {},
+            }
+        }
+        result = transform_galaxy_to_ansible_doc_format("ns.col.mod", entry)
+        assert result["ns.col.mod"]["doc"]["short_description"] == ""
+
+    def test_options_list_with_non_dict_items(self):
+        entry = {
+            "doc_strings": {
+                "doc": {
+                    "short_description": "Test",
+                    "options": [
+                        {"name": "valid", "type": "str"},
+                        "not_a_dict",
+                        42,
+                    ],
+                },
+                "examples": "",
+                "return": [],
+                "metadata": {},
+            }
+        }
+        result = transform_galaxy_to_ansible_doc_format("ns.col.mod", entry)
+        opts = result["ns.col.mod"]["doc"]["options"]
+        assert "valid" in opts
+        assert len(opts) == 1
+
+    def test_option_without_name_key(self):
+        entry = {
+            "doc_strings": {
+                "doc": {
+                    "short_description": "Test",
+                    "options": [
+                        {"type": "str", "required": True},
+                    ],
+                },
+                "examples": "",
+                "return": [],
+                "metadata": {},
+            }
+        }
+        result = transform_galaxy_to_ansible_doc_format("ns.col.mod", entry)
+        assert result["ns.col.mod"]["doc"]["options"] == {}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1174,7 +1174,7 @@ class TestGetCollectionManifestWithRoles:
     async def test_manifest_includes_roles(self, mock_ansible_doc):
         call_count = 0
 
-        def side_effect(*args):
+        def side_effect(*args, **kwargs):
             nonlocal call_count
             call_count += 1
             if "-t" in args and "role" in args and "--list" in args:


### PR DESCRIPTION
## Summary

- **V-E3**: Move `_transform_to_ansible_doc_format()` from `galaxy.py` to `parser.py` as public `transform_galaxy_to_ansible_doc_format()` — this is a data transformation (Galaxy → ansible-doc format) that belongs in the Domain layer, not External Access. `galaxy.py` lazy-imports it, matching the existing `readme_parser` pattern.
- **V-L4**: Decouple `parser.py` from `collections.py` by adding `collections_path: str | None = None` parameter to all public parser functions. Callers (server.py, resolution.py) inject the path from `collections.get_collections_path()`.
- **V-E2**: Mark as fully resolved — `GalaxyDocClient` Protocol already exists in `types.py` from PR #73.
- Update `service-contracts.md` to reflect all three fixes.

## Architecture violations fixed

| ID | Severity | Description |
|----|----------|-------------|
| V-E2 | Warning | `GalaxyDocClient` Protocol exists in `types.py` (already resolved in PR #73) |
| V-E3 | Warning | Transform function moved to Domain layer (`parser.py`) |
| V-L4 | Warning | `parser.py` no longer imports `collections.py`; path injected by callers |

## Test plan

- [x] `pytest tests/ -v` — 438 passed, 57 skipped
- [x] `ruff check src/ tests/` — no lint errors
- [x] `grep -n 'from ansible_know import collections' src/ansible_know/parser.py` — no matches
- [x] `grep -n 'def _transform_to_ansible_doc_format' src/ansible_know/galaxy.py` — no matches

Closes #69

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>