### PR TITLE
fix: improve Connect section layout and skip CI for site changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore: ['site/**']
   pull_request:
     branches: [main]
+    paths-ignore: ['site/**']
 
 jobs:
   test:

--- a/site/index.html
+++ b/site/index.html
@@ -331,8 +331,11 @@
   /* ---- CONNECT CARDS ---- */
   .connect-grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1.5rem;
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+    max-width: 540px;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   .connect-card {
@@ -350,21 +353,22 @@
     font-size: 1.3rem;
     color: var(--green);
     margin-bottom: 1rem;
+    text-align: center;
   }
 
   .connect-card pre {
     background: #050505;
     border: 1px solid var(--border);
-    padding: 0.85rem 1rem;
-    font-size: 0.78rem;
-    line-height: 1.6;
+    padding: 1rem 1.25rem;
+    font-size: 0.9rem;
+    line-height: 1.7;
     overflow-x: auto;
     color: var(--green-dim);
     cursor: pointer;
     transition: border-color 0.2s;
     position: relative;
     white-space: pre-wrap;
-    word-break: break-all;
+    word-break: break-word;
   }
   .connect-card pre:hover {
     border-color: var(--green);
@@ -386,6 +390,7 @@
     color: var(--muted);
     margin-top: 0.75rem;
     font-style: italic;
+    text-align: center;
   }
 
   /* ---- ECOSYSTEM ---- */
@@ -605,13 +610,20 @@
 
     <div class="connect-grid">
       <div class="connect-card">
-        <div class="connect-card-title">Claude Code</div>
-        <pre><code>claude mcp add ansible-know -- uvx ansible-know-mcp</code></pre>
+        <div class="connect-card-title">VS Code / Cursor</div>
+        <pre><code>{
+  "mcpServers": {
+    "ansible-know": {
+      "command": "uvx",
+      "args": ["ansible-know-mcp"]
+    }
+  }
+}</code></pre>
       </div>
 
       <div class="connect-card">
-        <div class="connect-card-title">VS Code / Cursor</div>
-        <pre><code>{"mcpServers":{"ansible-know":{"command":"uvx","args":["ansible-know-mcp"]}}}</code></pre>
+        <div class="connect-card-title">Claude Code</div>
+        <pre><code>claude mcp add ansible-know -- uvx ansible-know-mcp</code></pre>
       </div>
 
       <div class="connect-card">


### PR DESCRIPTION
## Summary
- Switch Connect section from 2x2 grid to single-column centered layout (540px max-width)
- VS Code JSON properly indented with readable formatting
- Larger font size (0.9rem) with centered titles and notes
- VS Code card listed first, followed by Claude Code, Remote, and Inspector
- Add `paths-ignore: ['site/**']` to CI workflow so site-only changes skip the full test suite

## Test plan
- [ ] Verify layout at desktop width
- [ ] Verify responsive collapse on mobile
- [ ] Click code blocks to test copy-to-clipboard
- [ ] Verify CI does not trigger on site-only PRs

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>