### PR TITLE
refactor: encapsulate server state for session isolation (#68)

### DIFF
--- a/docs/superpowers/plans/2026-06-20-session-isolation.md
+++ b/docs/superpowers/plans/2026-06-20-session-isolation.md
@@ -1,0 +1,622 @@
+# Session Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Encapsulate all module-level mutable server state into a `ServerState` dataclass and `CollectionManager` class so state is testable, resettable, and ready for future per-session isolation.
+
+**Architecture:** New `state.py` (Foundation) holds `ServerState` and `LifespanContext`. `CollectionManager` class replaces module-level globals in `collections.py` (External Access). `resolution.py` receives `missing_collections` as a parameter. `server.py` creates `ServerState` in lifespan, passes it through typed context.
+
+**Tech Stack:** Python 3.11+, dataclasses, TypedDict, pytest, FastMCP
+
+## Global Constraints
+
+- Layer dependency: Foundation has zero runtime imports from upper layers
+- `CollectionManager` imports under `TYPE_CHECKING` only in `state.py`
+- All new modules must define `__all__`
+- Thread safety patterns preserved identically
+- Existing test behavior must not change (438 passing, 57 skipped)
+- Run tests with `.venv/bin/pytest tests/ -v --tb=short`
+- Run lint with `.venv/bin/ruff check src/ tests/`
+
+---
+
+### Task 1: Create `CollectionManager` class in `collections.py`
+
+**Files:**
+- Modify: `src/ansible_know/collections.py`
+- Modify: `tests/test_collections.py`
+
+**Interfaces:**
+- Produces: `CollectionManager` class with methods `ensure_collection(collection_fqcn: str, version: str | None = None) -> EnsureCollectionResult`, `get_collections_path() -> str | None`, `list_installed() -> dict[str, str]`
+
+- [ ] **Step 1: Write tests that use `CollectionManager` directly**
+
+Replace the `reset_collections_state` fixture and update all test imports in `tests/test_collections.py`. Every test that called `ensure_collection()` as a module function now calls `mgr.ensure_collection()` on a fresh `CollectionManager` instance.
+
+New fixture:
+
+```python
+@pytest.fixture
+def mgr():
+    """Create a fresh CollectionManager for each test."""
+    from ansible_know.collections import CollectionManager
+    manager = CollectionManager()
+    yield manager
+    if manager._tmp_dir is not None:
+        try:
+            manager._tmp_dir.cleanup()
+        except Exception:
+            pass
+```
+
+Remove the `autouse=True` `reset_collections_state` fixture entirely.
+
+Update imports at the top of the file — remove `ensure_collection`, `get_collections_path`, `list_installed` imports. Add `from ansible_know.collections import CollectionManager`.
+
+Update every test class method signature to accept `mgr` and call methods on it:
+
+- `TestGetCollectionsPath`: call `mgr.get_collections_path()` and `mgr.ensure_collection()`
+- `TestListInstalled`: call `mgr.list_installed()` and `mgr.ensure_collection()`
+- `TestEnsureCollectionInstalls`: call `mgr.ensure_collection()` and `mgr.list_installed()`
+- `TestEnsureCollectionErrors`: call `mgr.ensure_collection()`
+- `TestVersionParsing`: call `mgr.ensure_collection()`. The `test_fallback_to_manifest` test that previously set `col._tmp_dir` directly now sets `mgr._tmp_dir` instead.
+- `TestConcurrentInstall`: all threads must share the same `mgr` instance (pass via `target=mgr.ensure_collection`)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_collections.py -v --tb=short`
+Expected: FAIL — `CollectionManager` class does not exist yet
+
+- [ ] **Step 3: Implement `CollectionManager` class**
+
+In `src/ansible_know/collections.py`:
+
+1. Keep module-level constants: `_VERSION_PARSE_RE`, `logger`
+2. Keep module-level stateless helpers: `_find_ansible_galaxy()`, `_parse_version()`
+3. Create `CollectionManager` class:
+   - Move `MAX_TRACKED_COLLECTIONS = 100` to class attribute
+   - `__init__` creates instance variables: `self._tmp_dir`, `self._installed`, `self._install_locks`, `self._locks_lock`, `self._install_gate`
+   - `_get_or_create_tmpdir(self)` — same logic, uses `self._locks_lock` and `self._tmp_dir`
+   - `ensure_collection(self, ...)` — same logic, uses `self._locks_lock`, `self._install_locks`, `self._installed`, `self._install_gate`, `self._get_or_create_tmpdir()`
+   - `get_collections_path(self)` — same logic, uses `self._locks_lock` and `self._tmp_dir`
+   - `list_installed(self)` — same logic, uses `self._locks_lock` and `self._installed`
+4. Delete old module-level globals: `_tmp_dir`, `_installed`, `_install_locks`, `_locks_lock`, `_install_gate`
+5. Delete old module-level functions: `_get_or_create_tmpdir()`, `ensure_collection()`, `get_collections_path()`, `list_installed()`
+6. Add `__all__ = ["CollectionManager"]`
+
+The method bodies are identical to the current functions — just replace module globals with `self._` attributes. `_find_ansible_galaxy()` and `_parse_version()` stay as module-level functions called from within the methods.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_collections.py -v --tb=short`
+Expected: All tests PASS
+
+- [ ] **Step 5: Run full suite to check for breakage**
+
+Run: `.venv/bin/pytest tests/ -v --tb=short`
+Expected: Failures in `test_server.py` and `test_resolution.py` (they still use old module-level functions). `test_collections.py` passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ansible_know/collections.py tests/test_collections.py
+git commit -m "refactor: extract CollectionManager class from collections globals
+
+Addresses V-E4: module-level mutable state in collections.py is now
+encapsulated in a CollectionManager class with identical thread-safety.
+
+Part of #68.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Create `state.py` with `ServerState` and `LifespanContext`
+
+**Files:**
+- Create: `src/ansible_know/state.py`
+- Create: `tests/test_state.py`
+
+**Interfaces:**
+- Consumes: `CollectionManager` from Task 1 (type-check only)
+- Produces: `ServerState` dataclass with fields `collection_manager: CollectionManager`, `missing_collections: set[str]`, `version_info: dict[str, Any] | None`, `galaxy_servers: list[GalaxyServerConfig]`, `upgrade_warned: bool`, method `clear_missing_namespace(namespace: str) -> None`. `LifespanContext` TypedDict with keys `http_client: httpx.AsyncClient`, `state: ServerState`.
+
+- [ ] **Step 1: Write tests for `ServerState` and `LifespanContext`**
+
+Create `tests/test_state.py`:
+
+```python
+"""Tests for ansible_know.state."""
+
+from ansible_know.collections import CollectionManager
+from ansible_know.state import LifespanContext, ServerState
+
+
+class TestServerState:
+    def test_create_with_required_fields(self):
+        mgr = CollectionManager()
+        state = ServerState(collection_manager=mgr)
+        assert state.collection_manager is mgr
+        assert state.missing_collections == set()
+        assert state.version_info is None
+        assert state.galaxy_servers == []
+        assert state.upgrade_warned is False
+
+    def test_clear_missing_namespace(self):
+        mgr = CollectionManager()
+        state = ServerState(collection_manager=mgr)
+        state.missing_collections.add("netbox.netbox")
+        state.clear_missing_namespace("netbox.netbox")
+        assert "netbox.netbox" not in state.missing_collections
+
+    def test_clear_missing_namespace_absent_is_noop(self):
+        mgr = CollectionManager()
+        state = ServerState(collection_manager=mgr)
+        state.clear_missing_namespace("nonexistent.ns")
+        assert state.missing_collections == set()
+
+    def test_independent_instances(self):
+        mgr1 = CollectionManager()
+        mgr2 = CollectionManager()
+        state1 = ServerState(collection_manager=mgr1)
+        state2 = ServerState(collection_manager=mgr2)
+        state1.missing_collections.add("netbox.netbox")
+        assert "netbox.netbox" not in state2.missing_collections
+
+
+class TestLifespanContext:
+    def test_is_typed_dict(self):
+        assert "http_client" in LifespanContext.__annotations__
+        assert "state" in LifespanContext.__annotations__
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_state.py -v --tb=short`
+Expected: FAIL — `ansible_know.state` module does not exist
+
+- [ ] **Step 3: Implement `state.py`**
+
+Create `src/ansible_know/state.py`:
+
+```python
+"""Server state and lifespan context types.
+
+Foundation-layer module: no runtime imports from Domain, External Access,
+or Orchestration. CollectionManager is imported under TYPE_CHECKING only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, TypedDict
+
+if TYPE_CHECKING:
+    import httpx
+
+    from ansible_know.collections import CollectionManager
+    from ansible_know.galaxy_config import GalaxyServerConfig
+
+__all__ = ["LifespanContext", "ServerState"]
+
+
+@dataclass
+class ServerState:
+    """All mutable runtime state for one server process.
+
+    Created once in lifespan, stored in LifespanContext,
+    accessed by tool handlers via _get_state(ctx).
+    """
+
+    collection_manager: CollectionManager
+    missing_collections: set[str] = field(default_factory=set)
+    version_info: dict[str, Any] | None = None
+    galaxy_servers: list[GalaxyServerConfig] = field(default_factory=list)
+    upgrade_warned: bool = False
+
+    def clear_missing_namespace(self, namespace: str) -> None:
+        """Remove a namespace from the negative cache."""
+        self.missing_collections.discard(namespace)
+
+
+class LifespanContext(TypedDict):
+    """Typed lifespan context replacing the untyped dict."""
+
+    http_client: httpx.AsyncClient
+    state: ServerState
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_state.py -v --tb=short`
+Expected: All tests PASS
+
+- [ ] **Step 5: Lint check**
+
+Run: `.venv/bin/ruff check src/ansible_know/state.py tests/test_state.py`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ansible_know/state.py tests/test_state.py
+git commit -m "feat: add ServerState and LifespanContext types
+
+Addresses V-S3 and V-T1: typed lifespan context and centralized
+state dataclass for all mutable runtime state.
+
+Part of #68.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Update `resolution.py` to accept `missing_collections` as parameter
+
+**Files:**
+- Modify: `src/ansible_know/resolution.py`
+- Modify: `tests/test_resolution.py`
+
+**Interfaces:**
+- Consumes: None (standalone change)
+- Produces: `resolve_module_doc(..., missing_collections: set[str] | None = None)`, `resolve_role_doc(..., missing_collections: set[str] | None = None)`. `clear_missing_namespace()` removed. `__all__` updated.
+
+- [ ] **Step 1: Update tests to pass `missing_collections` explicitly**
+
+In `tests/test_resolution.py`:
+
+Replace the `reset_negative_cache` autouse fixture with a simple fixture that provides a fresh set:
+
+```python
+@pytest.fixture
+def missing():
+    """Provide a fresh missing-collections set for each test."""
+    return set()
+```
+
+Update `TestResolveModuleDoc` — add `missing` param to each test and pass `missing_collections=missing` to `resolve_module_doc()`:
+
+```python
+async def test_local_success_no_galaxy(self, mock_ansible_doc, missing):
+    mock_ansible_doc.return_value = json.dumps(SAMPLE_MODULE_DOC)
+    from ansible_know.resolution import resolve_module_doc
+    raw_doc, galaxy_meta = await resolve_module_doc(
+        "ansible.builtin.package", missing_collections=missing,
+    )
+    assert "ansible.builtin.package" in raw_doc
+    assert galaxy_meta is None
+```
+
+Same pattern for all other tests. For `TestNegativeCache`:
+
+- `test_skips_local_on_cache_hit`: pre-populate `missing.add("netbox.netbox")` then pass `missing_collections=missing`
+- `test_populates_cache_on_collection_not_found`: pass `missing_collections=missing`, then assert `"netbox.netbox" in missing`
+- `test_does_not_cache_non_collection_errors`: pass `missing_collections=missing`, assert `"ansible.builtin" not in missing`
+- `test_clear_missing_namespace`: test `ServerState.clear_missing_namespace()` instead:
+
+```python
+def test_clear_missing_namespace(self):
+    from ansible_know.collections import CollectionManager
+    from ansible_know.state import ServerState
+    state = ServerState(collection_manager=CollectionManager())
+    state.missing_collections.add("netbox.netbox")
+    state.clear_missing_namespace("netbox.netbox")
+    assert "netbox.netbox" not in state.missing_collections
+```
+
+- `test_role_skips_local_on_cache_hit`: pre-populate `missing.add("some.col")` then pass `missing_collections=missing`
+
+Update `TestResolveRoleDoc` — add `missing` param and pass `missing_collections=missing`.
+
+`TestSearchGalaxyCollections` — no changes needed (doesn't use `missing_collections`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_resolution.py -v --tb=short`
+Expected: FAIL — `resolve_module_doc()` and `resolve_role_doc()` don't accept `missing_collections` parameter yet
+
+- [ ] **Step 3: Update `resolution.py`**
+
+1. Delete `_missing_collections: set[str] = set()` (line 43)
+2. Delete the comment block above it (lines 34-42)
+3. Delete `clear_missing_namespace()` function (lines 91-93)
+4. Update `__all__` — remove `"clear_missing_namespace"`
+5. Add `missing_collections: set[str] | None = None` parameter to `resolve_module_doc()` after `client_factory`
+6. Add `missing_collections: set[str] | None = None` parameter to `resolve_role_doc()` after `client_factory`
+7. In `resolve_module_doc()`: replace `_missing_collections` with `missing_collections` (guarded by `if missing_collections is not None`):
+   - Line 117: `if namespace and missing_collections is not None and namespace in missing_collections:`
+   - Line 139: `if namespace and missing_collections is not None: missing_collections.add(namespace)`
+8. In `resolve_role_doc()`: same replacements:
+   - Line 172: `if not (namespace and missing_collections is not None and namespace in missing_collections):`
+   - Line 179: `if namespace and missing_collections is not None: missing_collections.add(namespace)`
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_resolution.py -v --tb=short`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ansible_know/resolution.py tests/test_resolution.py
+git commit -m "refactor: pass missing_collections as parameter to resolution functions
+
+Addresses V-S2: _missing_collections module-level set removed.
+Resolution functions now receive the set as a parameter, making
+the negative cache testable and session-scoped.
+
+Part of #68.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Update `server.py` to use `ServerState` and `LifespanContext`
+
+**Files:**
+- Modify: `src/ansible_know/server.py`
+- Modify: `tests/test_server.py`
+
+**Interfaces:**
+- Consumes: `ServerState`, `LifespanContext` from Task 2; `CollectionManager` from Task 1; updated `resolve_module_doc`/`resolve_role_doc` signatures from Task 3
+
+- [ ] **Step 1: Update `test_server.py` fixtures and tests**
+
+Remove the `reset_negative_cache_global` autouse fixture (lines 17-23). It's no longer needed because `resolution.py` has no module-level `_missing_collections`.
+
+Update `TestMaybeWarnUpgrade` tests (lines 758-831). These currently mock `ctx.lifespan_context` as a dict with keys `"version_info"`, `"upgrade_warned"`. Change them to use `ServerState`:
+
+```python
+class TestMaybeWarnUpgrade:
+    @pytest.mark.asyncio
+    async def test_warns_when_outdated(self):
+        from ansible_know.collections import CollectionManager
+        from ansible_know.server import _maybe_warn_upgrade
+        from ansible_know.state import ServerState
+
+        state = ServerState(
+            collection_manager=CollectionManager(),
+            version_info={
+                "installed": "0.3.2", "latest": "0.4.0",
+                "outdated": True, "upgrade_command": "uvx --upgrade ansible-know-mcp",
+            },
+        )
+        mock_ctx = MagicMock()
+        mock_ctx.lifespan_context = {"state": state, "http_client": None}
+        mock_ctx.warning = AsyncMock()
+
+        await _maybe_warn_upgrade(mock_ctx)
+        mock_ctx.warning.assert_called_once()
+        assert "outdated" in mock_ctx.warning.call_args[0][0]
+        assert state.upgrade_warned is True
+```
+
+Apply same pattern to `test_warns_only_once`, `test_no_warn_when_current`, `test_no_warn_when_check_failed`. For `test_no_warn_when_no_ctx` — no change needed.
+
+Update `TestServerVersionResource` (lines 833-861). Replace `srv._version_info` manipulation with `ServerState`:
+
+```python
+class TestServerVersionResource:
+    def test_returns_installed_version_without_pypi_check(self):
+        from ansible_know.collections import CollectionManager
+        from ansible_know.state import ServerState
+        import ansible_know.server as srv
+        state = ServerState(collection_manager=CollectionManager())
+        old = srv._server_state
+        try:
+            srv._server_state = state
+            result = json.loads(srv.resource_server_version())
+            assert result["installed"] == srv._VERSION
+            assert result["latest"] is None
+            assert result["outdated"] is None
+        finally:
+            srv._server_state = old
+```
+
+Wait — the resource functions access `_version_info` as a module global. After refactoring, they'll need access to `ServerState`. Since resource functions don't receive `ctx`, they'll need a module-level reference. The simplest approach: keep a `_server_state: ServerState | None = None` module global in server.py, set in lifespan. Resources read from it. This is the same pattern as the current `_version_info` global — just consolidated into one object.
+
+Update `TestEnsureCollectionTool` (lines 300-345). Remove the `col._installed = {}; col._tmp_dir = None` lines — the tool now accesses `state.collection_manager`, so mock that path instead. The simplest approach: these tests call `ensure_collection()` as a tool function. The tool calls `_get_state(ctx)` which returns a `ServerState` with a fresh `CollectionManager` when `ctx is None`. So the tests can remain mostly as-is — just remove the monkeypatching of old globals.
+
+Update `TestLifespanHttpClient` (lines 931-1031). The `mock_ctx.lifespan_context` dicts change from `{"http_client": ..., "galaxy_servers": ...}` to `{"http_client": ..., "state": ServerState(collection_manager=CollectionManager(), galaxy_servers=[...])}`.
+
+Update `TestGetRoleDocTool.test_cached_missing_collection_skips_local` (line 1090). Replace `resolution._missing_collections.add("some.col")` with setting up a `ServerState` with pre-populated `missing_collections` and patching `_get_state` to return it.
+
+Update `TestResourceFunctions.test_resource_installed_collections_*` — these currently patch `collections.list_installed`. After refactoring, `resource_installed_collections()` calls `_server_state.collection_manager.list_installed()`, so the patch target changes.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_server.py -v --tb=short`
+Expected: Many failures — server.py not yet updated
+
+- [ ] **Step 3: Update `server.py`**
+
+**Imports:** Add at top:
+```python
+from ansible_know.state import LifespanContext, ServerState
+```
+
+**Module globals:** Replace `_version_info` and `_galaxy_servers` with:
+```python
+_server_state: ServerState | None = None
+```
+
+**Lifespan:** Replace `app_lifespan`:
+```python
+@lifespan
+async def app_lifespan(server):
+    global _server_state
+    from ansible_know.collections import CollectionManager
+    from ansible_know.galaxy_config import load_galaxy_servers
+
+    galaxy_servers = await run_in_executor(load_galaxy_servers)
+    state = ServerState(
+        collection_manager=CollectionManager(),
+        galaxy_servers=galaxy_servers,
+    )
+    _server_state = state
+    for gs in galaxy_servers:
+        auth_type = "token" if gs.token else ("basic" if gs.username else "none")
+        logger.info("Galaxy server: %s (%s, auth=%s)", gs.name, gs.url, auth_type)
+
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(10.0, read=120.0),
+        verify=True,
+    ) as client:
+        state.version_info = await _check_pypi_version(client)
+        yield LifespanContext(http_client=client, state=state)
+```
+
+**Replace `_get_lifespan_resources` and add new helpers:**
+```python
+def _get_state(ctx: Context | None) -> ServerState:
+    if ctx is None:
+        from ansible_know.collections import CollectionManager
+        return ServerState(collection_manager=CollectionManager())
+    return ctx.lifespan_context["state"]
+
+
+def _get_http_client(ctx: Context | None) -> httpx.AsyncClient | None:
+    if ctx is None:
+        return None
+    return ctx.lifespan_context["http_client"]
+```
+
+Delete `_get_lifespan_resources()`.
+
+**Replace `_maybe_warn_upgrade`:**
+```python
+async def _maybe_warn_upgrade(ctx: Context | None) -> None:
+    if ctx is None:
+        return
+    state = _get_state(ctx)
+    if state.upgrade_warned or not state.version_info or not state.version_info.get("outdated"):
+        return
+    info = state.version_info
+    await ctx.warning(
+        f"ansible-know-mcp {info['installed']} is outdated; "
+        f"latest is {info['latest']}. "
+        f"Upgrade: {info['upgrade_command']}"
+    )
+    state.upgrade_warned = True
+```
+
+**Update all tool handlers.** For each tool that uses state:
+
+`search_modules`: replace `collections.get_collections_path()` with `_get_state(None).collection_manager.get_collections_path()` — but this tool has no `ctx` param. Add `ctx: Context | None = None` and use `_get_state(ctx)`:
+```python
+state = _get_state(ctx)
+results = await run_in_executor(
+    parser.search_modules, keyword, collection_filter=namespace,
+    collections_path=state.collection_manager.get_collections_path(),
+)
+```
+
+`get_module_doc`: replace `_get_lifespan_resources(ctx)` with:
+```python
+state = _get_state(ctx)
+http_client = _get_http_client(ctx)
+raw_doc, galaxy_meta = await resolution.resolve_module_doc(
+    module_name, http_client=http_client, galaxy_servers=state.galaxy_servers,
+    client_factory=_galaxy_factory(),
+    missing_collections=state.missing_collections,
+)
+```
+
+Same pattern for `get_role_doc`, `search_collections`, `generate_skill`, `generate_role_skill`.
+
+`get_collection_manifest`: replace `collections.list_installed()` and `collections.get_collections_path()` with `state.collection_manager.list_installed()` and `state.collection_manager.get_collections_path()`.
+
+`ensure_collection`: replace `collections.ensure_collection(...)` with `state.collection_manager.ensure_collection(...)`. Replace `resolution.clear_missing_namespace(ns)` with `state.clear_missing_namespace(ns)`.
+
+`generate_collection_skills`: replace `collections.get_collections_path()` with `state.collection_manager.get_collections_path()`.
+
+`resource_installed_collections`: replace `collections.list_installed()` with `_server_state.collection_manager.list_installed() if _server_state else {}`.
+
+`resource_server_version`: replace `_version_info` with `_server_state.version_info if _server_state else None`.
+
+`resource_galaxy_servers`: if it references `_galaxy_servers`, replace with `_server_state.galaxy_servers if _server_state else []`.
+
+Remove `import ansible_know.collections as collections` from lazy imports where it was used for module-level function calls. The tool handlers now access collections via `state.collection_manager`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_server.py -v --tb=short`
+Expected: All tests PASS
+
+- [ ] **Step 5: Run full suite**
+
+Run: `.venv/bin/pytest tests/ -v --tb=short`
+Expected: All 438 tests PASS, 57 skipped
+
+- [ ] **Step 6: Lint check**
+
+Run: `.venv/bin/ruff check src/ansible_know/server.py`
+Expected: No errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ansible_know/server.py tests/test_server.py
+git commit -m "refactor: use ServerState and LifespanContext in server.py
+
+Replaces untyped lifespan dict with LifespanContext TypedDict.
+All tool handlers access state via _get_state(ctx) helper.
+Module-level globals _version_info and _galaxy_servers replaced
+by single _server_state reference for resource functions.
+
+Closes #68.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Final verification and cleanup
+
+**Files:**
+- Possibly modify: any file with remaining references to old patterns
+
+- [ ] **Step 1: Search for remaining references to old patterns**
+
+```bash
+grep -rn "_missing_collections\|_get_lifespan_resources\|_version_info\|_galaxy_servers" src/ansible_know/ tests/
+```
+
+Expected: No hits except `_server_state` in `server.py` and the `_version_info` type in `state.py`.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `.venv/bin/pytest tests/ -v --tb=short`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run lint**
+
+Run: `.venv/bin/ruff check src/ tests/`
+Expected: No errors
+
+- [ ] **Step 4: Verify architecture compliance**
+
+Check layer dependencies in `state.py`:
+```bash
+grep -n "^from ansible_know\|^import ansible_know" src/ansible_know/state.py
+```
+Expected: No runtime imports from upper layers. Only `TYPE_CHECKING` imports.
+
+Check `collections.py` has no module-level mutable state:
+```bash
+grep -n "^_tmp_dir\|^_installed\|^_install_locks\|^_locks_lock\|^_install_gate" src/ansible_know/collections.py
+```
+Expected: No hits.
+
+- [ ] **Step 5: Commit any cleanup**
+
+If any stray references were found and fixed, commit them:
+```bash
+git add -A
+git commit -m "refactor: clean up remaining references to old state patterns
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
+```

--- a/docs/superpowers/plans/2026-06-20-session-isolation.md
+++ b/docs/superpowers/plans/2026-06-20-session-isolation.md
@@ -8,6 +8,17 @@
 
 **Tech Stack:** Python 3.11+, dataclasses, TypedDict, pytest, FastMCP
 
+## Skills
+
+**Load at session start (before any task):**
+- `superpowers:test-driven-development` — all tasks follow TDD (write failing test → implement → verify)
+- `superpowers:verification-before-completion` — run full suite before claiming any task is done
+
+**Load per task:**
+- Tasks 1–4: no additional skills needed (TDD skill covers the workflow)
+- Task 5 (final verification): `superpowers:verification-before-completion`
+- Task 6 (PR): `superpowers:requesting-code-review` and local skill `skills/pr-architecture-review` (read `skills/pr-architecture-review/SKILL.md` and apply its checklist against the final diff)
+
 ## Global Constraints
 
 - Layer dependency: Foundation has zero runtime imports from upper layers
@@ -635,3 +646,47 @@ git commit -m "refactor: clean up remaining references to old state patterns
 
 Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
 ```
+
+---
+
+### Task 6: PR architecture review and submission
+
+**Skills:** Load `superpowers:requesting-code-review`. Read local skill `skills/pr-architecture-review/SKILL.md` and apply its full checklist.
+
+- [ ] **Step 1: Run PR architecture review**
+
+Read `skills/pr-architecture-review/SKILL.md` and apply every step against the full diff:
+
+```bash
+git diff main...HEAD
+```
+
+Check all 8 steps from the skill:
+1. Identify changed files and affected layers
+2. Check layer dependency rules (no new violations)
+3. Check type contracts (TypedDict usage, exception types)
+4. Check async/sync boundary (run_in_executor wrapping)
+5. Check state management (thread safety, BoundedCache usage)
+6. Check public API surface (__all__, ToolAnnotations)
+7. PEP 8 and Python standards
+8. Security review (input validation, path traversal, error sanitization)
+
+Fix any findings in-place. Commit fixes if needed.
+
+- [ ] **Step 2: Push and open PR**
+
+```bash
+git push -u origin worktree-issue-68-session-isolation
+```
+
+Open PR against `main` with:
+- Title: `refactor: encapsulate server state for session isolation (#68)`
+- Body: summary of changes, violations addressed (V-S3, V-T1, V-E4, V-S2), test results
+- Reference: Closes #68
+
+- [ ] **Step 3: Post review summary on PR**
+
+Post a comment on the PR with:
+- Architecture review results (findings, what was fixed, what was deferred)
+- Test verification results (test count, pass/fail)
+- Violations addressed vs remaining

--- a/docs/superpowers/plans/2026-06-20-session-isolation.md
+++ b/docs/superpowers/plans/2026-06-20-session-isolation.md
@@ -13,11 +13,14 @@
 **Load at session start (before any task):**
 - `superpowers:test-driven-development` — all tasks follow TDD (write failing test → implement → verify)
 - `superpowers:verification-before-completion` — run full suite before claiming any task is done
+- `pep8-naming` — naming conventions for new classes, methods, module-level names
+- `pep8-type-annotations` — type annotation formatting for TypedDict, dataclass fields
 
 **Load per task:**
-- Tasks 1–4: no additional skills needed (TDD skill covers the workflow)
-- Task 5 (final verification): `superpowers:verification-before-completion`
-- Task 6 (PR): `superpowers:requesting-code-review` and local skill `skills/pr-architecture-review` (read `skills/pr-architecture-review/SKILL.md` and apply its checklist against the final diff)
+- Tasks 1–2 (new classes): local skill `skills/python-contract-docstrings` (read SKILL.md, apply to `CollectionManager` and `ServerState` — document contracts, input invariants, errors)
+- Tasks 1–2 (new types): local skill `skills/python-tighten-types` (read SKILL.md, apply to `state.py` and `collections.py` — verify annotations are tight, no loose `dict[str, Any]` where TypedDict exists)
+- Task 5 (final verification): `superpowers:verification-before-completion` + local skill `skills/python-pre-mortem` (read SKILL.md, apply to the new state wiring — spot fragile assumptions, implicit coupling)
+- Task 6 (PR): `superpowers:requesting-code-review`, `pep8-review`, and local skill `skills/pr-architecture-review` (read SKILL.md, apply its 8-step checklist against the final diff)
 
 ## Global Constraints
 

--- a/docs/superpowers/plans/2026-06-20-session-isolation.md
+++ b/docs/superpowers/plans/2026-06-20-session-isolation.md
@@ -440,6 +440,9 @@ from ansible_know.state import LifespanContext, ServerState
 
 **Module globals:** Replace `_version_info` and `_galaxy_servers` with:
 ```python
+# Module-level reference for resource functions that don't receive FastMCP
+# Context. Set once in lifespan; consolidates the former _version_info and
+# _galaxy_servers globals into a single typed object.
 _server_state: ServerState | None = None
 ```
 
@@ -472,10 +475,13 @@ async def app_lifespan(server):
 **Replace `_get_lifespan_resources` and add new helpers:**
 ```python
 def _get_state(ctx: Context | None) -> ServerState:
-    if ctx is None:
-        from ansible_know.collections import CollectionManager
-        return ServerState(collection_manager=CollectionManager())
-    return ctx.lifespan_context["state"]
+    """Return ServerState from ctx, fall back to module-level, or create ephemeral."""
+    if ctx is not None:
+        return ctx.lifespan_context["state"]
+    if _server_state is not None:
+        return _server_state
+    from ansible_know.collections import CollectionManager
+    return ServerState(collection_manager=CollectionManager())
 
 
 def _get_http_client(ctx: Context | None) -> httpx.AsyncClient | None:
@@ -483,6 +489,11 @@ def _get_http_client(ctx: Context | None) -> httpx.AsyncClient | None:
         return None
     return ctx.lifespan_context["http_client"]
 ```
+
+The three-tier fallback: (1) ctx-based is primary (tool handlers in production),
+(2) `_server_state` for resource functions and edge cases where lifespan has run
+but no ctx is available, (3) ephemeral instance only in pure unit tests with no
+lifespan.
 
 Delete `_get_lifespan_resources()`.
 
@@ -582,10 +593,14 @@ Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"
 - [ ] **Step 1: Search for remaining references to old patterns**
 
 ```bash
-grep -rn "_missing_collections\|_get_lifespan_resources\|_version_info\|_galaxy_servers" src/ansible_know/ tests/
+grep -rn "_missing_collections\|_get_lifespan_resources\|_version_info\|_galaxy_servers" src/ tests/
+grep -rn "from ansible_know.collections import ensure_collection\|from ansible_know.collections import get_collections_path\|from ansible_know.collections import list_installed" .
+grep -rn "collections\.ensure_collection\|collections\.get_collections_path\|collections\.list_installed" src/ tests/
 ```
 
-Expected: No hits except `_server_state` in `server.py` and the `_version_info` type in `state.py`.
+Expected: No hits for old module-level function imports. No hits for `_missing_collections`,
+`_get_lifespan_resources`. `_version_info` only in `state.py` type annotation context.
+`_server_state` in `server.py` only.
 
 - [ ] **Step 2: Run full test suite**
 

--- a/docs/superpowers/plans/2026-06-20-session-isolation.md
+++ b/docs/superpowers/plans/2026-06-20-session-isolation.md
@@ -31,6 +31,7 @@
 - Existing test behavior must not change (438 passing, 57 skipped)
 - Run tests with `.venv/bin/pytest tests/ -v --tb=short`
 - Run lint with `.venv/bin/ruff check src/ tests/`
+- **Sandbox mode:** auto-allow, auto-edit. Never prefix commands with env var assignments (e.g. `FOO=bar command`) — use `export` on a separate line or pass via other means. Use `.venv/bin/` prefixed binaries directly, never `source activate`. These patterns trigger unnecessary permission prompts in sandboxed environments.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-20-session-isolation-design.md
+++ b/docs/superpowers/specs/2026-06-20-session-isolation-design.md
@@ -1,0 +1,250 @@
+# Session Isolation: Encapsulate Server State
+
+**Issue:** [#68](https://github.com/leogallego/ansible-know-mcp/issues/68)
+**Date:** 2026-06-20
+**Status:** Draft
+
+## Problem
+
+Mutable state is scattered across 4 modules as module-level globals:
+
+| File | Variables | Risk |
+|------|-----------|------|
+| `collections.py` | `_tmp_dir`, `_installed`, `_install_locks`, `_locks_lock`, `_install_gate` | Shared across sessions, untestable without monkeypatching |
+| `resolution.py` | `_missing_collections` | Stale negative cache persists across sessions |
+| `server.py` | `_version_info`, `_galaxy_servers` | Write-once in lifespan, but stored as globals AND in untyped dict |
+
+This makes the server difficult to test, reset, or run multiple sessions.
+It blocks #64 (HTTP transport) where a shared server needs clean state boundaries.
+
+## Scope
+
+**In scope (this PR):**
+- V-S3: Encapsulate all runtime state in a `ServerState` dataclass
+- V-T1: Define a `LifespanContext` TypedDict for the lifespan context
+- V-E4: Refactor `collections.py` into a `CollectionManager` class
+- V-S2: Move `_missing_collections` out of module scope into `ServerState`
+
+**Out of scope:**
+- V-D8: Split `generate_manifest()` generation from persistence (independent refactor)
+- Per-session isolation for HTTP transport (future — trivial once `ServerState` exists)
+- Moving `galaxy.py`/`docs.py` BoundedCache instances into `ServerState` (process-scoped with TTL, safe to share)
+
+## Design
+
+### `CollectionManager` class in `src/ansible_know/collections.py` (External Access layer)
+
+`CollectionManager` stays in `collections.py` because it runs subprocesses
+(`ansible-galaxy`) — that's External Access behavior. The module-level globals
+become instance variables with identical logic.
+
+```python
+class CollectionManager:
+    """Per-process collection install state.
+
+    Encapsulates the temp directory, installed collection tracking,
+    and per-collection locks that were previously module-level globals.
+    """
+
+    MAX_TRACKED_COLLECTIONS = 100
+
+    def __init__(self) -> None:
+        self._tmp_dir: tempfile.TemporaryDirectory | None = None
+        self._installed: dict[str, str] = {}
+        self._install_locks: dict[str, threading.Lock] = {}
+        self._locks_lock = threading.Lock()
+        self._install_gate = threading.Lock()
+
+    def get_collections_path(self) -> str | None: ...
+    def list_installed(self) -> dict[str, str]: ...
+    def ensure_collection(self, collection_fqcn: str, version: str | None = None) -> EnsureCollectionResult: ...
+```
+
+### New module: `src/ansible_know/state.py` (Foundation layer)
+
+`state.py` holds `ServerState` and `LifespanContext` only. It imports
+`CollectionManager` under `TYPE_CHECKING` to avoid a Foundation → External Access
+runtime dependency. At runtime, `ServerState.collection_manager` is set by
+the lifespan in `server.py`, not by `state.py` importing `collections.py`.
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, TypedDict
+
+if TYPE_CHECKING:
+    import httpx
+    from ansible_know.collections import CollectionManager
+    from ansible_know.galaxy_config import GalaxyServerConfig
+
+
+@dataclass
+class ServerState:
+    """All mutable runtime state for one server process.
+
+    Created once in lifespan, stored in LifespanContext,
+    accessed by tool handlers via _get_state(ctx).
+    """
+
+    collection_manager: CollectionManager = field(default_factory=lambda: _default_collection_manager())
+    missing_collections: set[str] = field(default_factory=set)
+    version_info: dict[str, Any] | None = None
+    galaxy_servers: list[GalaxyServerConfig] = field(default_factory=list)
+    upgrade_warned: bool = False
+
+    def clear_missing_namespace(self, namespace: str) -> None:
+        self.missing_collections.discard(namespace)
+
+
+def _default_collection_manager():
+    from ansible_know.collections import CollectionManager
+    return CollectionManager()
+
+
+class LifespanContext(TypedDict):
+    """Typed lifespan context replacing the untyped dict."""
+
+    http_client: httpx.AsyncClient
+    state: ServerState
+```
+
+### Changes to `collections.py`
+
+Module-level globals (`_tmp_dir`, `_installed`, `_install_locks`, `_locks_lock`, `_install_gate`) are deleted.
+All logic moves into `CollectionManager` methods with identical behavior (see class definition above).
+Helper functions (`_find_ansible_galaxy`, `_parse_version`) stay as module-level private functions (stateless utilities).
+`_get_or_create_tmpdir` becomes a private method on `CollectionManager`.
+
+The `_VERSION_PARSE_RE` compiled regex stays at module level (it's a constant).
+
+### Changes to `resolution.py`
+
+The `_missing_collections` module-level set is deleted.
+
+`resolve_module_doc()` and `resolve_role_doc()` gain a `missing_collections: set[str] | None = None` parameter.
+When `None`, they behave as if the set is empty (no negative caching — safe default).
+
+`clear_missing_namespace()` is removed from `resolution.py`.
+The equivalent is `state.clear_missing_namespace()` called from `server.py`.
+
+### Changes to `server.py`
+
+**Lifespan:**
+```python
+@lifespan
+async def app_lifespan(server):
+    from ansible_know.galaxy_config import load_galaxy_servers
+
+    state = ServerState()
+    state.galaxy_servers = await run_in_executor(load_galaxy_servers)
+    # ... log galaxy servers ...
+
+    async with httpx.AsyncClient(...) as client:
+        state.version_info = await _check_pypi_version(client)
+        yield LifespanContext(http_client=client, state=state)
+```
+
+**State access helper:**
+```python
+def _get_state(ctx: Context | None) -> ServerState:
+    if ctx is None:
+        return ServerState()
+    return ctx.lifespan_context["state"]
+
+def _get_http_client(ctx: Context | None) -> httpx.AsyncClient | None:
+    if ctx is None:
+        return None
+    return ctx.lifespan_context["http_client"]
+```
+
+**Tool handler pattern (before → after):**
+```python
+# Before:
+http_client, galaxy_servers = _get_lifespan_resources(ctx)
+raw_doc, meta = await resolution.resolve_module_doc(
+    module_name, http_client=http_client, galaxy_servers=galaxy_servers,
+    client_factory=_galaxy_factory(),
+)
+
+# After:
+state = _get_state(ctx)
+http_client = _get_http_client(ctx)
+raw_doc, meta = await resolution.resolve_module_doc(
+    module_name, http_client=http_client, galaxy_servers=state.galaxy_servers,
+    client_factory=_galaxy_factory(),
+    missing_collections=state.missing_collections,
+)
+```
+
+**Upgrade warning (before → after):**
+```python
+# Before:
+lc = ctx.lifespan_context
+if lc.get("upgrade_warned") or not info ...
+lc["upgrade_warned"] = True
+
+# After:
+state = _get_state(ctx)
+if state.upgrade_warned or not state.version_info ...
+state.upgrade_warned = True
+```
+
+**Collections access (before → after):**
+```python
+# Before:
+from ansible_know import collections
+collections.get_collections_path()
+collections.ensure_collection(...)
+collections.list_installed()
+resolution.clear_missing_namespace(ns)
+
+# After:
+state = _get_state(ctx)
+state.collection_manager.get_collections_path()
+state.collection_manager.ensure_collection(...)
+state.collection_manager.list_installed()
+state.clear_missing_namespace(ns)
+```
+
+### Changes to tests
+
+Tests that monkeypatch `collections._installed`, `collections._tmp_dir`, or `resolution._missing_collections` will instead create fresh instances:
+
+```python
+# Before:
+monkeypatch.setattr("ansible_know.collections._installed", {"ns.coll": "1.0.0"})
+
+# After:
+mgr = CollectionManager()
+# or
+state = ServerState()
+```
+
+### What stays unchanged
+
+- `galaxy.py` — `_version_cache`, `_blob_cache`, `_enrichment_semaphore` stay as module-level BoundedCache instances (process-scoped, TTL-managed, safe to share)
+- `docs.py` — `_manifest_cache` stays as module-level BoundedCache
+- `parser.py` — no state, no changes
+- `cache.py` — no changes
+- `config.py` — `SKILLS_DIR` lazy-load stays (it's a constant after first access)
+- `galaxy_config.py`, `readme_parser.py`, `async_utils.py`, `errors.py`, `types.py`, `validation.py` — no changes
+
+## Architecture compliance
+
+The new `state.py` module lives in the **Foundation** layer:
+- No imports from Orchestration, Domain, or External Access
+- Only imports: `typing`, `dataclasses`, `tempfile`, `threading`, stdlib
+- Type-checking-only imports for `httpx` and `GalaxyServerConfig`
+
+`CollectionManager` needs helpers from `errors.py` and `validation.py` (both Foundation) — acceptable.
+
+## Migration path to per-session isolation (#64)
+
+Once `ServerState` exists as a single object:
+1. HTTP transport creates one `ServerState` per session instead of per process
+2. `CollectionManager` can optionally share a temp directory across sessions (install once, share read-only)
+3. `missing_collections` becomes naturally per-session
+4. Caches in `galaxy.py`/`docs.py` can stay shared (performance optimization)
+
+No design changes needed — just change where `ServerState()` is constructed.

--- a/docs/superpowers/specs/2026-06-20-session-isolation-design.md
+++ b/docs/superpowers/specs/2026-06-20-session-isolation-design.md
@@ -148,13 +148,15 @@ async def app_lifespan(server):
         yield LifespanContext(http_client=client, state=state)
 ```
 
-**State access helper:**
+**State access helper (three-tier fallback):**
 ```python
 def _get_state(ctx: Context | None) -> ServerState:
-    if ctx is None:
-        from ansible_know.collections import CollectionManager
-        return ServerState(collection_manager=CollectionManager())
-    return ctx.lifespan_context["state"]
+    if ctx is not None:
+        return ctx.lifespan_context["state"]
+    if _server_state is not None:
+        return _server_state
+    from ansible_know.collections import CollectionManager
+    return ServerState(collection_manager=CollectionManager())
 
 def _get_http_client(ctx: Context | None) -> httpx.AsyncClient | None:
     if ctx is None:

--- a/docs/superpowers/specs/2026-06-20-session-isolation-design.md
+++ b/docs/superpowers/specs/2026-06-20-session-isolation-design.md
@@ -64,8 +64,8 @@ class CollectionManager:
 
 `state.py` holds `ServerState` and `LifespanContext` only. It imports
 `CollectionManager` under `TYPE_CHECKING` to avoid a Foundation → External Access
-runtime dependency. At runtime, `ServerState.collection_manager` is set by
-the lifespan in `server.py`, not by `state.py` importing `collections.py`.
+runtime dependency. `collection_manager` is a required field with no default —
+the lifespan in `server.py` must construct and pass it explicitly.
 
 ```python
 from __future__ import annotations
@@ -78,6 +78,8 @@ if TYPE_CHECKING:
     from ansible_know.collections import CollectionManager
     from ansible_know.galaxy_config import GalaxyServerConfig
 
+__all__ = ["ServerState", "LifespanContext"]
+
 
 @dataclass
 class ServerState:
@@ -87,7 +89,7 @@ class ServerState:
     accessed by tool handlers via _get_state(ctx).
     """
 
-    collection_manager: CollectionManager = field(default_factory=lambda: _default_collection_manager())
+    collection_manager: CollectionManager
     missing_collections: set[str] = field(default_factory=set)
     version_info: dict[str, Any] | None = None
     galaxy_servers: list[GalaxyServerConfig] = field(default_factory=list)
@@ -95,11 +97,6 @@ class ServerState:
 
     def clear_missing_namespace(self, namespace: str) -> None:
         self.missing_collections.discard(namespace)
-
-
-def _default_collection_manager():
-    from ansible_know.collections import CollectionManager
-    return CollectionManager()
 
 
 class LifespanContext(TypedDict):
@@ -128,16 +125,22 @@ When `None`, they behave as if the set is empty (no negative caching — safe de
 `clear_missing_namespace()` is removed from `resolution.py`.
 The equivalent is `state.clear_missing_namespace()` called from `server.py`.
 
+`__all__` is updated to remove `clear_missing_namespace`.
+
 ### Changes to `server.py`
 
 **Lifespan:**
 ```python
 @lifespan
 async def app_lifespan(server):
+    from ansible_know.collections import CollectionManager
     from ansible_know.galaxy_config import load_galaxy_servers
 
-    state = ServerState()
-    state.galaxy_servers = await run_in_executor(load_galaxy_servers)
+    galaxy_servers = await run_in_executor(load_galaxy_servers)
+    state = ServerState(
+        collection_manager=CollectionManager(),
+        galaxy_servers=galaxy_servers,
+    )
     # ... log galaxy servers ...
 
     async with httpx.AsyncClient(...) as client:
@@ -149,7 +152,8 @@ async def app_lifespan(server):
 ```python
 def _get_state(ctx: Context | None) -> ServerState:
     if ctx is None:
-        return ServerState()
+        from ansible_know.collections import CollectionManager
+        return ServerState(collection_manager=CollectionManager())
     return ctx.lifespan_context["state"]
 
 def _get_http_client(ctx: Context | None) -> httpx.AsyncClient | None:

--- a/docs/superpowers/specs/2026-06-20-session-isolation-design.md
+++ b/docs/superpowers/specs/2026-06-20-session-isolation-design.md
@@ -119,8 +119,9 @@ The `_VERSION_PARSE_RE` compiled regex stays at module level (it's a constant).
 
 The `_missing_collections` module-level set is deleted.
 
-`resolve_module_doc()` and `resolve_role_doc()` gain a `missing_collections: set[str] | None = None` parameter.
-When `None`, they behave as if the set is empty (no negative caching — safe default).
+`resolve_module_doc()` and `resolve_role_doc()` gain two new parameters:
+- `missing_collections: set[str] | None = None` — when `None`, they behave as if the set is empty (no negative caching — safe default).
+- `collections_path: str | None = None` — replaces the internal `collections.get_collections_path()` call, breaking the Domain → External Access import dependency.
 
 `clear_missing_namespace()` is removed from `resolution.py`.
 The equivalent is `state.clear_missing_namespace()` called from `server.py`.

--- a/src/ansible_know/collections.py
+++ b/src/ansible_know/collections.py
@@ -20,15 +20,11 @@ from ansible_know.errors import CollectionInstallError
 from ansible_know.types import EnsureCollectionResult
 from ansible_know.validation import sanitize_error
 
+__all__ = ["CollectionManager"]
+
 logger = logging.getLogger("ansible_know")
 
 _VERSION_PARSE_RE = re.compile(r"(\S+\.\S+):(\d+\.\d+\.\d+\S*)")
-
-_tmp_dir: tempfile.TemporaryDirectory | None = None
-_installed: dict[str, str] = {}
-_install_locks: dict[str, threading.Lock] = {}
-_locks_lock = threading.Lock()
-_install_gate = threading.Lock()  # serializes all ansible-galaxy subprocess calls
 
 
 def _find_ansible_galaxy() -> str:
@@ -41,14 +37,6 @@ def _find_ansible_galaxy() -> str:
     raise CollectionInstallError(
         "ansible-galaxy not found. Install ansible-core: pip install ansible-core"
     )
-
-
-def _get_or_create_tmpdir() -> str:
-    global _tmp_dir
-    with _locks_lock:
-        if _tmp_dir is None:
-            _tmp_dir = tempfile.TemporaryDirectory(prefix="ansible_know_")
-        return _tmp_dir.name
 
 
 def _parse_version(stdout: str, collection_fqcn: str, tmpdir: str) -> str:
@@ -71,94 +59,112 @@ def _parse_version(stdout: str, collection_fqcn: str, tmpdir: str) -> str:
     return "unknown"
 
 
-MAX_TRACKED_COLLECTIONS = 100
+class CollectionManager:
+    """Manages temporary collection installation and tracking.
 
-
-def ensure_collection(collection_fqcn: str, version: str | None = None) -> EnsureCollectionResult:
-    """Install a collection to the temp directory (thread-safe).
-
-    Args:
-        collection_fqcn: Two-part collection identifier (e.g., "netbox.netbox").
-        version: Optional version constraint (e.g., "4.1.0").
-
-    Installs once and pins the resolved version. Subsequent calls skip
-    unless a different version is explicitly requested.
-
-    Returns dict with keys: namespace, version, status, message.
+    Thread-safe manager for installing Ansible collections to a temporary
+    directory and tracking their versions. Each instance maintains its own
+    isolated state.
     """
-    with _locks_lock:
-        if len(_install_locks) >= MAX_TRACKED_COLLECTIONS and collection_fqcn not in _install_locks:
-            raise CollectionInstallError(
-                f"Too many collections tracked ({MAX_TRACKED_COLLECTIONS}). "
-                "Restart the server to reset."
-            )
-        if collection_fqcn not in _install_locks:
-            _install_locks[collection_fqcn] = threading.Lock()
-        lock = _install_locks[collection_fqcn]
 
-    with lock:
-        current = _installed.get(collection_fqcn)
-        if current and (not version or current == version):
+    MAX_TRACKED_COLLECTIONS = 100
+
+    def __init__(self) -> None:
+        self._tmp_dir: tempfile.TemporaryDirectory | None = None
+        self._installed: dict[str, str] = {}
+        self._install_locks: dict[str, threading.Lock] = {}
+        self._locks_lock = threading.Lock()
+        self._install_gate = threading.Lock()  # serializes all ansible-galaxy subprocess calls
+
+    def _get_or_create_tmpdir(self) -> str:
+        with self._locks_lock:
+            if self._tmp_dir is None:
+                self._tmp_dir = tempfile.TemporaryDirectory(prefix="ansible_know_")
+            return self._tmp_dir.name
+
+    def ensure_collection(self, collection_fqcn: str, version: str | None = None) -> EnsureCollectionResult:
+        """Install a collection to the temp directory (thread-safe).
+
+        Args:
+            collection_fqcn: Two-part collection identifier (e.g., "netbox.netbox").
+            version: Optional version constraint (e.g., "4.1.0").
+
+        Installs once and pins the resolved version. Subsequent calls skip
+        unless a different version is explicitly requested.
+
+        Returns dict with keys: namespace, version, status, message.
+        """
+        with self._locks_lock:
+            if len(self._install_locks) >= self.MAX_TRACKED_COLLECTIONS and collection_fqcn not in self._install_locks:
+                raise CollectionInstallError(
+                    f"Too many collections tracked ({self.MAX_TRACKED_COLLECTIONS}). "
+                    "Restart the server to reset."
+                )
+            if collection_fqcn not in self._install_locks:
+                self._install_locks[collection_fqcn] = threading.Lock()
+            lock = self._install_locks[collection_fqcn]
+
+        with lock:
+            current = self._installed.get(collection_fqcn)
+            if current and (not version or current == version):
+                return {
+                    "namespace": collection_fqcn,
+                    "version": current,
+                    "status": "already_installed",
+                    "message": f"Collection {collection_fqcn} v{current} is already available.",
+                }
+
+            previous_version = current
+            tmpdir = self._get_or_create_tmpdir()
+            galaxy = _find_ansible_galaxy()
+
+            collection_spec = f"{collection_fqcn}:=={version}" if version else collection_fqcn
+            cmd = [galaxy, "collection", "install", collection_spec, "-p", tmpdir, "--force"]
+
+            with self._install_gate:
+                try:
+                    result = subprocess.run(
+                        cmd,
+                        capture_output=True,
+                        text=True,
+                        timeout=120,
+                    )
+                except subprocess.TimeoutExpired as exc:
+                    raise CollectionInstallError(
+                        f"ansible-galaxy timed out installing {collection_fqcn}"
+                    ) from exc
+
+                if result.returncode != 0:
+                    raise CollectionInstallError(
+                        sanitize_error(result.stderr.strip())
+                    )
+
+            installed_version = _parse_version(result.stdout, collection_fqcn, tmpdir)
+            self._installed[collection_fqcn] = installed_version
+
+            if previous_version and previous_version != installed_version:
+                message = (
+                    f"Installed {collection_fqcn} v{installed_version}, "
+                    f"replacing previously installed v{previous_version}."
+                )
+            elif version:
+                message = f"Installed {collection_fqcn} v{installed_version}."
+            else:
+                message = f"Installed {collection_fqcn} v{installed_version} (latest)."
+
             return {
                 "namespace": collection_fqcn,
-                "version": current,
-                "status": "already_installed",
-                "message": f"Collection {collection_fqcn} v{current} is already available.",
+                "version": installed_version,
+                "status": "installed",
+                "message": message,
             }
 
-        previous_version = current
-        tmpdir = _get_or_create_tmpdir()
-        galaxy = _find_ansible_galaxy()
+    def get_collections_path(self) -> str | None:
+        with self._locks_lock:
+            if self._tmp_dir is None:
+                return None
+            return self._tmp_dir.name
 
-        collection_spec = f"{collection_fqcn}:=={version}" if version else collection_fqcn
-        cmd = [galaxy, "collection", "install", collection_spec, "-p", tmpdir, "--force"]
-
-        with _install_gate:
-            try:
-                result = subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    text=True,
-                    timeout=120,
-                )
-            except subprocess.TimeoutExpired as exc:
-                raise CollectionInstallError(
-                    f"ansible-galaxy timed out installing {collection_fqcn}"
-                ) from exc
-
-            if result.returncode != 0:
-                raise CollectionInstallError(
-                    sanitize_error(result.stderr.strip())
-                )
-
-        installed_version = _parse_version(result.stdout, collection_fqcn, tmpdir)
-        _installed[collection_fqcn] = installed_version
-
-        if previous_version and previous_version != installed_version:
-            message = (
-                f"Installed {collection_fqcn} v{installed_version}, "
-                f"replacing previously installed v{previous_version}."
-            )
-        elif version:
-            message = f"Installed {collection_fqcn} v{installed_version}."
-        else:
-            message = f"Installed {collection_fqcn} v{installed_version} (latest)."
-
-        return {
-            "namespace": collection_fqcn,
-            "version": installed_version,
-            "status": "installed",
-            "message": message,
-        }
-
-
-def get_collections_path() -> str | None:
-    with _locks_lock:
-        if _tmp_dir is None:
-            return None
-        return _tmp_dir.name
-
-
-def list_installed() -> dict[str, str]:
-    with _locks_lock:
-        return dict(_installed)
+    def list_installed(self) -> dict[str, str]:
+        with self._locks_lock:
+            return dict(self._installed)

--- a/src/ansible_know/resolution.py
+++ b/src/ansible_know/resolution.py
@@ -28,19 +28,8 @@ __all__ = [
     "resolve_module_doc",
     "resolve_role_doc",
     "search_galaxy_collections",
-    "clear_missing_namespace",
 ]
 
-# Negative cache: namespaces that failed local ansible-doc lookup.
-# Skips retrying local resolution for known-missing collections,
-# going straight to Galaxy fallback. Cleared per-namespace on
-# successful ensure_collection().
-#
-# Thread safety: only mutated from the asyncio event loop thread
-# (add/discard in coroutines); executor callbacks (parser calls)
-# never touch it. Under CPython, set.add/discard/`in` are also
-# GIL-atomic, so even an accidental cross-thread read is safe.
-_missing_collections: set[str] = set()
 
 
 def _select_http_client(
@@ -88,33 +77,30 @@ def _get_servers(
     return load_galaxy_servers()
 
 
-def clear_missing_namespace(namespace: str) -> None:
-    """Remove a namespace from the negative cache."""
-    _missing_collections.discard(namespace)
-
-
 async def resolve_module_doc(
     module_name: str,
     http_client: httpx.AsyncClient | None = None,
     galaxy_servers: list[GalaxyServerConfig] | None = None,
     client_factory: GalaxyClientFactory | None = None,
+    missing_collections: set[str] | None = None,
+    collections_path: str | None = None,
 ) -> tuple[dict[str, Any], DocProvenance | None]:
     """Try local ansible-doc, fall back to Galaxy if the collection is missing.
 
     Returns (raw_doc, galaxy_meta_or_none). Raises on non-missing-collection
     errors and when both local and Galaxy lookups fail.
     """
-    from ansible_know import collections, parser
+    from ansible_know import parser
     from ansible_know.errors import CollectionNotFoundError, GalaxyError
 
     servers = _get_servers(galaxy_servers)
     namespace = ".".join(module_name.split(".")[:2]) if "." in module_name else None
-    cpath = collections.get_collections_path()
+    cpath = collections_path
 
     async def _fetch_from_galaxy(client):
         return await client.fetch_module_doc(module_name)
 
-    if namespace and namespace in _missing_collections:
+    if namespace and missing_collections is not None and namespace in missing_collections:
         if client_factory is None:
             raise CollectionNotFoundError(
                 f"Collection '{namespace}' not installed locally"
@@ -135,8 +121,8 @@ async def resolve_module_doc(
         )
         return raw_doc, None
     except CollectionNotFoundError as local_exc:
-        if namespace:
-            _missing_collections.add(namespace)
+        if namespace and missing_collections is not None:
+            missing_collections.add(namespace)
         if client_factory is None:
             raise
         logger.info("Collection not installed, trying Galaxy: %s", local_exc)
@@ -155,28 +141,30 @@ async def resolve_role_doc(
     http_client: httpx.AsyncClient | None = None,
     galaxy_servers: list[GalaxyServerConfig] | None = None,
     client_factory: GalaxyClientFactory | None = None,
+    missing_collections: set[str] | None = None,
+    collections_path: str | None = None,
 ) -> dict[str, Any]:
     """Try local ansible-doc -t role, fall back to Galaxy readme_html.
 
     Returns the complete tool response dict including doc_source and content_type.
     """
-    from ansible_know import collections, parser
+    from ansible_know import parser
     from ansible_know.errors import CollectionNotFoundError, GalaxyError
 
     servers = _get_servers(galaxy_servers)
     namespace = ".".join(role_name.split(".")[:2]) if "." in role_name else None
-    cpath = collections.get_collections_path()
+    cpath = collections_path
 
     local_doc: dict[str, Any] = {}
 
-    if not (namespace and namespace in _missing_collections):
+    if not (namespace and missing_collections is not None and namespace in missing_collections):
         try:
             local_doc = await run_in_executor(
                 parser.get_role_doc, role_name, collections_path=cpath,
             )
         except CollectionNotFoundError:
-            if namespace:
-                _missing_collections.add(namespace)
+            if namespace and missing_collections is not None:
+                missing_collections.add(namespace)
             local_doc = {}
         except AnsibleDocError as exc:
             logger.warning("Local role doc failed for %s: %s", role_name, exc)

--- a/src/ansible_know/resolution.py
+++ b/src/ansible_know/resolution.py
@@ -31,7 +31,6 @@ __all__ = [
 ]
 
 
-
 def _select_http_client(
     http_client: httpx.AsyncClient | None,
     server: GalaxyServerConfig,
@@ -71,7 +70,7 @@ def _get_servers(
     galaxy_servers: list[GalaxyServerConfig] | None,
 ) -> list[GalaxyServerConfig]:
     """Return explicit servers or fall back to ansible.cfg discovery."""
-    if galaxy_servers is not None:
+    if galaxy_servers:
         return galaxy_servers
     from ansible_know.galaxy_config import load_galaxy_servers
     return load_galaxy_servers()

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -14,7 +14,7 @@ from importlib.metadata import version as pkg_version
 from typing import TYPE_CHECKING, Annotated, Any
 
 if TYPE_CHECKING:
-    from ansible_know.galaxy_config import GalaxyServerConfig
+    pass
 
 import httpx
 from fastmcp import Context, FastMCP
@@ -23,6 +23,7 @@ from mcp.types import ToolAnnotations
 
 from ansible_know.async_utils import run_in_executor
 from ansible_know.errors import AnsibleDocError, ValidationError, collection_hint, maybe_add_hint
+from ansible_know.state import LifespanContext, ServerState
 from ansible_know.validation import (
     sanitize_error,
     truncate_response,
@@ -39,8 +40,11 @@ from ansible_know.validation import (
 logger = logging.getLogger("ansible_know")
 
 _VERSION = pkg_version("ansible-know-mcp")
-_version_info: dict[str, Any] | None = None
-_galaxy_servers: list[GalaxyServerConfig] | None = None
+
+# Module-level reference for resource functions that don't receive FastMCP
+# Context. Set once in lifespan; consolidates the former _version_info and
+# _galaxy_servers globals into a single typed object.
+_server_state: ServerState | None = None
 
 
 def _is_stable(v: str) -> bool:
@@ -83,11 +87,16 @@ async def _check_pypi_version(client: httpx.AsyncClient) -> dict[str, Any] | Non
 
 @lifespan
 async def app_lifespan(server):
-    global _version_info, _galaxy_servers
+    global _server_state
+    from ansible_know.collections import CollectionManager
     from ansible_know.galaxy_config import load_galaxy_servers
 
     galaxy_servers = await run_in_executor(load_galaxy_servers)
-    _galaxy_servers = galaxy_servers
+    state = ServerState(
+        collection_manager=CollectionManager(),
+        galaxy_servers=galaxy_servers,
+    )
+    _server_state = state
     for gs in galaxy_servers:
         auth_type = "token" if gs.token else ("basic" if gs.username else "none")
         logger.info("Galaxy server: %s (%s, auth=%s)", gs.name, gs.url, auth_type)
@@ -96,13 +105,8 @@ async def app_lifespan(server):
         timeout=httpx.Timeout(10.0, read=120.0),
         verify=True,
     ) as client:
-        _version_info = await _check_pypi_version(client)
-        yield {
-            "http_client": client,
-            "version_info": _version_info,
-            "upgrade_warned": False,
-            "galaxy_servers": galaxy_servers,
-        }
+        state.version_info = await _check_pypi_version(client)
+        yield LifespanContext(http_client=client, state=state)
 
 mcp = FastMCP(
     name="Ansible Know",
@@ -126,29 +130,36 @@ def _galaxy_factory():
     return GalaxyClient.from_config
 
 
-def _get_lifespan_resources(
-    ctx: Context | None,
-) -> tuple[httpx.AsyncClient | None, list[GalaxyServerConfig] | None]:
-    """Extract http_client and galaxy_servers from the lifespan context."""
+def _get_state(ctx: Context | None) -> ServerState:
+    """Return ServerState from ctx, fall back to module-level, or create ephemeral."""
+    if ctx is not None:
+        return ctx.lifespan_context["state"]
+    if _server_state is not None:
+        return _server_state
+    from ansible_know.collections import CollectionManager
+    return ServerState(collection_manager=CollectionManager())
+
+
+def _get_http_client(ctx: Context | None) -> httpx.AsyncClient | None:
+    """Extract http_client from the lifespan context."""
     if ctx is None:
-        return None, None
-    lc = ctx.lifespan_context
-    return lc.get("http_client"), lc.get("galaxy_servers")
+        return None
+    return ctx.lifespan_context["http_client"]
 
 
 async def _maybe_warn_upgrade(ctx: Context | None) -> None:
     if ctx is None:
         return
-    lc = ctx.lifespan_context
-    info = lc.get("version_info")
-    if lc.get("upgrade_warned") or not info or not info.get("outdated"):
+    state = _get_state(ctx)
+    if state.upgrade_warned or not state.version_info or not state.version_info.get("outdated"):
         return
+    info = state.version_info
     await ctx.warning(
         f"ansible-know-mcp {info['installed']} is outdated; "
         f"latest is {info['latest']}. "
         f"Upgrade: {info['upgrade_command']}"
     )
-    lc["upgrade_warned"] = True
+    state.upgrade_warned = True
 
 
 # --- Discovery tools (read-only) ---
@@ -158,6 +169,7 @@ async def _maybe_warn_upgrade(ctx: Context | None) -> None:
 async def search_modules(
     keyword: Annotated[str, "Search term to match against module names and descriptions"],
     namespace: Annotated[str | None, "Optional collection namespace filter (e.g. 'community.docker')"] = None,
+    ctx: Context | None = None,
 ) -> dict[str, str]:
     """Find Ansible modules by keyword in name or description. Returns up to 50 matches as {fqcn: short_description}.
 
@@ -172,12 +184,13 @@ async def search_modules(
         return {"error": str(exc)}
 
     try:
-        from ansible_know import collections, parser
+        from ansible_know import parser
         from ansible_know.config import SEARCH_MODULES_LIMIT
 
+        state = _get_state(ctx)
         results = await run_in_executor(
             parser.search_modules, keyword, collection_filter=namespace,
-            collections_path=collections.get_collections_path(),
+            collections_path=state.collection_manager.get_collections_path(),
         )
         if len(results) > SEARCH_MODULES_LIMIT:
             results = dict(list(results.items())[:SEARCH_MODULES_LIMIT])
@@ -210,10 +223,13 @@ async def get_module_doc(
     try:
         from ansible_know import parser, resolution
 
-        http_client, galaxy_servers = _get_lifespan_resources(ctx)
+        state = _get_state(ctx)
+        http_client = _get_http_client(ctx)
         raw_doc, galaxy_meta = await resolution.resolve_module_doc(
-            module_name, http_client=http_client, galaxy_servers=galaxy_servers,
+            module_name, http_client=http_client, galaxy_servers=state.galaxy_servers or None,
             client_factory=_galaxy_factory(),
+            missing_collections=state.missing_collections,
+            collections_path=state.collection_manager.get_collections_path(),
         )
         metadata = parser.extract_module_metadata(raw_doc)
         if galaxy_meta:
@@ -255,10 +271,13 @@ async def get_role_doc(
     try:
         from ansible_know import resolution
 
-        http_client, galaxy_servers = _get_lifespan_resources(ctx)
+        state = _get_state(ctx)
+        http_client = _get_http_client(ctx)
         return await resolution.resolve_role_doc(
-            role_name, http_client=http_client, galaxy_servers=galaxy_servers,
+            role_name, http_client=http_client, galaxy_servers=state.galaxy_servers or None,
             client_factory=_galaxy_factory(),
+            missing_collections=state.missing_collections,
+            collections_path=state.collection_manager.get_collections_path(),
         )
     except Exception as exc:
         logger.warning("get_role_doc failed: %s", exc)
@@ -328,9 +347,10 @@ async def search_collections(
     try:
         from ansible_know import resolution
 
-        http_client, galaxy_servers = _get_lifespan_resources(ctx)
+        state = _get_state(ctx)
+        http_client = _get_http_client(ctx)
         return await resolution.search_galaxy_collections(
-            query, tags=tags, http_client=http_client, galaxy_servers=galaxy_servers,
+            query, tags=tags, http_client=http_client, galaxy_servers=state.galaxy_servers or None,
             client_factory=_galaxy_factory(),
         )
     except Exception as exc:
@@ -355,16 +375,17 @@ async def get_collection_manifest(
         return {"error": str(exc)}
 
     try:
-        from ansible_know import collection_manifest, collections, parser
+        from ansible_know import collection_manifest, parser
 
-        installed_version = collections.list_installed().get(collection_namespace)
+        state = _get_state(None)
+        installed_version = state.collection_manager.list_installed().get(collection_namespace)
         cached = collection_manifest.load_cached_manifest(
             collection_namespace, installed_version=installed_version,
         )
         if cached:
             return cached
 
-        cpath = collections.get_collections_path()
+        cpath = state.collection_manager.get_collections_path()
 
         modules = await run_in_executor(
             parser.search_modules, "", collection_filter=collection_namespace,
@@ -451,12 +472,11 @@ async def ensure_collection(
         return {"error": str(exc)}
 
     try:
-        from ansible_know import collections, resolution
-
+        state = _get_state(None)
         result = await run_in_executor(
-            collections.ensure_collection, collection_fqcn=collection_namespace, version=version,
+            state.collection_manager.ensure_collection, collection_fqcn=collection_namespace, version=version,
         )
-        resolution.clear_missing_namespace(collection_namespace)
+        state.clear_missing_namespace(collection_namespace)
         logger.info(
             "ensure_collection result: namespace=%s version=%s status=%s",
             result["namespace"], result["version"], result["status"],
@@ -561,10 +581,13 @@ async def generate_skill(
         if ctx:
             await ctx.report_progress(progress=0, total=100)
 
-        http_client, galaxy_servers = _get_lifespan_resources(ctx)
+        state = _get_state(ctx)
+        http_client = _get_http_client(ctx)
         raw_doc, galaxy_meta = await resolution.resolve_module_doc(
-            module_name, http_client=http_client, galaxy_servers=galaxy_servers,
+            module_name, http_client=http_client, galaxy_servers=state.galaxy_servers or None,
             client_factory=_galaxy_factory(),
+            missing_collections=state.missing_collections,
+            collections_path=state.collection_manager.get_collections_path(),
         )
         metadata = parser.extract_module_metadata(raw_doc)
         if galaxy_meta:
@@ -622,10 +645,13 @@ async def generate_role_skill(
         if ctx:
             await ctx.report_progress(progress=0, total=100)
 
-        http_client, galaxy_servers = _get_lifespan_resources(ctx)
+        state = _get_state(ctx)
+        http_client = _get_http_client(ctx)
         metadata = await resolution.resolve_role_doc(
-            role_name, http_client=http_client, galaxy_servers=galaxy_servers,
+            role_name, http_client=http_client, galaxy_servers=state.galaxy_servers or None,
             client_factory=_galaxy_factory(),
+            missing_collections=state.missing_collections,
+            collections_path=state.collection_manager.get_collections_path(),
         )
 
         if metadata.get("doc_source") == "unavailable":
@@ -674,10 +700,11 @@ async def generate_collection_skills(
         return {"error": str(exc)}
 
     try:
-        from ansible_know import collection_manifest, collections, parser, skills
+        from ansible_know import collection_manifest, parser, skills
         from ansible_know.config import SKILLS_DIR
 
-        cpath = collections.get_collections_path()
+        state = _get_state(ctx)
+        cpath = state.collection_manager.get_collections_path()
         modules = await run_in_executor(
             parser.search_modules, "", collection_filter=collection_namespace,
             collections_path=cpath,
@@ -782,9 +809,8 @@ def resource_skill_content(skill_name: str) -> str:
     description="List collections installed in this session via ensure_collection",
 )
 def resource_installed_collections() -> str:
-    from ansible_know import collections
-
-    return json.dumps(collections.list_installed(), indent=2)
+    installed = _server_state.collection_manager.list_installed() if _server_state else {}
+    return json.dumps(installed, indent=2)
 
 
 @mcp.resource(
@@ -793,8 +819,9 @@ def resource_installed_collections() -> str:
     description="Installed and latest version info with upgrade status",
 )
 def resource_server_version() -> str:
-    if _version_info:
-        return json.dumps(_version_info, indent=2)
+    version_info = _server_state.version_info if _server_state else None
+    if version_info:
+        return json.dumps(version_info, indent=2)
     return json.dumps(
         {
             "installed": _VERSION,
@@ -817,7 +844,7 @@ def resource_server_version() -> str:
 def resource_galaxy_servers() -> str:
     from ansible_know.galaxy_config import load_galaxy_servers
 
-    servers = _galaxy_servers or load_galaxy_servers()
+    servers = (_server_state.galaxy_servers if _server_state else None) or load_galaxy_servers()
     return json.dumps([
         {
             "name": s.name,

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -223,7 +223,7 @@ async def get_module_doc(
         state = _get_state(ctx)
         http_client = _get_http_client(ctx)
         raw_doc, galaxy_meta = await resolution.resolve_module_doc(
-            module_name, http_client=http_client, galaxy_servers=state.galaxy_servers or None,
+            module_name, http_client=http_client, galaxy_servers=state.galaxy_servers,
             client_factory=_galaxy_factory(),
             missing_collections=state.missing_collections,
             collections_path=state.collection_manager.get_collections_path(),
@@ -271,7 +271,7 @@ async def get_role_doc(
         state = _get_state(ctx)
         http_client = _get_http_client(ctx)
         return await resolution.resolve_role_doc(
-            role_name, http_client=http_client, galaxy_servers=state.galaxy_servers or None,
+            role_name, http_client=http_client, galaxy_servers=state.galaxy_servers,
             client_factory=_galaxy_factory(),
             missing_collections=state.missing_collections,
             collections_path=state.collection_manager.get_collections_path(),
@@ -347,7 +347,7 @@ async def search_collections(
         state = _get_state(ctx)
         http_client = _get_http_client(ctx)
         return await resolution.search_galaxy_collections(
-            query, tags=tags, http_client=http_client, galaxy_servers=state.galaxy_servers or None,
+            query, tags=tags, http_client=http_client, galaxy_servers=state.galaxy_servers,
             client_factory=_galaxy_factory(),
         )
     except Exception as exc:
@@ -358,6 +358,7 @@ async def search_collections(
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def get_collection_manifest(
     collection_namespace: Annotated[str, "Collection namespace (e.g. 'netbox.netbox')"],
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Get collection-level manifest with per-module summaries.
 
@@ -371,10 +372,11 @@ async def get_collection_manifest(
     except ValidationError as exc:
         return {"error": str(exc)}
 
+    await _maybe_warn_upgrade(ctx)
     try:
         from ansible_know import collection_manifest, parser
 
-        state = _get_state(None)
+        state = _get_state(ctx)
         installed_version = state.collection_manager.list_installed().get(collection_namespace)
         cached = collection_manifest.load_cached_manifest(
             collection_namespace, installed_version=installed_version,
@@ -444,6 +446,7 @@ async def ensure_collection(
         str | None,
         "Optional version (e.g. '4.1.0'). If omitted, installs latest and pins the resolved version.",
     ] = None,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Install a collection to a temporary directory for this session.
 
@@ -461,6 +464,7 @@ async def ensure_collection(
     On failure returns {"error": str}.
     """
     logger.info("ensure_collection namespace=%r version=%r", collection_namespace, version)
+    await _maybe_warn_upgrade(ctx)
     try:
         validate_namespace(collection_namespace)
         if version:
@@ -469,7 +473,7 @@ async def ensure_collection(
         return {"error": str(exc)}
 
     try:
-        state = _get_state(None)
+        state = _get_state(ctx)
         result = await run_in_executor(
             state.collection_manager.ensure_collection, collection_fqcn=collection_namespace, version=version,
         )
@@ -581,7 +585,7 @@ async def generate_skill(
         state = _get_state(ctx)
         http_client = _get_http_client(ctx)
         raw_doc, galaxy_meta = await resolution.resolve_module_doc(
-            module_name, http_client=http_client, galaxy_servers=state.galaxy_servers or None,
+            module_name, http_client=http_client, galaxy_servers=state.galaxy_servers,
             client_factory=_galaxy_factory(),
             missing_collections=state.missing_collections,
             collections_path=state.collection_manager.get_collections_path(),
@@ -645,7 +649,7 @@ async def generate_role_skill(
         state = _get_state(ctx)
         http_client = _get_http_client(ctx)
         metadata = await resolution.resolve_role_doc(
-            role_name, http_client=http_client, galaxy_servers=state.galaxy_servers or None,
+            role_name, http_client=http_client, galaxy_servers=state.galaxy_servers,
             client_factory=_galaxy_factory(),
             missing_collections=state.missing_collections,
             collections_path=state.collection_manager.get_collections_path(),

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -11,10 +11,7 @@ import json
 import logging
 import os
 from importlib.metadata import version as pkg_version
-from typing import TYPE_CHECKING, Annotated, Any
-
-if TYPE_CHECKING:
-    pass
+from typing import Annotated, Any
 
 import httpx
 from fastmcp import Context, FastMCP

--- a/src/ansible_know/state.py
+++ b/src/ansible_know/state.py
@@ -1,0 +1,44 @@
+"""Server state and lifespan context types.
+
+Foundation-layer module: no runtime imports from Domain, External Access,
+or Orchestration. CollectionManager is imported under TYPE_CHECKING only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, TypedDict
+
+if TYPE_CHECKING:
+    import httpx
+
+    from ansible_know.collections import CollectionManager
+    from ansible_know.galaxy_config import GalaxyServerConfig
+
+__all__ = ["LifespanContext", "ServerState"]
+
+
+@dataclass
+class ServerState:
+    """All mutable runtime state for one server process.
+
+    Created once in lifespan, stored in LifespanContext,
+    accessed by tool handlers via _get_state(ctx).
+    """
+
+    collection_manager: CollectionManager
+    missing_collections: set[str] = field(default_factory=set)
+    version_info: dict[str, Any] | None = None
+    galaxy_servers: list[GalaxyServerConfig] = field(default_factory=list)
+    upgrade_warned: bool = False
+
+    def clear_missing_namespace(self, namespace: str) -> None:
+        """Remove a namespace from the negative cache."""
+        self.missing_collections.discard(namespace)
+
+
+class LifespanContext(TypedDict):
+    """Typed lifespan context replacing the untyped dict."""
+
+    http_client: httpx.AsyncClient
+    state: ServerState

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -6,31 +6,20 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ansible_know.collections import (
-    ensure_collection,
-    get_collections_path,
-    list_installed,
-)
+from ansible_know.collections import CollectionManager
 from ansible_know.errors import CollectionInstallError
 
 
-@pytest.fixture(autouse=True)
-def reset_collections_state():
-    """Reset module-level state between tests."""
-    import ansible_know.collections as col
-    col._installed = {}
-    col._install_locks = {}
-    old_tmp = col._tmp_dir
-    col._tmp_dir = None
-    yield
-    test_tmp = col._tmp_dir
-    col._tmp_dir = None
-    for tmp in [old_tmp, test_tmp]:
-        if tmp is not None:
-            try:
-                tmp.cleanup()
-            except Exception:
-                pass
+@pytest.fixture
+def mgr():
+    """Create a fresh CollectionManager for each test."""
+    manager = CollectionManager()
+    yield manager
+    if manager._tmp_dir is not None:
+        try:
+            manager._tmp_dir.cleanup()
+        except Exception:
+            pass
 
 
 def _make_subprocess_result(stdout="", stderr="", returncode=0):
@@ -42,38 +31,38 @@ def _make_subprocess_result(stdout="", stderr="", returncode=0):
 
 
 class TestGetCollectionsPath:
-    def test_returns_none_before_install(self):
-        assert get_collections_path() is None
+    def test_returns_none_before_install(self, mgr):
+        assert mgr.get_collections_path() is None
 
-    def test_returns_path_after_install(self):
+    def test_returns_path_after_install(self, mgr):
         galaxy_stdout = "Installing 'netbox.netbox:4.1.0' to '<path>'\nnetbox.netbox:4.1.0 was installed successfully"
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout)):
-                ensure_collection("netbox.netbox")
-        path = get_collections_path()
+                mgr.ensure_collection("netbox.netbox")
+        path = mgr.get_collections_path()
         assert path is not None
         assert "ansible_collections" not in path
 
 
 class TestListInstalled:
-    def test_returns_empty_before_install(self):
-        assert list_installed() == {}
+    def test_returns_empty_before_install(self, mgr):
+        assert mgr.list_installed() == {}
 
-    def test_returns_installed_after_install(self):
+    def test_returns_installed_after_install(self, mgr):
         galaxy_stdout = "Installing 'netbox.netbox:4.1.0' to '<path>'\nnetbox.netbox:4.1.0 was installed successfully"
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout)):
-                ensure_collection("netbox.netbox")
-        installed = list_installed()
+                mgr.ensure_collection("netbox.netbox")
+        installed = mgr.list_installed()
         assert "netbox.netbox" in installed
 
 
 class TestEnsureCollectionInstalls:
-    def test_installs_collection(self):
+    def test_installs_collection(self, mgr):
         galaxy_stdout = "Installing 'netbox.netbox:4.1.0' to '<path>'\nnetbox.netbox:4.1.0 was installed successfully"
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout)) as mock_run:
-                result = ensure_collection("netbox.netbox")
+                result = mgr.ensure_collection("netbox.netbox")
         assert result["status"] == "installed"
         assert result["namespace"] == "netbox.netbox"
         assert result["version"] == "4.1.0"
@@ -82,123 +71,122 @@ class TestEnsureCollectionInstalls:
         assert "install" in args
         assert "netbox.netbox" in args
 
-    def test_installs_with_version_pin(self):
+    def test_installs_with_version_pin(self, mgr):
         galaxy_stdout = "Installing 'netbox.netbox:3.9.0' to '<path>'\nnetbox.netbox:3.9.0 was installed successfully"
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout)) as mock_run:
-                result = ensure_collection("netbox.netbox", version="3.9.0")
+                result = mgr.ensure_collection("netbox.netbox", version="3.9.0")
         assert result["version"] == "3.9.0"
         args = mock_run.call_args[0][0]
         assert "netbox.netbox:==3.9.0" in args
 
-    def test_no_version_skips_after_first_install(self):
+    def test_no_version_skips_after_first_install(self, mgr):
         galaxy_stdout = "Installing 'netbox.netbox:4.0.0' to '<path>'\nnetbox.netbox:4.0.0 was installed successfully"
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout)):
-                ensure_collection("netbox.netbox")
+                mgr.ensure_collection("netbox.netbox")
             with patch("subprocess.run") as mock_run:
-                result = ensure_collection("netbox.netbox")
+                result = mgr.ensure_collection("netbox.netbox")
         assert result["status"] == "already_installed"
         assert result["version"] == "4.0.0"
         mock_run.assert_not_called()
 
-    def test_different_version_replaces(self):
+    def test_different_version_replaces(self, mgr):
         galaxy_stdout_1 = "Installing 'netbox.netbox:3.9.0' to '<path>'\nnetbox.netbox:3.9.0 was installed successfully"
         galaxy_stdout_2 = "Installing 'netbox.netbox:4.1.0' to '<path>'\nnetbox.netbox:4.1.0 was installed successfully"
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout_1)):
-                ensure_collection("netbox.netbox", version="3.9.0")
+                mgr.ensure_collection("netbox.netbox", version="3.9.0")
             with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout_2)):
-                result = ensure_collection("netbox.netbox", version="4.1.0")
+                result = mgr.ensure_collection("netbox.netbox", version="4.1.0")
         assert result["status"] == "installed"
         assert "replacing" in result["message"].lower()
         assert "3.9.0" in result["message"]
 
-    def test_skips_matching_pin(self):
+    def test_skips_matching_pin(self, mgr):
         galaxy_stdout = "Installing 'netbox.netbox:3.9.0' to '<path>'\nnetbox.netbox:3.9.0 was installed successfully"
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout)):
-                ensure_collection("netbox.netbox", version="3.9.0")
+                mgr.ensure_collection("netbox.netbox", version="3.9.0")
             with patch("subprocess.run") as mock_run:
-                result = ensure_collection("netbox.netbox", version="3.9.0")
+                result = mgr.ensure_collection("netbox.netbox", version="3.9.0")
         assert result["status"] == "already_installed"
         mock_run.assert_not_called()
 
-    def test_reinstalls_different_version(self):
+    def test_reinstalls_different_version(self, mgr):
         galaxy_stdout_1 = "Installing 'netbox.netbox:3.9.0' to '<path>'\nnetbox.netbox:3.9.0 was installed successfully"
         galaxy_stdout_2 = "Installing 'netbox.netbox:4.0.0' to '<path>'\nnetbox.netbox:4.0.0 was installed successfully"
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout_1)):
-                ensure_collection("netbox.netbox", version="3.9.0")
+                mgr.ensure_collection("netbox.netbox", version="3.9.0")
             with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout_2)):
-                result = ensure_collection("netbox.netbox", version="4.0.0")
+                result = mgr.ensure_collection("netbox.netbox", version="4.0.0")
         assert result["status"] == "installed"
         assert result["version"] == "4.0.0"
-        assert list_installed()["netbox.netbox"] == "4.0.0"
+        assert mgr.list_installed()["netbox.netbox"] == "4.0.0"
 
 
 class TestEnsureCollectionErrors:
-    def test_galaxy_failure_raises(self):
+    def test_galaxy_failure_raises(self, mgr):
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=_make_subprocess_result(
                 stderr="ERROR! Failed to resolve collection netbox.netbox at /home/user/.ansible/tmp",
                 returncode=1,
             )):
                 with pytest.raises(CollectionInstallError, match="Failed to resolve"):
-                    ensure_collection("netbox.netbox")
+                    mgr.ensure_collection("netbox.netbox")
 
-    def test_galaxy_failure_sanitizes_paths(self):
+    def test_galaxy_failure_sanitizes_paths(self, mgr):
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=_make_subprocess_result(
                 stderr="ERROR! at /home/user/.ansible/collections/path: denied",
                 returncode=1,
             )):
                 with pytest.raises(CollectionInstallError) as exc_info:
-                    ensure_collection("netbox.netbox")
+                    mgr.ensure_collection("netbox.netbox")
                 assert "/home/user" not in str(exc_info.value)
 
-    def test_timeout_raises(self):
+    def test_timeout_raises(self, mgr):
         import subprocess as sp
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", side_effect=sp.TimeoutExpired(cmd="ansible-galaxy", timeout=120)):
                 with pytest.raises(CollectionInstallError, match="timed out"):
-                    ensure_collection("netbox.netbox")
+                    mgr.ensure_collection("netbox.netbox")
 
 
 class TestVersionParsing:
-    def test_parses_version_from_stdout(self):
+    def test_parses_version_from_stdout(self, mgr):
         galaxy_stdout = "Installing 'netbox.netbox:4.1.0' to '<path>'\nnetbox.netbox:4.1.0 was installed successfully"
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout)):
-                result = ensure_collection("netbox.netbox")
+                result = mgr.ensure_collection("netbox.netbox")
         assert result["version"] == "4.1.0"
 
-    def test_fallback_to_manifest(self):
+    def test_fallback_to_manifest(self, mgr):
         galaxy_stdout = "Some unexpected output format"
         manifest_data = {"collection_info": {"version": "3.5.0"}}
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout)):
                 import tempfile
-
-                import ansible_know.collections as col
-                col._tmp_dir = tempfile.TemporaryDirectory()
                 from pathlib import Path
-                manifest_dir = Path(col._tmp_dir.name) / "ansible_collections" / "netbox" / "netbox"
+
+                mgr._tmp_dir = tempfile.TemporaryDirectory()
+                manifest_dir = Path(mgr._tmp_dir.name) / "ansible_collections" / "netbox" / "netbox"
                 manifest_dir.mkdir(parents=True, exist_ok=True)
                 (manifest_dir / "MANIFEST.json").write_text(json.dumps(manifest_data))
-                result = ensure_collection("netbox.netbox")
+                result = mgr.ensure_collection("netbox.netbox")
         assert result["version"] == "3.5.0"
 
-    def test_fallback_to_unknown(self):
+    def test_fallback_to_unknown(self, mgr):
         galaxy_stdout = "Some unexpected output format"
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout)):
-                result = ensure_collection("netbox.netbox")
+                result = mgr.ensure_collection("netbox.netbox")
         assert result["version"] == "unknown"
 
 
 class TestConcurrentInstall:
-    def test_same_collection_installs_once(self):
+    def test_same_collection_installs_once(self, mgr):
         call_count = 0
         def slow_run(*args, **kwargs):
             nonlocal call_count
@@ -209,15 +197,15 @@ class TestConcurrentInstall:
 
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", side_effect=slow_run):
-                t1 = threading.Thread(target=ensure_collection, args=("netbox.netbox",))
-                t2 = threading.Thread(target=ensure_collection, args=("netbox.netbox",))
+                t1 = threading.Thread(target=mgr.ensure_collection, args=("netbox.netbox",))
+                t2 = threading.Thread(target=mgr.ensure_collection, args=("netbox.netbox",))
                 t1.start()
                 t2.start()
                 t1.join()
                 t2.join()
         assert call_count == 1  # second thread sees first's result and skips
 
-    def test_different_collections_parallel(self):
+    def test_different_collections_parallel(self, mgr):
         call_order = []
         def tracking_run(*args, **kwargs):
             cmd = args[0]
@@ -229,8 +217,8 @@ class TestConcurrentInstall:
 
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", side_effect=tracking_run):
-                t1 = threading.Thread(target=ensure_collection, args=("netbox.netbox",))
-                t2 = threading.Thread(target=ensure_collection, args=("community.general",))
+                t1 = threading.Thread(target=mgr.ensure_collection, args=("netbox.netbox",))
+                t2 = threading.Thread(target=mgr.ensure_collection, args=("community.general",))
                 t1.start()
                 t2.start()
                 t1.join()

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -11,13 +11,10 @@ from tests.conftest import SAMPLE_MODULE_DOC, SAMPLE_ROLE_DOC
 FACTORY = GalaxyClient.from_config
 
 
-@pytest.fixture(autouse=True)
-def reset_negative_cache():
-    """Clear the negative cache before each test."""
-    from ansible_know import resolution
-    resolution._missing_collections.clear()
-    yield
-    resolution._missing_collections.clear()
+@pytest.fixture
+def missing():
+    """Provide a fresh missing-collections set for each test."""
+    return set()
 
 
 @pytest.fixture
@@ -30,15 +27,17 @@ class TestResolveModuleDoc:
     """Tests migrated from test_server.py::TestResolveModuleDoc + new cases."""
 
     @pytest.mark.asyncio
-    async def test_local_success_no_galaxy(self, mock_ansible_doc):
+    async def test_local_success_no_galaxy(self, mock_ansible_doc, missing):
         mock_ansible_doc.return_value = json.dumps(SAMPLE_MODULE_DOC)
         from ansible_know.resolution import resolve_module_doc
-        raw_doc, galaxy_meta = await resolve_module_doc("ansible.builtin.package")
+        raw_doc, galaxy_meta = await resolve_module_doc(
+            "ansible.builtin.package", missing_collections=missing,
+        )
         assert "ansible.builtin.package" in raw_doc
         assert galaxy_meta is None
 
     @pytest.mark.asyncio
-    async def test_non_missing_collection_error_not_retried(self, mock_ansible_doc):
+    async def test_non_missing_collection_error_not_retried(self, mock_ansible_doc, missing):
         from ansible_know.errors import AnsibleDocError
         mock_ansible_doc.side_effect = AnsibleDocError("ansible-doc timed out")
 
@@ -48,10 +47,12 @@ class TestResolveModuleDoc:
         ):
             from ansible_know.resolution import resolve_module_doc
             with pytest.raises(AnsibleDocError, match="timed out"):
-                await resolve_module_doc("ansible.builtin.copy")
+                await resolve_module_doc(
+                    "ansible.builtin.copy", missing_collections=missing,
+                )
 
     @pytest.mark.asyncio
-    async def test_galaxy_fallback_on_missing_collection(self, mock_ansible_doc):
+    async def test_galaxy_fallback_on_missing_collection(self, mock_ansible_doc, missing):
         from ansible_know.errors import CollectionNotFoundError
         mock_ansible_doc.side_effect = CollectionNotFoundError(
             "ansible-doc failed (exit 1): netbox.netbox.netbox_device has no attribute"
@@ -76,14 +77,16 @@ class TestResolveModuleDoc:
         ):
             from ansible_know.resolution import resolve_module_doc
             raw_doc, meta = await resolve_module_doc(
-                "netbox.netbox.netbox_device", client_factory=FACTORY,
+                "netbox.netbox.netbox_device",
+                client_factory=FACTORY,
+                missing_collections=missing,
             )
 
         assert raw_doc == galaxy_doc
         assert meta["doc_source"] == "galaxy"
 
     @pytest.mark.asyncio
-    async def test_both_fail_raises_local_error(self, mock_ansible_doc):
+    async def test_both_fail_raises_local_error(self, mock_ansible_doc, missing):
         from ansible_know.errors import CollectionNotFoundError, GalaxyError
         mock_ansible_doc.side_effect = CollectionNotFoundError(
             "ansible-doc failed (exit 1): some.col.mod was not found"
@@ -95,21 +98,27 @@ class TestResolveModuleDoc:
         ):
             from ansible_know.resolution import resolve_module_doc
             with pytest.raises(CollectionNotFoundError, match="was not found"):
-                await resolve_module_doc("some.col.mod", client_factory=FACTORY)
+                await resolve_module_doc(
+                    "some.col.mod",
+                    client_factory=FACTORY,
+                    missing_collections=missing,
+                )
 
 
 class TestResolveRoleDoc:
 
     @pytest.mark.asyncio
-    async def test_local_success(self, mock_ansible_doc):
+    async def test_local_success(self, mock_ansible_doc, missing):
         mock_ansible_doc.return_value = json.dumps(SAMPLE_ROLE_DOC)
         from ansible_know.resolution import resolve_role_doc
-        result = await resolve_role_doc("fedora.linux_system_roles.gfs2")
+        result = await resolve_role_doc(
+            "fedora.linux_system_roles.gfs2", missing_collections=missing,
+        )
         assert result["content_type"] == "role"
         assert result["doc_source"] == "local"
 
     @pytest.mark.asyncio
-    async def test_galaxy_fallback_on_empty_doc(self, mock_ansible_doc):
+    async def test_galaxy_fallback_on_empty_doc(self, mock_ansible_doc, missing):
         mock_ansible_doc.return_value = "{}"
         galaxy_role_meta = {
             "role_name": "fedora.linux_system_roles.timesync",
@@ -125,14 +134,16 @@ class TestResolveRoleDoc:
         ):
             from ansible_know.resolution import resolve_role_doc
             result = await resolve_role_doc(
-                "fedora.linux_system_roles.timesync", client_factory=FACTORY,
+                "fedora.linux_system_roles.timesync",
+                client_factory=FACTORY,
+                missing_collections=missing,
             )
 
         assert result["doc_source"] == "galaxy_readme"
         assert result["content_type"] == "role"
 
     @pytest.mark.asyncio
-    async def test_graceful_degradation(self, mock_ansible_doc):
+    async def test_graceful_degradation(self, mock_ansible_doc, missing):
         mock_ansible_doc.return_value = "{}"
         from ansible_know.errors import GalaxyError
 
@@ -142,7 +153,9 @@ class TestResolveRoleDoc:
         ):
             from ansible_know.resolution import resolve_role_doc
             result = await resolve_role_doc(
-                "some.col.missing_role", client_factory=FACTORY,
+                "some.col.missing_role",
+                client_factory=FACTORY,
+                missing_collections=missing,
             )
 
         assert result["doc_source"] == "unavailable"
@@ -153,9 +166,8 @@ class TestNegativeCache:
     """Tests migrated from test_server.py::TestNegativeCache."""
 
     @pytest.mark.asyncio
-    async def test_skips_local_on_cache_hit(self, mock_ansible_doc):
-        from ansible_know import resolution
-        resolution._missing_collections.add("netbox.netbox")
+    async def test_skips_local_on_cache_hit(self, mock_ansible_doc, missing):
+        missing.add("netbox.netbox")
 
         galaxy_doc = {
             "netbox.netbox.netbox_device": {
@@ -173,16 +185,18 @@ class TestNegativeCache:
             "ansible_know.galaxy.GalaxyClient.fetch_module_doc",
             return_value=(galaxy_doc, galaxy_meta),
         ):
-            raw_doc, meta = await resolution.resolve_module_doc(
-                "netbox.netbox.netbox_device", client_factory=FACTORY,
+            from ansible_know.resolution import resolve_module_doc
+            raw_doc, meta = await resolve_module_doc(
+                "netbox.netbox.netbox_device",
+                client_factory=FACTORY,
+                missing_collections=missing,
             )
 
         mock_ansible_doc.assert_not_called()
         assert meta["doc_source"] == "galaxy"
 
     @pytest.mark.asyncio
-    async def test_populates_cache_on_collection_not_found(self, mock_ansible_doc):
-        from ansible_know import resolution
+    async def test_populates_cache_on_collection_not_found(self, mock_ansible_doc, missing):
         from ansible_know.errors import CollectionNotFoundError, GalaxyError
 
         mock_ansible_doc.side_effect = CollectionNotFoundError("netbox.netbox has no attribute")
@@ -191,35 +205,41 @@ class TestNegativeCache:
             "ansible_know.galaxy.GalaxyClient.fetch_module_doc",
             side_effect=GalaxyError("not found"),
         ):
+            from ansible_know.resolution import resolve_module_doc
             with pytest.raises(CollectionNotFoundError):
-                await resolution.resolve_module_doc(
-                    "netbox.netbox.netbox_device", client_factory=FACTORY,
+                await resolve_module_doc(
+                    "netbox.netbox.netbox_device",
+                    client_factory=FACTORY,
+                    missing_collections=missing,
                 )
 
-        assert "netbox.netbox" in resolution._missing_collections
+        assert "netbox.netbox" in missing
 
     @pytest.mark.asyncio
-    async def test_does_not_cache_non_collection_errors(self, mock_ansible_doc):
-        from ansible_know import resolution
+    async def test_does_not_cache_non_collection_errors(self, mock_ansible_doc, missing):
         from ansible_know.errors import AnsibleDocError
 
         mock_ansible_doc.side_effect = AnsibleDocError("ansible-doc timed out")
 
+        from ansible_know.resolution import resolve_module_doc
         with pytest.raises(AnsibleDocError):
-            await resolution.resolve_module_doc("ansible.builtin.copy")
+            await resolve_module_doc(
+                "ansible.builtin.copy", missing_collections=missing,
+            )
 
-        assert "ansible.builtin" not in resolution._missing_collections
+        assert "ansible.builtin" not in missing
 
     def test_clear_missing_namespace(self):
-        from ansible_know import resolution
-        resolution._missing_collections.add("netbox.netbox")
-        resolution.clear_missing_namespace("netbox.netbox")
-        assert "netbox.netbox" not in resolution._missing_collections
+        from ansible_know.collections import CollectionManager
+        from ansible_know.state import ServerState
+        state = ServerState(collection_manager=CollectionManager())
+        state.missing_collections.add("netbox.netbox")
+        state.clear_missing_namespace("netbox.netbox")
+        assert "netbox.netbox" not in state.missing_collections
 
     @pytest.mark.asyncio
-    async def test_role_skips_local_on_cache_hit(self, mock_ansible_doc):
-        from ansible_know import resolution
-        resolution._missing_collections.add("some.col")
+    async def test_role_skips_local_on_cache_hit(self, mock_ansible_doc, missing):
+        missing.add("some.col")
 
         galaxy_role_meta = {
             "role_name": "some.col.role",
@@ -233,8 +253,11 @@ class TestNegativeCache:
             "ansible_know.galaxy.GalaxyClient.fetch_role_doc",
             return_value=(galaxy_role_meta, galaxy_meta),
         ):
-            result = await resolution.resolve_role_doc(
-                "some.col.role", client_factory=FACTORY,
+            from ansible_know.resolution import resolve_role_doc
+            result = await resolve_role_doc(
+                "some.col.role",
+                client_factory=FACTORY,
+                missing_collections=missing,
             )
 
         mock_ansible_doc.assert_not_called()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -574,12 +574,12 @@ class TestResourceFunctions:
         from ansible_know.state import ServerState
 
         cm = CollectionManager()
-        cm._installed = {"netbox.netbox": "4.1.0", "ansible.utils": "5.0.0"}
         state = ServerState(collection_manager=cm)
         old = srv._server_state
         try:
             srv._server_state = state
-            result = json.loads(srv.resource_installed_collections())
+            with patch.object(cm, "list_installed", return_value={"netbox.netbox": "4.1.0", "ansible.utils": "5.0.0"}):
+                result = json.loads(srv.resource_installed_collections())
         finally:
             srv._server_state = old
         assert result == {"netbox.netbox": "4.1.0", "ansible.utils": "5.0.0"}
@@ -973,7 +973,7 @@ class TestLifespanHttpClient:
         args, kwargs = mock_resolve.call_args
         assert args == ("ansible.builtin.package",)
         assert kwargs["http_client"] is mock_client
-        assert kwargs["galaxy_servers"] is None
+        assert kwargs["galaxy_servers"] == []
         assert kwargs["client_factory"] is not None
 
     @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,15 +14,6 @@ from tests.conftest import (
 )
 
 
-@pytest.fixture(autouse=True)
-def reset_negative_cache_global():
-    """Clear the negative cache before each test to prevent test pollution."""
-    from ansible_know import resolution
-    resolution._missing_collections.clear()
-    yield
-    resolution._missing_collections.clear()
-
-
 @pytest.fixture
 def mock_ansible_doc():
     with patch("ansible_know.parser._run_ansible_doc") as mock:
@@ -307,9 +298,6 @@ class TestEnsureCollectionTool:
         mock_result.returncode = 0
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=mock_result):
-                import ansible_know.collections as col
-                col._installed = {}
-                col._tmp_dir = None
                 from ansible_know.server import ensure_collection
                 result = await ensure_collection("netbox.netbox")
         assert result["status"] == "installed"
@@ -336,9 +324,6 @@ class TestEnsureCollectionTool:
         mock_result.returncode = 0
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
             with patch("subprocess.run", return_value=mock_result):
-                import ansible_know.collections as col
-                col._installed = {}
-                col._tmp_dir = None
                 from ansible_know.server import ensure_collection
                 result = await ensure_collection("netbox.netbox", version="3.9.0")
         assert result["status"] == "installed"
@@ -570,17 +555,34 @@ class TestResourceFunctions:
         assert "invalid" in result.lower() or "expected" in result.lower()
 
     def test_resource_installed_collections_empty(self):
-        with patch("ansible_know.collections.list_installed", return_value={}):
-            from ansible_know.server import resource_installed_collections
-            result = json.loads(resource_installed_collections())
+        import ansible_know.server as srv
+        from ansible_know.collections import CollectionManager
+        from ansible_know.state import ServerState
+
+        state = ServerState(collection_manager=CollectionManager())
+        old = srv._server_state
+        try:
+            srv._server_state = state
+            result = json.loads(srv.resource_installed_collections())
+        finally:
+            srv._server_state = old
         assert result == {}
 
     def test_resource_installed_collections_with_data(self):
-        installed = {"netbox.netbox": "4.1.0", "ansible.utils": "5.0.0"}
-        with patch("ansible_know.collections.list_installed", return_value=installed):
-            from ansible_know.server import resource_installed_collections
-            result = json.loads(resource_installed_collections())
-        assert result == installed
+        import ansible_know.server as srv
+        from ansible_know.collections import CollectionManager
+        from ansible_know.state import ServerState
+
+        cm = CollectionManager()
+        cm._installed = {"netbox.netbox": "4.1.0", "ansible.utils": "5.0.0"}
+        state = ServerState(collection_manager=cm)
+        old = srv._server_state
+        try:
+            srv._server_state = state
+            result = json.loads(srv.resource_installed_collections())
+        finally:
+            srv._server_state = old
+        assert result == {"netbox.netbox": "4.1.0", "ansible.utils": "5.0.0"}
 
     def test_resource_doc_sources(self):
         from ansible_know.server import resource_doc_sources
@@ -758,35 +760,41 @@ class TestCheckPypiVersion:
 class TestMaybeWarnUpgrade:
     @pytest.mark.asyncio
     async def test_warns_when_outdated(self):
+        from ansible_know.collections import CollectionManager
         from ansible_know.server import _maybe_warn_upgrade
+        from ansible_know.state import ServerState
 
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {
-            "version_info": {
+        state = ServerState(
+            collection_manager=CollectionManager(),
+            version_info={
                 "installed": "0.3.2", "latest": "0.4.0",
                 "outdated": True, "upgrade_command": "uvx --upgrade ansible-know-mcp",
             },
-            "upgrade_warned": False,
-        }
+        )
+        mock_ctx = MagicMock()
+        mock_ctx.lifespan_context = {"state": state, "http_client": None}
         mock_ctx.warning = AsyncMock()
 
         await _maybe_warn_upgrade(mock_ctx)
         mock_ctx.warning.assert_called_once()
         assert "outdated" in mock_ctx.warning.call_args[0][0]
-        assert mock_ctx.lifespan_context["upgrade_warned"] is True
+        assert state.upgrade_warned is True
 
     @pytest.mark.asyncio
     async def test_warns_only_once(self):
+        from ansible_know.collections import CollectionManager
         from ansible_know.server import _maybe_warn_upgrade
+        from ansible_know.state import ServerState
 
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {
-            "version_info": {
+        state = ServerState(
+            collection_manager=CollectionManager(),
+            version_info={
                 "installed": "0.3.2", "latest": "0.4.0",
                 "outdated": True, "upgrade_command": "uvx --upgrade ansible-know-mcp",
             },
-            "upgrade_warned": False,
-        }
+        )
+        mock_ctx = MagicMock()
+        mock_ctx.lifespan_context = {"state": state, "http_client": None}
         mock_ctx.warning = AsyncMock()
 
         await _maybe_warn_upgrade(mock_ctx)
@@ -795,16 +803,19 @@ class TestMaybeWarnUpgrade:
 
     @pytest.mark.asyncio
     async def test_no_warn_when_current(self):
+        from ansible_know.collections import CollectionManager
         from ansible_know.server import _maybe_warn_upgrade
+        from ansible_know.state import ServerState
 
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {
-            "version_info": {
+        state = ServerState(
+            collection_manager=CollectionManager(),
+            version_info={
                 "installed": "0.3.2", "latest": "0.3.2",
                 "outdated": False, "upgrade_command": "uvx --upgrade ansible-know-mcp",
             },
-            "upgrade_warned": False,
-        }
+        )
+        mock_ctx = MagicMock()
+        mock_ctx.lifespan_context = {"state": state, "http_client": None}
         mock_ctx.warning = AsyncMock()
 
         await _maybe_warn_upgrade(mock_ctx)
@@ -812,13 +823,16 @@ class TestMaybeWarnUpgrade:
 
     @pytest.mark.asyncio
     async def test_no_warn_when_check_failed(self):
+        from ansible_know.collections import CollectionManager
         from ansible_know.server import _maybe_warn_upgrade
+        from ansible_know.state import ServerState
 
+        state = ServerState(
+            collection_manager=CollectionManager(),
+            version_info=None,
+        )
         mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {
-            "version_info": None,
-            "upgrade_warned": False,
-        }
+        mock_ctx.lifespan_context = {"state": state, "http_client": None}
         mock_ctx.warning = AsyncMock()
 
         await _maybe_warn_upgrade(mock_ctx)
@@ -833,32 +847,43 @@ class TestMaybeWarnUpgrade:
 class TestServerVersionResource:
     def test_returns_installed_version_without_pypi_check(self):
         import ansible_know.server as srv
-        old = srv._version_info
+        from ansible_know.collections import CollectionManager
+        from ansible_know.state import ServerState
+
+        state = ServerState(collection_manager=CollectionManager())
+        old = srv._server_state
         try:
-            srv._version_info = None
+            srv._server_state = state
             result = json.loads(srv.resource_server_version())
             assert result["installed"] == srv._VERSION
             assert result["latest"] is None
             assert result["outdated"] is None
         finally:
-            srv._version_info = old
+            srv._server_state = old
 
     def test_returns_pypi_info_when_available(self):
         import ansible_know.server as srv
-        old = srv._version_info
-        try:
-            srv._version_info = {
+        from ansible_know.collections import CollectionManager
+        from ansible_know.state import ServerState
+
+        state = ServerState(
+            collection_manager=CollectionManager(),
+            version_info={
                 "installed": "0.3.2",
                 "latest": "0.4.0",
                 "outdated": True,
                 "upgrade_command": "uvx --upgrade ansible-know-mcp",
-            }
+            },
+        )
+        old = srv._server_state
+        try:
+            srv._server_state = state
             result = json.loads(srv.resource_server_version())
             assert result["installed"] == "0.3.2"
             assert result["latest"] == "0.4.0"
             assert result["outdated"] is True
         finally:
-            srv._version_info = old
+            srv._server_state = old
 
 
 class TestSearchCollectionsTool:
@@ -931,10 +956,14 @@ class TestSearchCollectionsTool:
 class TestLifespanHttpClient:
     @pytest.mark.asyncio
     async def test_get_module_doc_passes_lifespan_http_client(self, mock_ansible_doc):
+        from ansible_know.collections import CollectionManager
+        from ansible_know.state import ServerState
+
         mock_ansible_doc.return_value = json.dumps(SAMPLE_MODULE_DOC)
         mock_client = AsyncMock()
+        state = ServerState(collection_manager=CollectionManager())
         mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"http_client": mock_client, "galaxy_servers": None}
+        mock_ctx.lifespan_context = {"http_client": mock_client, "state": state}
 
         with patch("ansible_know.resolution.resolve_module_doc") as mock_resolve:
             mock_resolve.return_value = (SAMPLE_MODULE_DOC, None)
@@ -949,9 +978,13 @@ class TestLifespanHttpClient:
 
     @pytest.mark.asyncio
     async def test_search_collections_passes_lifespan_http_client(self):
+        from ansible_know.collections import CollectionManager
+        from ansible_know.state import ServerState
+
         mock_client = AsyncMock()
+        state = ServerState(collection_manager=CollectionManager())
         mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"http_client": mock_client, "galaxy_servers": None}
+        mock_ctx.lifespan_context = {"http_client": mock_client, "state": state}
 
         mock_result = {"query": "test", "count": 0, "collections": []}
         with patch("ansible_know.galaxy.GalaxyClient.from_config") as mock_from_config:
@@ -967,20 +1000,23 @@ class TestLifespanHttpClient:
 
     @pytest.mark.asyncio
     async def test_validate_certs_false_skips_shared_client(self):
+        from ansible_know.collections import CollectionManager
         from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.state import ServerState
 
         mock_client = AsyncMock()
-        mock_ctx = MagicMock()
         server = GalaxyServerConfig(
             name="private_hub",
             url="https://hub.internal.com/api/galaxy",
             token="secret",
             validate_certs=False,
         )
-        mock_ctx.lifespan_context = {
-            "http_client": mock_client,
-            "galaxy_servers": [server],
-        }
+        state = ServerState(
+            collection_manager=CollectionManager(),
+            galaxy_servers=[server],
+        )
+        mock_ctx = MagicMock()
+        mock_ctx.lifespan_context = {"http_client": mock_client, "state": state}
 
         mock_result = {"query": "test", "count": 0, "collections": []}
         with patch("ansible_know.galaxy.GalaxyClient.from_config") as mock_from_config:
@@ -996,19 +1032,22 @@ class TestLifespanHttpClient:
 
     @pytest.mark.asyncio
     async def test_validate_certs_true_uses_shared_client(self):
+        from ansible_know.collections import CollectionManager
         from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.state import ServerState
 
         mock_client = AsyncMock()
-        mock_ctx = MagicMock()
         server = GalaxyServerConfig(
             name="public_galaxy",
             url="https://galaxy.ansible.com",
             validate_certs=True,
         )
-        mock_ctx.lifespan_context = {
-            "http_client": mock_client,
-            "galaxy_servers": [server],
-        }
+        state = ServerState(
+            collection_manager=CollectionManager(),
+            galaxy_servers=[server],
+        )
+        mock_ctx = MagicMock()
+        mock_ctx.lifespan_context = {"http_client": mock_client, "state": state}
 
         mock_result = {"query": "test", "count": 0, "collections": []}
         with patch("ansible_know.galaxy.GalaxyClient.from_config") as mock_from_config:
@@ -1088,8 +1127,15 @@ class TestGetRoleDocTool:
 
     @pytest.mark.asyncio
     async def test_cached_missing_collection_skips_local(self, mock_ansible_doc):
-        from ansible_know import resolution
-        resolution._missing_collections.add("some.col")
+        from ansible_know.collections import CollectionManager
+        from ansible_know.state import ServerState
+
+        state = ServerState(collection_manager=CollectionManager())
+        state.missing_collections.add("some.col")
+
+        mock_ctx = MagicMock()
+        mock_ctx.lifespan_context = {"state": state, "http_client": None}
+        mock_ctx.warning = AsyncMock()
 
         galaxy_role_meta = {
             "role_name": "some.col.role",
@@ -1105,12 +1151,12 @@ class TestGetRoleDocTool:
             return_value=(galaxy_role_meta, galaxy_meta),
         ):
             from ansible_know.server import get_role_doc
-            result = await get_role_doc("some.col.role")
+            result = await get_role_doc("some.col.role", ctx=mock_ctx)
 
         mock_ansible_doc.assert_not_called()
         assert result["doc_source"] == "galaxy_readme"
 
-        assert "ansible.builtin" not in resolution._missing_collections
+        assert "ansible.builtin" not in state.missing_collections
 
 
 class TestGenerateRoleSkillTool:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -40,3 +40,7 @@ class TestLifespanContext:
     def test_is_typed_dict(self):
         assert "http_client" in LifespanContext.__annotations__
         assert "state" in LifespanContext.__annotations__
+
+    def test_required_keys(self):
+        assert "http_client" in LifespanContext.__required_keys__
+        assert "state" in LifespanContext.__required_keys__

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,42 @@
+"""Tests for ansible_know.state."""
+
+from ansible_know.collections import CollectionManager
+from ansible_know.state import LifespanContext, ServerState
+
+
+class TestServerState:
+    def test_create_with_required_fields(self):
+        mgr = CollectionManager()
+        state = ServerState(collection_manager=mgr)
+        assert state.collection_manager is mgr
+        assert state.missing_collections == set()
+        assert state.version_info is None
+        assert state.galaxy_servers == []
+        assert state.upgrade_warned is False
+
+    def test_clear_missing_namespace(self):
+        mgr = CollectionManager()
+        state = ServerState(collection_manager=mgr)
+        state.missing_collections.add("netbox.netbox")
+        state.clear_missing_namespace("netbox.netbox")
+        assert "netbox.netbox" not in state.missing_collections
+
+    def test_clear_missing_namespace_absent_is_noop(self):
+        mgr = CollectionManager()
+        state = ServerState(collection_manager=mgr)
+        state.clear_missing_namespace("nonexistent.ns")
+        assert state.missing_collections == set()
+
+    def test_independent_instances(self):
+        mgr1 = CollectionManager()
+        mgr2 = CollectionManager()
+        state1 = ServerState(collection_manager=mgr1)
+        state2 = ServerState(collection_manager=mgr2)
+        state1.missing_collections.add("netbox.netbox")
+        assert "netbox.netbox" not in state2.missing_collections
+
+
+class TestLifespanContext:
+    def test_is_typed_dict(self):
+        assert "http_client" in LifespanContext.__annotations__
+        assert "state" in LifespanContext.__annotations__


### PR DESCRIPTION
## Summary

- **V-E4**: Extract `CollectionManager` class from module-level globals in `collections.py` — encapsulates `_tmp_dir`, `_installed`, `_install_locks`, `_locks_lock`, `_install_gate` with identical thread-safety semantics
- **V-S3**: Create `ServerState` dataclass in new Foundation-layer `state.py` — centralizes all mutable runtime state (`collection_manager`, `missing_collections`, `version_info`, `galaxy_servers`, `upgrade_warned`)
- **V-T1**: Create `LifespanContext` TypedDict replacing the untyped `dict[str, Any]` lifespan context
- **V-S2**: Remove `_missing_collections` module-level set from `resolution.py` — now passed as parameter, enabling per-session negative caching

### Architecture improvements
- `state.py` (Foundation) has zero runtime imports from upper layers — `CollectionManager` imported under `TYPE_CHECKING` only
- `resolution.py` no longer imports `collections` at all — `collections_path` injected as parameter (partial V-L4 remediation)
- Tests create fresh `CollectionManager`/`ServerState` instances instead of monkeypatching module globals — eliminates cross-test pollution

### Migration path
Once `ServerState` exists as a single object, per-session isolation (#64) becomes trivial: create one `ServerState` per session instead of per process. No design changes needed.

## Test plan

- [x] All 443 unit tests pass (438 original + 5 new for `ServerState`/`LifespanContext`)
- [x] 57 integration tests skipped (expected, need ansible-core + network)
- [x] `ruff check src/ tests/` — all checks pass
- [x] Architecture review: no layer violations, no thread-safety regressions, no security issues
- [x] Verified no remaining references to old patterns (`_missing_collections`, `_get_lifespan_resources`, old module-level function imports)

Closes #68.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>