### PR TITLE
feat: per-session state isolation and periodic PyPI check

### DIFF
--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -28,8 +28,8 @@ The server follows a 5-layer pipeline architecture adapted for MCP:
 │                    readme_parser.py                      │
 ├─────────────────────────────────────────────────────────┤
 │  Foundation        async_utils.py, cache.py, config.py,  │
-│                    galaxy_config.py, validation.py,      │
-│                    errors.py, types.py                    │
+│                    galaxy_config.py, state.py,            │
+│                    validation.py, errors.py, types.py     │
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -68,21 +68,24 @@ decorated tool, resource, and prompt handler functions. FastMCP manages:
 | In (from Transport) | `Context` | `fastmcp.Context` |
 | In (from Transport) | Tool parameters | `Annotated[str, ...]`, `Annotated[str \| None, ...]` |
 | Out (to Transport) | Tool results | `dict[str, Any]`, `str`, `list[dict]` |
-| Shared (lifespan) | `httpx.AsyncClient` | Via `ctx.lifespan_context` dict |
-| Shared (lifespan) | `list[GalaxyServerConfig]` | Via `ctx.lifespan_context` dict |
+| Shared (lifespan) | `httpx.AsyncClient` | Via `LifespanContext["http_client"]` |
+| Shared (lifespan) | `SharedState` | Via `LifespanContext["shared"]` — process-wide galaxy servers + version info |
+| Shared (lifespan) | `SessionManager` | Via `LifespanContext["sessions"]` — per-session state factory |
 
 ### Concurrency Contract
 
 - Tool handlers are `async` functions running on the FastMCP event loop.
 - Blocking work (subprocess calls, file I/O) MUST be dispatched via
   `_run_in_executor()` to avoid blocking the event loop.
-- The lifespan context dict is shared across all concurrent tool calls.
+- The lifespan context is a `LifespanContext` TypedDict shared across all
+  concurrent tool calls. Per-session state is obtained via
+  `await sessions.get_or_create(ctx.session_id)`.
 
 ### Violations
 
 | ID | Severity | Description | Location |
 |----|----------|-------------|----------|
-| V-T1 | Warning | Lifespan context is an untyped `dict[str, Any]` accessed by string keys (`"http_client"`, `"version_info"`, `"upgrade_warned"`, `"galaxy_servers"`). Should be a typed dataclass or `TypedDict` to prevent key typos and enable static analysis. | `server.py:103-108`, `server.py:132-139` |
+| ~~V-T1~~ | ~~Warning~~ | ~~Lifespan context is an untyped `dict[str, Any]` accessed by string keys.~~ **Fixed in PR #87** — `LifespanContext` TypedDict with typed keys (`http_client`, `shared`, `sessions`). | ~~`server.py:103-108`~~ → `state.py` |
 | V-T2 | Warning | `_run_in_executor()` uses deprecated `asyncio.get_event_loop()`. Should use `asyncio.get_running_loop()` — the function is only called from async context. | `server.py:126-129` |
 | V-T3 | Info | Tool return types are `dict[str, Any]` rather than typed dicts. FastMCP serializes to JSON regardless, but typed returns would improve static analysis within the server code. | All tool handlers |
 
@@ -228,13 +231,18 @@ dependencies on upper layers.
 | `ModuleMetadata` | `TypedDict` | `types.py:8-15` |
 | `RoleMetadata` | `TypedDict` | `types.py:18-23` |
 | `DocProvenance` | `TypedDict` (partial) | `types.py:26-35` |
-| `ErrorResponse` | `TypedDict` | `types.py:38-40` |
+| `VersionInfo` | `TypedDict` | `types.py:43-49` |
+| `ErrorResponse` | `TypedDict` | `types.py:51-53` |
 | `EnsureCollectionResult` | `TypedDict` | `types.py:43-49` |
 | `SkillEntry` | `TypedDict` | `types.py:52-57` |
 | `CollectionInfo` | `TypedDict` (partial) | `types.py:74-82` |
 | `CollectionSearchResult` | `TypedDict` | `types.py:85-90` |
 | `GalaxyDocClient` | `Protocol` | `types.py:94-120` |
 | `GalaxyClientFactory` | `Protocol` | `types.py:123-131` |
+| `ServerState` | `@dataclass` | `state.py` |
+| `SharedState` | `@dataclass` | `state.py` |
+| `SessionManager` | class | `state.py` |
+| `LifespanContext` | `TypedDict` | `state.py` |
 | `GalaxyServerConfig` | `@dataclass(frozen=True)` | `galaxy_config.py:24-35` |
 | `AnsibleKnowError` | Exception base | `errors.py:6-7` |
 | `AnsibleDocError` | Exception | `errors.py:10-11` |
@@ -268,15 +276,25 @@ AnsibleKnowError
 
 ### State Management
 
-Module-level mutable state exists in four modules. `galaxy.py` and `docs.py`
-use `BoundedCache` (introduced in PR #60) for thread-safe, bounded, TTL-aware
-caching.
+State is split into process-wide and per-session layers (PR #87):
+
+- **`SharedState`** (process-wide): `galaxy_servers`, `version_info`. Created
+  once in lifespan. `version_info` updated by periodic PyPI check.
+- **`ServerState`** (per-session): `collection_manager`, `missing_collections`,
+  `upgrade_warned`. Created lazily by `SessionManager.get_or_create()`.
+- **`SessionManager`**: manages session lifecycle with `asyncio.Lock`.
+  Accepts a `collection_factory` callable to avoid Foundation→External Access
+  imports. Provides `remove_session()` for cleanup.
+
+Module-level references `_shared_state` and `_session_manager` in `server.py`
+are write-once at lifespan startup for resource handlers (which don't receive
+`Context`).
+
+Additional module-level caches:
 
 | Module | State Variables | Thread Safety |
 |--------|----------------|---------------|
-| `server.py` | `_version_info`, `_galaxy_servers`, `_missing_collections` | `_version_info` and `_galaxy_servers` are write-once at startup (safe). `_missing_collections` is a `set` mutated from async context — documented as a negative cache but **not explicitly synchronized**. |
 | `galaxy.py` | `_version_cache`, `_blob_cache` | Thread-safe via `BoundedCache` (internal `threading.Lock`, LRU eviction, 1hr TTL) |
-| `collections.py` | `_tmp_dir`, `_installed`, `_install_locks` | Thread-safe via `threading.Lock` |
 | `docs.py` | `_manifest_cache` | Thread-safe via `BoundedCache` (max 50 entries, 1hr TTL) — **fixed in PR #60** |
 
 #### Violations
@@ -284,8 +302,8 @@ caching.
 | ID | Severity | Description | Location |
 |----|----------|-------------|----------|
 | ~~V-S1~~ | ~~Error~~ | ~~`docs.py` `_manifest_cache` is not thread-safe.~~ **Fixed in PR #60** — now uses `BoundedCache` with thread-safe locking and bounded size. | `docs.py:20` |
-| V-S2 | Warning | `server.py` `_missing_collections` is a module-level `set` mutated from async tool handlers without synchronization. While CPython's GIL provides some protection for `set.add()` and `set.discard()`, this is an implementation detail, not a contract. The negative cache semantics are now documented (PR #60) but synchronization is still missing. | `server.py:165-169` |
-| V-S3 | Warning | Module-level mutable state in 4 modules makes the server difficult to test, reset, or run multiple instances. State should be encapsulated in a server context or session object. (Partially mitigated by `BoundedCache` providing a consistent cache abstraction.) | Multiple modules |
+| ~~V-S2~~ | ~~Warning~~ | ~~`server.py` `_missing_collections` is a module-level `set` mutated from async tool handlers without synchronization.~~ **Mitigated in PR #87** — `missing_collections` is now per-session in `ServerState`. Async-only access within a session is safe (no preemption at `set.add()`/`set.discard()`). | ~~`server.py:165-169`~~ → `state.py:ServerState` |
+| ~~V-S3~~ | ~~Warning~~ | ~~Module-level mutable state makes the server difficult to test, reset, or run multiple instances.~~ **Partially resolved in PR #87** — State split into `SharedState` (process-wide) and `ServerState` (per-session) via `SessionManager`. `collections.py` still uses per-instance state (`CollectionManager` class) but is now created per-session. | ~~Multiple modules~~ → `state.py`, `server.py` |
 
 ### Validation
 
@@ -343,8 +361,8 @@ Foundation   → (no internal dependencies)
 
 ### Priority 2 (Warning-level violations)
 
-3. **V-T1**: Define a `LifespanContext` TypedDict or dataclass for the lifespan
-   context dict.
+3. ~~**V-T1**: Define a `LifespanContext` TypedDict or dataclass for the lifespan
+   context dict.~~ **Fixed in PR #87** — `LifespanContext` TypedDict in `state.py`.
 4. **V-T2**: Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()`.
 5. **V-D1**: Make `_module_to_skill_name()` public (rename to
    `module_to_skill_name()`).
@@ -357,9 +375,11 @@ Foundation   → (no internal dependencies)
 10. ~~**V-E3**: Move `_transform_to_ansible_doc_format()` to `parser.py`.~~
     **Fixed in PR #69** — now `parser.transform_galaxy_to_ansible_doc_format()`.
 11. **V-E4**: Encapsulate `collections.py` state in a `CollectionManager` class.
-12. **V-S2**: Use `asyncio.Lock` or explicit synchronization for `_missing_collections`.
-13. **V-S3**: Design a `ServerState` or session context that encapsulates all
-    mutable state.
+12. ~~**V-S2**: Use `asyncio.Lock` or explicit synchronization for
+    `_missing_collections`.~~ **Mitigated in PR #87** — now per-session.
+13. ~~**V-S3**: Design a `ServerState` or session context that encapsulates all
+    mutable state.~~ **Partially resolved in PR #87** — `SharedState` +
+    `SessionManager` with per-session `ServerState`.
 14. **V-F1**: Make `SKILLS_DIR` lazy (function or descriptor).
 
 ### Priority 3 (Info-level, PEP 8 suggestions)
@@ -367,7 +387,7 @@ Foundation   → (no internal dependencies)
 15. **V-D6 / V-F2 / V-T3**: Tighten return types from `dict[str, Any]` to
     specific `TypedDict`s where definitions exist. (Partially addressed in
     PR #60 — `EnsureCollectionResult`, `ErrorResponse`, `SkillEntry`,
-    `CollectionInfo`, `CollectionSearchResult` TypedDicts added to `types.py`,
-    and `collections.ensure_collection()` now returns `EnsureCollectionResult`.
-    Remaining tool handlers still return untyped dicts.)
+    `CollectionInfo`, `CollectionSearchResult` TypedDicts added to `types.py`.
+    Further tightened in PR #87 — `VersionInfo` TypedDict for version check
+    results. Remaining tool handlers still return untyped dicts.)
 16. Add `__all__` exports to all public modules.

--- a/src/ansible_know/cli.py
+++ b/src/ansible_know/cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import os
 from dataclasses import dataclass
+from typing import Literal
 
 __all__ = ["ServerConfig", "parse_args"]
 
@@ -21,7 +22,7 @@ _DEFAULT_PORT = 8080
 class ServerConfig:
     """Resolved server transport configuration."""
 
-    transport: str
+    transport: Literal["stdio", "http"]
     host: str
     port: int
 

--- a/src/ansible_know/collections.py
+++ b/src/ansible_know/collections.py
@@ -168,3 +168,12 @@ class CollectionManager:
     def list_installed(self) -> dict[str, str]:
         with self._locks_lock:
             return dict(self._installed)
+
+    def cleanup(self) -> None:
+        """Remove the temporary directory and reset tracked state."""
+        with self._locks_lock:
+            if self._tmp_dir is not None:
+                self._tmp_dir.cleanup()
+                self._tmp_dir = None
+            self._installed.clear()
+            self._install_locks.clear()

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -23,6 +23,7 @@ from mcp.types import ToolAnnotations
 from ansible_know.async_utils import run_in_executor
 from ansible_know.errors import AnsibleDocError, ValidationError, collection_hint, maybe_add_hint
 from ansible_know.state import LifespanContext, ServerState, SessionManager, SharedState
+from ansible_know.types import VersionInfo
 from ansible_know.validation import (
     sanitize_error,
     truncate_response,
@@ -60,7 +61,7 @@ def _parse_version(v: str) -> tuple[int, ...]:
     return tuple(int(x) for x in match.group(1).split("."))
 
 
-async def _check_pypi_version(client: httpx.AsyncClient) -> dict[str, Any] | None:
+async def _check_pypi_version(client: httpx.AsyncClient) -> VersionInfo | None:
     if os.environ.get("ANSIBLE_KNOW_SKIP_UPDATE_CHECK", "").strip() in ("1", "true", "yes"):
         return None
     try:

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -105,7 +105,7 @@ async def app_lifespan(server):
     ) as client:
         shared.version_info = await _check_pypi_version(client)
         check_task = asyncio.create_task(
-            _periodic_version_check(client, sessions)
+            _periodic_version_check(client, shared, sessions)
         )
         try:
             yield LifespanContext(
@@ -181,6 +181,7 @@ async def _maybe_warn_upgrade(ctx: Context | None) -> None:
 
 async def _periodic_version_check(
     client: httpx.AsyncClient,
+    shared: SharedState,
     sessions: SessionManager,
 ) -> None:
     """Re-check PyPI for updates periodically (non-blocking)."""
@@ -191,8 +192,8 @@ async def _periodic_version_check(
             if new_info is None:
                 continue
             old_latest = (
-                sessions._shared.version_info.get("latest")
-                if sessions._shared.version_info
+                shared.version_info.get("latest")
+                if shared.version_info
                 else None
             )
             if new_info.get("latest") != old_latest:
@@ -202,7 +203,7 @@ async def _periodic_version_check(
                     new_info.get("latest"),
                 )
             else:
-                sessions._shared.version_info = new_info
+                shared.version_info = new_info
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -145,7 +145,20 @@ async def _get_state(ctx: Context | None) -> ServerState:
     """Return per-session ServerState from ctx, or create ephemeral."""
     if ctx is not None:
         sessions: SessionManager = ctx.lifespan_context["sessions"]
-        return await sessions.get_or_create(ctx.session_id)
+        state = await sessions.get_or_create(ctx.session_id)
+        if (
+            hasattr(ctx.session, "_exit_stack")
+            and ctx.session._exit_stack is not None
+            and not getattr(ctx.session, "_ansible_know_cleanup_registered", False)
+        ):
+            session_id = ctx.session_id
+
+            async def _cleanup_session() -> None:
+                await sessions.remove_session(session_id)
+
+            ctx.session._exit_stack.push_async_callback(_cleanup_session)
+            ctx.session._ansible_know_cleanup_registered = True
+        return state
     from ansible_know.collections import CollectionManager
     return ServerState(collection_manager=CollectionManager())
 
@@ -192,7 +205,11 @@ async def _periodic_version_check(
         await asyncio.sleep(_VERSION_CHECK_INTERVAL)
         if client.is_closed:
             return
-        new_info = await _check_pypi_version(client)
+        try:
+            new_info = await _check_pypi_version(client)
+        except Exception:
+            logger.debug("Periodic version check raised unexpectedly", exc_info=True)
+            continue
         if new_info is None:
             continue
         old_latest = (
@@ -200,14 +217,12 @@ async def _periodic_version_check(
             if shared.version_info
             else None
         )
+        await sessions.on_version_update(new_info)
         if new_info.get("latest") != old_latest:
-            await sessions.on_version_update(new_info)
             logger.info(
                 "Periodic version check: new version %s available",
                 new_info.get("latest"),
             )
-        else:
-            shared.version_info = new_info
 
 
 # --- Discovery tools (read-only) ---

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -88,11 +88,12 @@ async def _check_pypi_version(client: httpx.AsyncClient) -> dict[str, Any] | Non
 @lifespan
 async def app_lifespan(server):
     global _shared_state, _session_manager
+    from ansible_know.collections import CollectionManager
     from ansible_know.galaxy_config import load_galaxy_servers
 
     galaxy_servers = await run_in_executor(load_galaxy_servers)
     shared = SharedState(galaxy_servers=galaxy_servers)
-    sessions = SessionManager(shared)
+    sessions = SessionManager(shared, collection_factory=CollectionManager)
     _shared_state = shared
     _session_manager = sessions
     for gs in galaxy_servers:

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -71,19 +71,20 @@ async def _check_pypi_version(client: httpx.AsyncClient) -> VersionInfo | None:
             headers={"Accept": "application/json"},
         )
         resp.raise_for_status()
-        latest = resp.json().get("info", {}).get("version", "")
-        if not latest or not _is_stable(latest):
-            return None
-        outdated = _parse_version(latest) > _parse_version(_VERSION)
-        return {
-            "installed": _VERSION,
-            "latest": latest,
-            "outdated": outdated,
-            "upgrade_command": "uvx --upgrade ansible-know-mcp",
-        }
-    except Exception:
+        data = resp.json()
+    except (httpx.HTTPError, ValueError):
         logger.debug("PyPI version check failed (non-blocking)")
         return None
+    latest = data.get("info", {}).get("version", "")
+    if not latest or not _is_stable(latest):
+        return None
+    outdated = _parse_version(latest) > _parse_version(_VERSION)
+    return {
+        "installed": _VERSION,
+        "latest": latest,
+        "outdated": outdated,
+        "upgrade_command": "uvx --upgrade ansible-know-mcp",
+    }
 
 
 @lifespan
@@ -189,27 +190,24 @@ async def _periodic_version_check(
     """Re-check PyPI for updates periodically (non-blocking)."""
     while True:
         await asyncio.sleep(_VERSION_CHECK_INTERVAL)
-        try:
-            new_info = await _check_pypi_version(client)
-            if new_info is None:
-                continue
-            old_latest = (
-                shared.version_info.get("latest")
-                if shared.version_info
-                else None
+        if client.is_closed:
+            return
+        new_info = await _check_pypi_version(client)
+        if new_info is None:
+            continue
+        old_latest = (
+            shared.version_info.get("latest")
+            if shared.version_info
+            else None
+        )
+        if new_info.get("latest") != old_latest:
+            await sessions.on_version_update(new_info)
+            logger.info(
+                "Periodic version check: new version %s available",
+                new_info.get("latest"),
             )
-            if new_info.get("latest") != old_latest:
-                await sessions.on_version_update(new_info)
-                logger.info(
-                    "Periodic version check: new version %s available",
-                    new_info.get("latest"),
-                )
-            else:
-                shared.version_info = new_info
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.debug("Periodic version check failed (non-blocking)")
+        else:
+            shared.version_info = new_info
 
 
 # --- Discovery tools (read-only) ---

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -7,6 +7,8 @@ via the Model Context Protocol.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -20,7 +22,7 @@ from mcp.types import ToolAnnotations
 
 from ansible_know.async_utils import run_in_executor
 from ansible_know.errors import AnsibleDocError, ValidationError, collection_hint, maybe_add_hint
-from ansible_know.state import LifespanContext, ServerState
+from ansible_know.state import LifespanContext, ServerState, SessionManager, SharedState
 from ansible_know.validation import (
     sanitize_error,
     truncate_response,
@@ -38,10 +40,11 @@ logger = logging.getLogger("ansible_know")
 
 _VERSION = pkg_version("ansible-know-mcp")
 
-# Module-level reference for resource functions that don't receive FastMCP
-# Context. Set once in lifespan; consolidates the former _version_info and
-# _galaxy_servers globals into a single typed object.
-_server_state: ServerState | None = None
+_VERSION_CHECK_INTERVAL = 6 * 3600  # 6 hours
+
+# Module-level references for resource functions (no FastMCP Context).
+_shared_state: SharedState | None = None
+_session_manager: SessionManager | None = None
 
 
 def _is_stable(v: str) -> bool:
@@ -84,16 +87,14 @@ async def _check_pypi_version(client: httpx.AsyncClient) -> dict[str, Any] | Non
 
 @lifespan
 async def app_lifespan(server):
-    global _server_state
-    from ansible_know.collections import CollectionManager
+    global _shared_state, _session_manager
     from ansible_know.galaxy_config import load_galaxy_servers
 
     galaxy_servers = await run_in_executor(load_galaxy_servers)
-    state = ServerState(
-        collection_manager=CollectionManager(),
-        galaxy_servers=galaxy_servers,
-    )
-    _server_state = state
+    shared = SharedState(galaxy_servers=galaxy_servers)
+    sessions = SessionManager(shared)
+    _shared_state = shared
+    _session_manager = sessions
     for gs in galaxy_servers:
         auth_type = "token" if gs.token else ("basic" if gs.username else "none")
         logger.info("Galaxy server: %s (%s, auth=%s)", gs.name, gs.url, auth_type)
@@ -102,8 +103,18 @@ async def app_lifespan(server):
         timeout=httpx.Timeout(10.0, read=120.0),
         verify=True,
     ) as client:
-        state.version_info = await _check_pypi_version(client)
-        yield LifespanContext(http_client=client, state=state)
+        shared.version_info = await _check_pypi_version(client)
+        check_task = asyncio.create_task(
+            _periodic_version_check(client, sessions)
+        )
+        try:
+            yield LifespanContext(
+                http_client=client, shared=shared, sessions=sessions,
+            )
+        finally:
+            check_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await check_task
 
 mcp = FastMCP(
     name="Ansible Know",
@@ -127,14 +138,22 @@ def _galaxy_factory():
     return GalaxyClient.from_config
 
 
-def _get_state(ctx: Context | None) -> ServerState:
-    """Return ServerState from ctx, fall back to module-level, or create ephemeral."""
+async def _get_state(ctx: Context | None) -> ServerState:
+    """Return per-session ServerState from ctx, or create ephemeral."""
     if ctx is not None:
-        return ctx.lifespan_context["state"]
-    if _server_state is not None:
-        return _server_state
+        sessions: SessionManager = ctx.lifespan_context["sessions"]
+        return await sessions.get_or_create(ctx.session_id)
     from ansible_know.collections import CollectionManager
     return ServerState(collection_manager=CollectionManager())
+
+
+def _get_shared(ctx: Context | None) -> SharedState:
+    """Return process-wide SharedState from ctx or module-level."""
+    if ctx is not None:
+        return ctx.lifespan_context["shared"]
+    if _shared_state is not None:
+        return _shared_state
+    return SharedState()
 
 
 def _get_http_client(ctx: Context | None) -> httpx.AsyncClient | None:
@@ -147,16 +166,47 @@ def _get_http_client(ctx: Context | None) -> httpx.AsyncClient | None:
 async def _maybe_warn_upgrade(ctx: Context | None) -> None:
     if ctx is None:
         return
-    state = _get_state(ctx)
-    if state.upgrade_warned or not state.version_info or not state.version_info.get("outdated"):
+    state = await _get_state(ctx)
+    shared = _get_shared(ctx)
+    version_info = shared.version_info
+    if state.upgrade_warned or not version_info or not version_info.get("outdated"):
         return
-    info = state.version_info
     await ctx.warning(
-        f"ansible-know-mcp {info['installed']} is outdated; "
-        f"latest is {info['latest']}. "
-        f"Upgrade: {info['upgrade_command']}"
+        f"ansible-know-mcp {version_info['installed']} is outdated; "
+        f"latest is {version_info['latest']}. "
+        f"Upgrade: {version_info['upgrade_command']}"
     )
     state.upgrade_warned = True
+
+
+async def _periodic_version_check(
+    client: httpx.AsyncClient,
+    sessions: SessionManager,
+) -> None:
+    """Re-check PyPI for updates periodically (non-blocking)."""
+    while True:
+        await asyncio.sleep(_VERSION_CHECK_INTERVAL)
+        try:
+            new_info = await _check_pypi_version(client)
+            if new_info is None:
+                continue
+            old_latest = (
+                sessions._shared.version_info.get("latest")
+                if sessions._shared.version_info
+                else None
+            )
+            if new_info.get("latest") != old_latest:
+                await sessions.on_version_update(new_info)
+                logger.info(
+                    "Periodic version check: new version %s available",
+                    new_info.get("latest"),
+                )
+            else:
+                sessions._shared.version_info = new_info
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug("Periodic version check failed (non-blocking)")
 
 
 # --- Discovery tools (read-only) ---
@@ -184,7 +234,7 @@ async def search_modules(
         from ansible_know import parser
         from ansible_know.config import SEARCH_MODULES_LIMIT
 
-        state = _get_state(ctx)
+        state = await _get_state(ctx)
         results = await run_in_executor(
             parser.search_modules, keyword, collection_filter=namespace,
             collections_path=state.collection_manager.get_collections_path(),
@@ -220,7 +270,7 @@ async def get_module_doc(
     try:
         from ansible_know import parser, resolution
 
-        state = _get_state(ctx)
+        state = await _get_state(ctx)
         http_client = _get_http_client(ctx)
         raw_doc, galaxy_meta = await resolution.resolve_module_doc(
             module_name, http_client=http_client, galaxy_servers=state.galaxy_servers,
@@ -268,7 +318,7 @@ async def get_role_doc(
     try:
         from ansible_know import resolution
 
-        state = _get_state(ctx)
+        state = await _get_state(ctx)
         http_client = _get_http_client(ctx)
         return await resolution.resolve_role_doc(
             role_name, http_client=http_client, galaxy_servers=state.galaxy_servers,
@@ -344,7 +394,7 @@ async def search_collections(
     try:
         from ansible_know import resolution
 
-        state = _get_state(ctx)
+        state = await _get_state(ctx)
         http_client = _get_http_client(ctx)
         return await resolution.search_galaxy_collections(
             query, tags=tags, http_client=http_client, galaxy_servers=state.galaxy_servers,
@@ -376,7 +426,7 @@ async def get_collection_manifest(
     try:
         from ansible_know import collection_manifest, parser
 
-        state = _get_state(ctx)
+        state = await _get_state(ctx)
         installed_version = state.collection_manager.list_installed().get(collection_namespace)
         cached = collection_manifest.load_cached_manifest(
             collection_namespace, installed_version=installed_version,
@@ -473,7 +523,7 @@ async def ensure_collection(
         return {"error": str(exc)}
 
     try:
-        state = _get_state(ctx)
+        state = await _get_state(ctx)
         result = await run_in_executor(
             state.collection_manager.ensure_collection, collection_fqcn=collection_namespace, version=version,
         )
@@ -582,7 +632,7 @@ async def generate_skill(
         if ctx:
             await ctx.report_progress(progress=0, total=100)
 
-        state = _get_state(ctx)
+        state = await _get_state(ctx)
         http_client = _get_http_client(ctx)
         raw_doc, galaxy_meta = await resolution.resolve_module_doc(
             module_name, http_client=http_client, galaxy_servers=state.galaxy_servers,
@@ -646,7 +696,7 @@ async def generate_role_skill(
         if ctx:
             await ctx.report_progress(progress=0, total=100)
 
-        state = _get_state(ctx)
+        state = await _get_state(ctx)
         http_client = _get_http_client(ctx)
         metadata = await resolution.resolve_role_doc(
             role_name, http_client=http_client, galaxy_servers=state.galaxy_servers,
@@ -704,7 +754,7 @@ async def generate_collection_skills(
         from ansible_know import collection_manifest, parser, skills
         from ansible_know.config import SKILLS_DIR
 
-        state = _get_state(ctx)
+        state = await _get_state(ctx)
         cpath = state.collection_manager.get_collections_path()
         modules = await run_in_executor(
             parser.search_modules, "", collection_filter=collection_namespace,
@@ -807,10 +857,10 @@ def resource_skill_content(skill_name: str) -> str:
 @mcp.resource(
     "galaxy://installed",
     name="Installed Collections",
-    description="List collections installed in this session via ensure_collection",
+    description="List collections installed across all active sessions",
 )
 def resource_installed_collections() -> str:
-    installed = _server_state.collection_manager.list_installed() if _server_state else {}
+    installed = _session_manager.all_installed_collections if _session_manager else {}
     return json.dumps(installed, indent=2)
 
 
@@ -820,7 +870,7 @@ def resource_installed_collections() -> str:
     description="Installed and latest version info with upgrade status",
 )
 def resource_server_version() -> str:
-    version_info = _server_state.version_info if _server_state else None
+    version_info = _shared_state.version_info if _shared_state else None
     if version_info:
         return json.dumps(version_info, indent=2)
     return json.dumps(
@@ -845,7 +895,7 @@ def resource_server_version() -> str:
 def resource_galaxy_servers() -> str:
     from ansible_know.galaxy_config import load_galaxy_servers
 
-    servers = (_server_state.galaxy_servers if _server_state else None) or load_galaxy_servers()
+    servers = (_shared_state.galaxy_servers if _shared_state else None) or load_galaxy_servers()
     return json.dumps([
         {
             "name": s.name,

--- a/src/ansible_know/state.py
+++ b/src/ansible_know/state.py
@@ -51,8 +51,11 @@ class ServerState:
 class SharedState:
     """Process-wide state shared across all sessions.
 
-    Created once at lifespan startup. Read-only except for
-    ``version_info`` which is updated by the periodic check.
+    Created once at lifespan startup. ``galaxy_servers`` is write-once:
+    set at lifespan startup, never mutated thereafter. Per-session
+    ``ServerState`` references the same list object for zero-copy reads.
+    ``version_info`` is updated by the periodic check via
+    ``SessionManager.on_version_update()``.
     """
 
     galaxy_servers: list[GalaxyServerConfig] = field(default_factory=list)
@@ -90,6 +93,8 @@ class SessionManager:
             return existing
         async with self._lock:
             if session_id not in self._sessions:
+                # galaxy_servers is a shared reference (write-once list);
+                # see SharedState docstring for the invariant.
                 self._sessions[session_id] = ServerState(
                     collection_manager=self._collection_factory(),
                     galaxy_servers=self._shared.galaxy_servers,

--- a/src/ansible_know/state.py
+++ b/src/ansible_know/state.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, TypedDict
 
@@ -64,29 +65,46 @@ class SessionManager:
     Uses ``asyncio.Lock`` for coroutine-safe access.  Each session
     gets its own ``CollectionManager``, ``missing_collections`` set,
     and ``upgrade_warned`` flag.
+
+    The ``collection_factory`` callable is injected by the caller
+    (Orchestration layer) so this Foundation-layer module never
+    imports External Access modules at runtime.
     """
 
-    def __init__(self, shared: SharedState) -> None:
+    def __init__(
+        self,
+        shared: SharedState,
+        collection_factory: Callable[[], CollectionManager],
+    ) -> None:
         self._shared = shared
+        self._collection_factory = collection_factory
         self._sessions: dict[str, ServerState] = {}
         self._lock = asyncio.Lock()
 
     async def get_or_create(self, session_id: str) -> ServerState:
         """Return existing session state or create a new one."""
+        # Fast path: dict.get() is atomic in single-threaded asyncio
+        # (no await between read and lock acquisition).
         existing = self._sessions.get(session_id)
         if existing is not None:
             return existing
         async with self._lock:
             if session_id not in self._sessions:
-                from ansible_know.collections import CollectionManager
-
                 self._sessions[session_id] = ServerState(
-                    collection_manager=CollectionManager(),
+                    collection_manager=self._collection_factory(),
                     galaxy_servers=self._shared.galaxy_servers,
                     version_info=self._shared.version_info,
                 )
                 logger.debug("Created session state for %s", session_id)
             return self._sessions[session_id]
+
+    async def remove_session(self, session_id: str) -> None:
+        """Remove a session and clean up its resources."""
+        async with self._lock:
+            state = self._sessions.pop(session_id, None)
+        if state is not None:
+            state.collection_manager.cleanup()
+            logger.debug("Removed session state for %s", session_id)
 
     async def on_version_update(self, new_info: dict[str, Any] | None) -> None:
         """Update version info and reset upgrade_warned for all sessions."""
@@ -104,7 +122,11 @@ class SessionManager:
 
     @property
     def all_installed_collections(self) -> dict[str, str]:
-        """Union of installed collections across all sessions."""
+        """Union of installed collections across all sessions.
+
+        Lockless read: safe in single-threaded asyncio (no await
+        between ``list()`` copy and iteration).
+        """
         result: dict[str, str] = {}
         for session in list(self._sessions.values()):
             result.update(session.collection_manager.list_installed())

--- a/src/ansible_know/state.py
+++ b/src/ansible_know/state.py
@@ -6,6 +6,8 @@ or Orchestration. CollectionManager is imported under TYPE_CHECKING only.
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, TypedDict
 
@@ -15,15 +17,22 @@ if TYPE_CHECKING:
     from ansible_know.collections import CollectionManager
     from ansible_know.galaxy_config import GalaxyServerConfig
 
-__all__ = ["LifespanContext", "ServerState"]
+__all__ = [
+    "LifespanContext",
+    "ServerState",
+    "SessionManager",
+    "SharedState",
+]
+
+logger = logging.getLogger("ansible_know")
 
 
 @dataclass
 class ServerState:
-    """All mutable runtime state for one server process.
+    """Per-session mutable state.
 
-    Created once in lifespan, stored in LifespanContext,
-    accessed by tool handlers via _get_state(ctx).
+    Each MCP session gets its own instance via SessionManager.
+    Tool handlers access it via ``await _get_state(ctx)``.
     """
 
     collection_manager: CollectionManager
@@ -37,8 +46,69 @@ class ServerState:
         self.missing_collections.discard(namespace)
 
 
+@dataclass
+class SharedState:
+    """Process-wide state shared across all sessions.
+
+    Created once at lifespan startup. Read-only except for
+    ``version_info`` which is updated by the periodic check.
+    """
+
+    galaxy_servers: list[GalaxyServerConfig] = field(default_factory=list)
+    version_info: dict[str, Any] | None = None
+
+
+class SessionManager:
+    """Creates and tracks per-session ServerState instances.
+
+    Uses ``asyncio.Lock`` for coroutine-safe access.  Each session
+    gets its own ``CollectionManager``, ``missing_collections`` set,
+    and ``upgrade_warned`` flag.
+    """
+
+    def __init__(self, shared: SharedState) -> None:
+        self._shared = shared
+        self._sessions: dict[str, ServerState] = {}
+        self._lock = asyncio.Lock()
+
+    async def get_or_create(self, session_id: str) -> ServerState:
+        """Return existing session state or create a new one."""
+        existing = self._sessions.get(session_id)
+        if existing is not None:
+            return existing
+        async with self._lock:
+            if session_id not in self._sessions:
+                from ansible_know.collections import CollectionManager
+
+                self._sessions[session_id] = ServerState(
+                    collection_manager=CollectionManager(),
+                    galaxy_servers=self._shared.galaxy_servers,
+                    version_info=self._shared.version_info,
+                )
+                logger.debug("Created session state for %s", session_id)
+            return self._sessions[session_id]
+
+    async def on_version_update(self, new_info: dict[str, Any] | None) -> None:
+        """Update version info and reset upgrade_warned for all sessions."""
+        async with self._lock:
+            self._shared.version_info = new_info
+            for session in self._sessions.values():
+                session.version_info = new_info
+                if new_info and new_info.get("outdated"):
+                    session.upgrade_warned = False
+
+    @property
+    def all_installed_collections(self) -> dict[str, str]:
+        """Union of installed collections across all sessions."""
+        result: dict[str, str] = {}
+        for session in self._sessions.values():
+            result.update(session.collection_manager.list_installed())
+        return result
+
+
 class LifespanContext(TypedDict):
-    """Typed lifespan context replacing the untyped dict."""
+    """Typed lifespan context for tool and resource access."""
 
     http_client: httpx.AsyncClient
-    state: ServerState
+    shared: SharedState
+    sessions: SessionManager

--- a/src/ansible_know/state.py
+++ b/src/ansible_know/state.py
@@ -10,13 +10,14 @@ import asyncio
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
     import httpx
 
     from ansible_know.collections import CollectionManager
     from ansible_know.galaxy_config import GalaxyServerConfig
+    from ansible_know.types import VersionInfo
 
 __all__ = [
     "LifespanContext",
@@ -38,7 +39,6 @@ class ServerState:
 
     collection_manager: CollectionManager
     missing_collections: set[str] = field(default_factory=set)
-    version_info: dict[str, Any] | None = None
     galaxy_servers: list[GalaxyServerConfig] = field(default_factory=list)
     upgrade_warned: bool = False
 
@@ -56,7 +56,7 @@ class SharedState:
     """
 
     galaxy_servers: list[GalaxyServerConfig] = field(default_factory=list)
-    version_info: dict[str, Any] | None = None
+    version_info: VersionInfo | None = None
 
 
 class SessionManager:
@@ -93,7 +93,6 @@ class SessionManager:
                 self._sessions[session_id] = ServerState(
                     collection_manager=self._collection_factory(),
                     galaxy_servers=self._shared.galaxy_servers,
-                    version_info=self._shared.version_info,
                 )
                 logger.debug("Created session state for %s", session_id)
             return self._sessions[session_id]
@@ -106,13 +105,12 @@ class SessionManager:
             state.collection_manager.cleanup()
             logger.debug("Removed session state for %s", session_id)
 
-    async def on_version_update(self, new_info: dict[str, Any] | None) -> None:
+    async def on_version_update(self, new_info: VersionInfo | None) -> None:
         """Update version info and reset upgrade_warned for all sessions."""
         async with self._lock:
             self._shared.version_info = new_info
-            for session in self._sessions.values():
-                session.version_info = new_info
-                if new_info and new_info.get("outdated"):
+            if new_info and new_info.get("outdated"):
+                for session in self._sessions.values():
                     session.upgrade_warned = False
 
     @property

--- a/src/ansible_know/state.py
+++ b/src/ansible_know/state.py
@@ -98,10 +98,15 @@ class SessionManager:
                     session.upgrade_warned = False
 
     @property
+    def shared(self) -> SharedState:
+        """Read-only access to the process-wide shared state."""
+        return self._shared
+
+    @property
     def all_installed_collections(self) -> dict[str, str]:
         """Union of installed collections across all sessions."""
         result: dict[str, str] = {}
-        for session in self._sessions.values():
+        for session in list(self._sessions.values()):
             result.update(session.collection_manager.list_installed())
         return result
 

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -40,6 +40,15 @@ class DocProvenance(_DocProvenanceBase, total=False):
     doc_source_server: str
 
 
+class VersionInfo(TypedDict):
+    """Version check result from PyPI."""
+
+    installed: str
+    latest: str
+    outdated: bool
+    upgrade_command: str
+
+
 class ErrorResponse(TypedDict):
     """Standard error shape returned by all tools on failure."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1336,13 +1336,10 @@ class TestPeriodicVersionCheck:
         mock_client.is_closed = False
         with patch("ansible_know.server._check_pypi_version", return_value=same_info):
             with patch("asyncio.sleep", side_effect=fake_sleep):
-                with patch.object(sessions, "on_version_update", new_callable=AsyncMock) as mock_update:
-                    with pytest.raises(asyncio.CancelledError):
-                        await _periodic_version_check(mock_client, shared, sessions)
+                with pytest.raises(asyncio.CancelledError):
+                    await _periodic_version_check(mock_client, shared, sessions)
 
-        # Same version: on_version_update should NOT be called
-        mock_update.assert_not_called()
-        # But shared.version_info should still be refreshed
+        # Same version: on_version_update is called but upgrade_warned not reset
         assert shared.version_info["latest"] == "0.3.0"
 
     @pytest.mark.asyncio
@@ -1363,6 +1360,34 @@ class TestPeriodicVersionCheck:
         with patch("asyncio.sleep", side_effect=fake_sleep):
             await _periodic_version_check(mock_client, shared, sessions)
 
+        assert shared.version_info["latest"] == "0.3.0"
+
+    @pytest.mark.asyncio
+    async def test_survives_unexpected_exception(self):
+        from ansible_know.collections import CollectionManager
+        from ansible_know.server import _periodic_version_check
+        from ansible_know.state import SessionManager, SharedState
+
+        shared = SharedState(version_info={"installed": "0.3.0", "latest": "0.3.0", "outdated": False})
+        sessions = SessionManager(shared, collection_factory=CollectionManager)
+
+        call_count = 0
+
+        async def fake_sleep(_):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 2:
+                raise asyncio.CancelledError
+
+        mock_client = MagicMock()
+        mock_client.is_closed = False
+        with patch("ansible_know.server._check_pypi_version", side_effect=RuntimeError("boom")):
+            with patch("asyncio.sleep", side_effect=fake_sleep):
+                with pytest.raises(asyncio.CancelledError):
+                    await _periodic_version_check(mock_client, shared, sessions)
+
+        # Loop survived the exception and ran again (call_count > 2)
+        assert call_count > 2
         assert shared.version_info["latest"] == "0.3.0"
 
 
@@ -1415,3 +1440,45 @@ class TestGetStateSessionIsolation:
         # Each call returns a new ephemeral instance
         state_2 = await _get_state(None)
         assert state is not state_2
+
+    @pytest.mark.asyncio
+    async def test_registers_cleanup_on_session_exit_stack(self):
+        from ansible_know.collections import CollectionManager
+        from ansible_know.server import _get_state
+        from ansible_know.state import SessionManager, SharedState
+
+        shared = SharedState()
+        sessions = SessionManager(shared, collection_factory=CollectionManager)
+
+        mock_exit_stack = MagicMock()
+        ctx = MagicMock()
+        ctx.lifespan_context = {"shared": shared, "sessions": sessions, "http_client": None}
+        ctx.session_id = "session-cleanup"
+        ctx.session._exit_stack = mock_exit_stack
+        ctx.session._ansible_know_cleanup_registered = False
+
+        await _get_state(ctx)
+
+        mock_exit_stack.push_async_callback.assert_called_once()
+        assert ctx.session._ansible_know_cleanup_registered is True
+
+    @pytest.mark.asyncio
+    async def test_cleanup_not_registered_twice(self):
+        from ansible_know.collections import CollectionManager
+        from ansible_know.server import _get_state
+        from ansible_know.state import SessionManager, SharedState
+
+        shared = SharedState()
+        sessions = SessionManager(shared, collection_factory=CollectionManager)
+
+        mock_exit_stack = MagicMock()
+        ctx = MagicMock()
+        ctx.lifespan_context = {"shared": shared, "sessions": sessions, "http_client": None}
+        ctx.session_id = "session-once"
+        ctx.session._exit_stack = mock_exit_stack
+        ctx.session._ansible_know_cleanup_registered = False
+
+        await _get_state(ctx)
+        await _get_state(ctx)
+
+        mock_exit_stack.push_async_callback.assert_called_once()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 """Tests for ansible_know.server MCP tools."""
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -12,6 +13,21 @@ from tests.conftest import (
     SAMPLE_ROLE_DOC,
     SAMPLE_ROLE_LIST,
 )
+
+
+def _make_mock_ctx(state, shared, http_client=None):
+    """Build a mock FastMCP Context with session-based state."""
+    mock_ctx = MagicMock()
+    sessions = MagicMock()
+    sessions.get_or_create = AsyncMock(return_value=state)
+    mock_ctx.lifespan_context = {
+        "shared": shared,
+        "sessions": sessions,
+        "http_client": http_client,
+    }
+    mock_ctx.session_id = "test-session"
+    mock_ctx.warning = AsyncMock()
+    return mock_ctx
 
 
 @pytest.fixture
@@ -556,32 +572,29 @@ class TestResourceFunctions:
 
     def test_resource_installed_collections_empty(self):
         import ansible_know.server as srv
-        from ansible_know.collections import CollectionManager
-        from ansible_know.state import ServerState
+        from ansible_know.state import SessionManager, SharedState
 
-        state = ServerState(collection_manager=CollectionManager())
-        old = srv._server_state
+        shared = SharedState()
+        sessions = SessionManager(shared)
+        old = srv._session_manager
         try:
-            srv._server_state = state
+            srv._session_manager = sessions
             result = json.loads(srv.resource_installed_collections())
         finally:
-            srv._server_state = old
+            srv._session_manager = old
         assert result == {}
 
     def test_resource_installed_collections_with_data(self):
         import ansible_know.server as srv
-        from ansible_know.collections import CollectionManager
-        from ansible_know.state import ServerState
 
-        cm = CollectionManager()
-        state = ServerState(collection_manager=cm)
-        old = srv._server_state
+        mock_manager = MagicMock()
+        mock_manager.all_installed_collections = {"netbox.netbox": "4.1.0", "ansible.utils": "5.0.0"}
+        old = srv._session_manager
         try:
-            srv._server_state = state
-            with patch.object(cm, "list_installed", return_value={"netbox.netbox": "4.1.0", "ansible.utils": "5.0.0"}):
-                result = json.loads(srv.resource_installed_collections())
+            srv._session_manager = mock_manager
+            result = json.loads(srv.resource_installed_collections())
         finally:
-            srv._server_state = old
+            srv._session_manager = old
         assert result == {"netbox.netbox": "4.1.0", "ansible.utils": "5.0.0"}
 
     def test_resource_doc_sources(self):
@@ -762,18 +775,15 @@ class TestMaybeWarnUpgrade:
     async def test_warns_when_outdated(self):
         from ansible_know.collections import CollectionManager
         from ansible_know.server import _maybe_warn_upgrade
-        from ansible_know.state import ServerState
+        from ansible_know.state import ServerState, SharedState
 
-        state = ServerState(
-            collection_manager=CollectionManager(),
-            version_info={
-                "installed": "0.3.2", "latest": "0.4.0",
-                "outdated": True, "upgrade_command": "uvx --upgrade ansible-know-mcp",
-            },
-        )
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"state": state, "http_client": None}
-        mock_ctx.warning = AsyncMock()
+        version_info = {
+            "installed": "0.3.2", "latest": "0.4.0",
+            "outdated": True, "upgrade_command": "uvx --upgrade ansible-know-mcp",
+        }
+        state = ServerState(collection_manager=CollectionManager())
+        shared = SharedState(version_info=version_info)
+        mock_ctx = _make_mock_ctx(state, shared)
 
         await _maybe_warn_upgrade(mock_ctx)
         mock_ctx.warning.assert_called_once()
@@ -784,18 +794,15 @@ class TestMaybeWarnUpgrade:
     async def test_warns_only_once(self):
         from ansible_know.collections import CollectionManager
         from ansible_know.server import _maybe_warn_upgrade
-        from ansible_know.state import ServerState
+        from ansible_know.state import ServerState, SharedState
 
-        state = ServerState(
-            collection_manager=CollectionManager(),
-            version_info={
-                "installed": "0.3.2", "latest": "0.4.0",
-                "outdated": True, "upgrade_command": "uvx --upgrade ansible-know-mcp",
-            },
-        )
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"state": state, "http_client": None}
-        mock_ctx.warning = AsyncMock()
+        version_info = {
+            "installed": "0.3.2", "latest": "0.4.0",
+            "outdated": True, "upgrade_command": "uvx --upgrade ansible-know-mcp",
+        }
+        state = ServerState(collection_manager=CollectionManager())
+        shared = SharedState(version_info=version_info)
+        mock_ctx = _make_mock_ctx(state, shared)
 
         await _maybe_warn_upgrade(mock_ctx)
         await _maybe_warn_upgrade(mock_ctx)
@@ -805,18 +812,15 @@ class TestMaybeWarnUpgrade:
     async def test_no_warn_when_current(self):
         from ansible_know.collections import CollectionManager
         from ansible_know.server import _maybe_warn_upgrade
-        from ansible_know.state import ServerState
+        from ansible_know.state import ServerState, SharedState
 
-        state = ServerState(
-            collection_manager=CollectionManager(),
-            version_info={
-                "installed": "0.3.2", "latest": "0.3.2",
-                "outdated": False, "upgrade_command": "uvx --upgrade ansible-know-mcp",
-            },
-        )
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"state": state, "http_client": None}
-        mock_ctx.warning = AsyncMock()
+        version_info = {
+            "installed": "0.3.2", "latest": "0.3.2",
+            "outdated": False, "upgrade_command": "uvx --upgrade ansible-know-mcp",
+        }
+        state = ServerState(collection_manager=CollectionManager())
+        shared = SharedState(version_info=version_info)
+        mock_ctx = _make_mock_ctx(state, shared)
 
         await _maybe_warn_upgrade(mock_ctx)
         mock_ctx.warning.assert_not_called()
@@ -825,15 +829,11 @@ class TestMaybeWarnUpgrade:
     async def test_no_warn_when_check_failed(self):
         from ansible_know.collections import CollectionManager
         from ansible_know.server import _maybe_warn_upgrade
-        from ansible_know.state import ServerState
+        from ansible_know.state import ServerState, SharedState
 
-        state = ServerState(
-            collection_manager=CollectionManager(),
-            version_info=None,
-        )
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"state": state, "http_client": None}
-        mock_ctx.warning = AsyncMock()
+        state = ServerState(collection_manager=CollectionManager())
+        shared = SharedState(version_info=None)
+        mock_ctx = _make_mock_ctx(state, shared)
 
         await _maybe_warn_upgrade(mock_ctx)
         mock_ctx.warning.assert_not_called()
@@ -847,27 +847,24 @@ class TestMaybeWarnUpgrade:
 class TestServerVersionResource:
     def test_returns_installed_version_without_pypi_check(self):
         import ansible_know.server as srv
-        from ansible_know.collections import CollectionManager
-        from ansible_know.state import ServerState
+        from ansible_know.state import SharedState
 
-        state = ServerState(collection_manager=CollectionManager())
-        old = srv._server_state
+        shared = SharedState()
+        old = srv._shared_state
         try:
-            srv._server_state = state
+            srv._shared_state = shared
             result = json.loads(srv.resource_server_version())
             assert result["installed"] == srv._VERSION
             assert result["latest"] is None
             assert result["outdated"] is None
         finally:
-            srv._server_state = old
+            srv._shared_state = old
 
     def test_returns_pypi_info_when_available(self):
         import ansible_know.server as srv
-        from ansible_know.collections import CollectionManager
-        from ansible_know.state import ServerState
+        from ansible_know.state import SharedState
 
-        state = ServerState(
-            collection_manager=CollectionManager(),
+        shared = SharedState(
             version_info={
                 "installed": "0.3.2",
                 "latest": "0.4.0",
@@ -875,15 +872,15 @@ class TestServerVersionResource:
                 "upgrade_command": "uvx --upgrade ansible-know-mcp",
             },
         )
-        old = srv._server_state
+        old = srv._shared_state
         try:
-            srv._server_state = state
+            srv._shared_state = shared
             result = json.loads(srv.resource_server_version())
             assert result["installed"] == "0.3.2"
             assert result["latest"] == "0.4.0"
             assert result["outdated"] is True
         finally:
-            srv._server_state = old
+            srv._shared_state = old
 
 
 class TestSearchCollectionsTool:
@@ -957,13 +954,13 @@ class TestLifespanHttpClient:
     @pytest.mark.asyncio
     async def test_get_module_doc_passes_lifespan_http_client(self, mock_ansible_doc):
         from ansible_know.collections import CollectionManager
-        from ansible_know.state import ServerState
+        from ansible_know.state import ServerState, SharedState
 
         mock_ansible_doc.return_value = json.dumps(SAMPLE_MODULE_DOC)
         mock_client = AsyncMock()
         state = ServerState(collection_manager=CollectionManager())
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"http_client": mock_client, "state": state}
+        shared = SharedState()
+        mock_ctx = _make_mock_ctx(state, shared, http_client=mock_client)
 
         with patch("ansible_know.resolution.resolve_module_doc") as mock_resolve:
             mock_resolve.return_value = (SAMPLE_MODULE_DOC, None)
@@ -979,12 +976,12 @@ class TestLifespanHttpClient:
     @pytest.mark.asyncio
     async def test_search_collections_passes_lifespan_http_client(self):
         from ansible_know.collections import CollectionManager
-        from ansible_know.state import ServerState
+        from ansible_know.state import ServerState, SharedState
 
         mock_client = AsyncMock()
         state = ServerState(collection_manager=CollectionManager())
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"http_client": mock_client, "state": state}
+        shared = SharedState()
+        mock_ctx = _make_mock_ctx(state, shared, http_client=mock_client)
 
         mock_result = {"query": "test", "count": 0, "collections": []}
         with patch("ansible_know.galaxy.GalaxyClient.from_config") as mock_from_config:
@@ -1002,7 +999,7 @@ class TestLifespanHttpClient:
     async def test_validate_certs_false_skips_shared_client(self):
         from ansible_know.collections import CollectionManager
         from ansible_know.galaxy_config import GalaxyServerConfig
-        from ansible_know.state import ServerState
+        from ansible_know.state import ServerState, SharedState
 
         mock_client = AsyncMock()
         server = GalaxyServerConfig(
@@ -1015,8 +1012,8 @@ class TestLifespanHttpClient:
             collection_manager=CollectionManager(),
             galaxy_servers=[server],
         )
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"http_client": mock_client, "state": state}
+        shared = SharedState()
+        mock_ctx = _make_mock_ctx(state, shared, http_client=mock_client)
 
         mock_result = {"query": "test", "count": 0, "collections": []}
         with patch("ansible_know.galaxy.GalaxyClient.from_config") as mock_from_config:
@@ -1034,7 +1031,7 @@ class TestLifespanHttpClient:
     async def test_validate_certs_true_uses_shared_client(self):
         from ansible_know.collections import CollectionManager
         from ansible_know.galaxy_config import GalaxyServerConfig
-        from ansible_know.state import ServerState
+        from ansible_know.state import ServerState, SharedState
 
         mock_client = AsyncMock()
         server = GalaxyServerConfig(
@@ -1046,8 +1043,8 @@ class TestLifespanHttpClient:
             collection_manager=CollectionManager(),
             galaxy_servers=[server],
         )
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"http_client": mock_client, "state": state}
+        shared = SharedState()
+        mock_ctx = _make_mock_ctx(state, shared, http_client=mock_client)
 
         mock_result = {"query": "test", "count": 0, "collections": []}
         with patch("ansible_know.galaxy.GalaxyClient.from_config") as mock_from_config:
@@ -1128,14 +1125,12 @@ class TestGetRoleDocTool:
     @pytest.mark.asyncio
     async def test_cached_missing_collection_skips_local(self, mock_ansible_doc):
         from ansible_know.collections import CollectionManager
-        from ansible_know.state import ServerState
+        from ansible_know.state import ServerState, SharedState
 
         state = ServerState(collection_manager=CollectionManager())
         state.missing_collections.add("some.col")
-
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"state": state, "http_client": None}
-        mock_ctx.warning = AsyncMock()
+        shared = SharedState()
+        mock_ctx = _make_mock_ctx(state, shared)
 
         galaxy_role_meta = {
             "role_name": "some.col.role",
@@ -1261,3 +1256,130 @@ class TestGetCollectionManifestWithRoles:
             from ansible_know.server import search_collections
             result = await search_collections("linux")
         assert result["collections"][0]["role_count"] == 43
+
+
+class TestPeriodicVersionCheck:
+    @pytest.mark.asyncio
+    async def test_updates_version_on_new_release(self):
+        from ansible_know.server import _periodic_version_check
+        from ansible_know.state import SessionManager, SharedState
+
+        shared = SharedState(version_info={"installed": "0.3.0", "latest": "0.3.0", "outdated": False})
+        sessions = SessionManager(shared)
+        new_info = {"installed": "0.3.0", "latest": "0.4.0", "outdated": True}
+
+        call_count = 0
+
+        async def fake_sleep(_):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise asyncio.CancelledError
+
+        with patch("ansible_know.server._check_pypi_version", return_value=new_info):
+            with patch("asyncio.sleep", side_effect=fake_sleep):
+                with pytest.raises(asyncio.CancelledError):
+                    await _periodic_version_check(AsyncMock(), sessions)
+
+        assert shared.version_info["latest"] == "0.4.0"
+
+    @pytest.mark.asyncio
+    async def test_skips_when_check_returns_none(self):
+        from ansible_know.server import _periodic_version_check
+        from ansible_know.state import SessionManager, SharedState
+
+        shared = SharedState(version_info={"installed": "0.3.0", "latest": "0.3.0", "outdated": False})
+        sessions = SessionManager(shared)
+
+        call_count = 0
+
+        async def fake_sleep(_):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise asyncio.CancelledError
+
+        with patch("ansible_know.server._check_pypi_version", return_value=None):
+            with patch("asyncio.sleep", side_effect=fake_sleep):
+                with pytest.raises(asyncio.CancelledError):
+                    await _periodic_version_check(AsyncMock(), sessions)
+
+        # version_info unchanged when check returns None
+        assert shared.version_info["latest"] == "0.3.0"
+
+    @pytest.mark.asyncio
+    async def test_no_update_when_same_version(self):
+        from ansible_know.server import _periodic_version_check
+        from ansible_know.state import SessionManager, SharedState
+
+        shared = SharedState(version_info={"installed": "0.3.0", "latest": "0.3.0", "outdated": False})
+        sessions = SessionManager(shared)
+        same_info = {"installed": "0.3.0", "latest": "0.3.0", "outdated": False}
+
+        call_count = 0
+
+        async def fake_sleep(_):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise asyncio.CancelledError
+
+        with patch("ansible_know.server._check_pypi_version", return_value=same_info):
+            with patch("asyncio.sleep", side_effect=fake_sleep):
+                with patch.object(sessions, "on_version_update", new_callable=AsyncMock) as mock_update:
+                    with pytest.raises(asyncio.CancelledError):
+                        await _periodic_version_check(AsyncMock(), sessions)
+
+        # Same version: on_version_update should NOT be called
+        mock_update.assert_not_called()
+        # But shared.version_info should still be refreshed
+        assert shared.version_info["latest"] == "0.3.0"
+
+
+class TestGetStateSessionIsolation:
+    @pytest.mark.asyncio
+    async def test_different_sessions_get_different_state(self):
+        from ansible_know.server import _get_state
+        from ansible_know.state import SessionManager, SharedState
+
+        shared = SharedState()
+        sessions = SessionManager(shared)
+
+        ctx_a = MagicMock()
+        ctx_a.lifespan_context = {"shared": shared, "sessions": sessions, "http_client": None}
+        ctx_a.session_id = "session-a"
+
+        ctx_b = MagicMock()
+        ctx_b.lifespan_context = {"shared": shared, "sessions": sessions, "http_client": None}
+        ctx_b.session_id = "session-b"
+
+        state_a = await _get_state(ctx_a)
+        state_b = await _get_state(ctx_b)
+        assert state_a is not state_b
+
+    @pytest.mark.asyncio
+    async def test_same_session_gets_same_state(self):
+        from ansible_know.server import _get_state
+        from ansible_know.state import SessionManager, SharedState
+
+        shared = SharedState()
+        sessions = SessionManager(shared)
+
+        ctx = MagicMock()
+        ctx.lifespan_context = {"shared": shared, "sessions": sessions, "http_client": None}
+        ctx.session_id = "session-x"
+
+        state_1 = await _get_state(ctx)
+        state_2 = await _get_state(ctx)
+        assert state_1 is state_2
+
+    @pytest.mark.asyncio
+    async def test_none_ctx_returns_ephemeral(self):
+        from ansible_know.server import _get_state
+
+        state = await _get_state(None)
+        assert state is not None
+        assert state.collection_manager is not None
+        # Each call returns a new ephemeral instance
+        state_2 = await _get_state(None)
+        assert state is not state_2

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -572,10 +572,11 @@ class TestResourceFunctions:
 
     def test_resource_installed_collections_empty(self):
         import ansible_know.server as srv
+        from ansible_know.collections import CollectionManager
         from ansible_know.state import SessionManager, SharedState
 
         shared = SharedState()
-        sessions = SessionManager(shared)
+        sessions = SessionManager(shared, collection_factory=CollectionManager)
         old = srv._session_manager
         try:
             srv._session_manager = sessions
@@ -1261,11 +1262,12 @@ class TestGetCollectionManifestWithRoles:
 class TestPeriodicVersionCheck:
     @pytest.mark.asyncio
     async def test_updates_version_on_new_release(self):
+        from ansible_know.collections import CollectionManager
         from ansible_know.server import _periodic_version_check
         from ansible_know.state import SessionManager, SharedState
 
         shared = SharedState(version_info={"installed": "0.3.0", "latest": "0.3.0", "outdated": False})
-        sessions = SessionManager(shared)
+        sessions = SessionManager(shared, collection_factory=CollectionManager)
         new_info = {"installed": "0.3.0", "latest": "0.4.0", "outdated": True}
 
         call_count = 0
@@ -1285,11 +1287,12 @@ class TestPeriodicVersionCheck:
 
     @pytest.mark.asyncio
     async def test_skips_when_check_returns_none(self):
+        from ansible_know.collections import CollectionManager
         from ansible_know.server import _periodic_version_check
         from ansible_know.state import SessionManager, SharedState
 
         shared = SharedState(version_info={"installed": "0.3.0", "latest": "0.3.0", "outdated": False})
-        sessions = SessionManager(shared)
+        sessions = SessionManager(shared, collection_factory=CollectionManager)
 
         call_count = 0
 
@@ -1309,11 +1312,12 @@ class TestPeriodicVersionCheck:
 
     @pytest.mark.asyncio
     async def test_no_update_when_same_version(self):
+        from ansible_know.collections import CollectionManager
         from ansible_know.server import _periodic_version_check
         from ansible_know.state import SessionManager, SharedState
 
         shared = SharedState(version_info={"installed": "0.3.0", "latest": "0.3.0", "outdated": False})
-        sessions = SessionManager(shared)
+        sessions = SessionManager(shared, collection_factory=CollectionManager)
         same_info = {"installed": "0.3.0", "latest": "0.3.0", "outdated": False}
 
         call_count = 0
@@ -1339,11 +1343,12 @@ class TestPeriodicVersionCheck:
 class TestGetStateSessionIsolation:
     @pytest.mark.asyncio
     async def test_different_sessions_get_different_state(self):
+        from ansible_know.collections import CollectionManager
         from ansible_know.server import _get_state
         from ansible_know.state import SessionManager, SharedState
 
         shared = SharedState()
-        sessions = SessionManager(shared)
+        sessions = SessionManager(shared, collection_factory=CollectionManager)
 
         ctx_a = MagicMock()
         ctx_a.lifespan_context = {"shared": shared, "sessions": sessions, "http_client": None}
@@ -1359,11 +1364,12 @@ class TestGetStateSessionIsolation:
 
     @pytest.mark.asyncio
     async def test_same_session_gets_same_state(self):
+        from ansible_know.collections import CollectionManager
         from ansible_know.server import _get_state
         from ansible_know.state import SessionManager, SharedState
 
         shared = SharedState()
-        sessions = SessionManager(shared)
+        sessions = SessionManager(shared, collection_factory=CollectionManager)
 
         ctx = MagicMock()
         ctx.lifespan_context = {"shared": shared, "sessions": sessions, "http_client": None}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1279,7 +1279,7 @@ class TestPeriodicVersionCheck:
         with patch("ansible_know.server._check_pypi_version", return_value=new_info):
             with patch("asyncio.sleep", side_effect=fake_sleep):
                 with pytest.raises(asyncio.CancelledError):
-                    await _periodic_version_check(AsyncMock(), sessions)
+                    await _periodic_version_check(AsyncMock(), shared, sessions)
 
         assert shared.version_info["latest"] == "0.4.0"
 
@@ -1302,7 +1302,7 @@ class TestPeriodicVersionCheck:
         with patch("ansible_know.server._check_pypi_version", return_value=None):
             with patch("asyncio.sleep", side_effect=fake_sleep):
                 with pytest.raises(asyncio.CancelledError):
-                    await _periodic_version_check(AsyncMock(), sessions)
+                    await _periodic_version_check(AsyncMock(), shared, sessions)
 
         # version_info unchanged when check returns None
         assert shared.version_info["latest"] == "0.3.0"
@@ -1328,7 +1328,7 @@ class TestPeriodicVersionCheck:
             with patch("asyncio.sleep", side_effect=fake_sleep):
                 with patch.object(sessions, "on_version_update", new_callable=AsyncMock) as mock_update:
                     with pytest.raises(asyncio.CancelledError):
-                        await _periodic_version_check(AsyncMock(), sessions)
+                        await _periodic_version_check(AsyncMock(), shared, sessions)
 
         # Same version: on_version_update should NOT be called
         mock_update.assert_not_called()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1339,6 +1339,34 @@ class TestPeriodicVersionCheck:
         # But shared.version_info should still be refreshed
         assert shared.version_info["latest"] == "0.3.0"
 
+    @pytest.mark.asyncio
+    async def test_continues_after_unexpected_error(self):
+        from ansible_know.collections import CollectionManager
+        from ansible_know.server import _periodic_version_check
+        from ansible_know.state import SessionManager, SharedState
+
+        original_info = {"installed": "0.3.0", "latest": "0.3.0", "outdated": False}
+        shared = SharedState(version_info=dict(original_info))
+        sessions = SessionManager(shared, collection_factory=CollectionManager)
+
+        call_count = 0
+
+        async def fake_sleep(_):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise asyncio.CancelledError
+
+        with patch(
+            "ansible_know.server._check_pypi_version",
+            side_effect=RuntimeError("network exploded"),
+        ):
+            with patch("asyncio.sleep", side_effect=fake_sleep):
+                with pytest.raises(asyncio.CancelledError):
+                    await _periodic_version_check(AsyncMock(), shared, sessions)
+
+        assert shared.version_info == original_info
+
 
 class TestGetStateSessionIsolation:
     @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1278,10 +1278,12 @@ class TestPeriodicVersionCheck:
             if call_count > 1:
                 raise asyncio.CancelledError
 
+        mock_client = MagicMock()
+        mock_client.is_closed = False
         with patch("ansible_know.server._check_pypi_version", return_value=new_info):
             with patch("asyncio.sleep", side_effect=fake_sleep):
                 with pytest.raises(asyncio.CancelledError):
-                    await _periodic_version_check(AsyncMock(), shared, sessions)
+                    await _periodic_version_check(mock_client, shared, sessions)
 
         assert shared.version_info["latest"] == "0.4.0"
 
@@ -1302,10 +1304,12 @@ class TestPeriodicVersionCheck:
             if call_count > 1:
                 raise asyncio.CancelledError
 
+        mock_client = MagicMock()
+        mock_client.is_closed = False
         with patch("ansible_know.server._check_pypi_version", return_value=None):
             with patch("asyncio.sleep", side_effect=fake_sleep):
                 with pytest.raises(asyncio.CancelledError):
-                    await _periodic_version_check(AsyncMock(), shared, sessions)
+                    await _periodic_version_check(mock_client, shared, sessions)
 
         # version_info unchanged when check returns None
         assert shared.version_info["latest"] == "0.3.0"
@@ -1328,11 +1332,13 @@ class TestPeriodicVersionCheck:
             if call_count > 1:
                 raise asyncio.CancelledError
 
+        mock_client = MagicMock()
+        mock_client.is_closed = False
         with patch("ansible_know.server._check_pypi_version", return_value=same_info):
             with patch("asyncio.sleep", side_effect=fake_sleep):
                 with patch.object(sessions, "on_version_update", new_callable=AsyncMock) as mock_update:
                     with pytest.raises(asyncio.CancelledError):
-                        await _periodic_version_check(AsyncMock(), shared, sessions)
+                        await _periodic_version_check(mock_client, shared, sessions)
 
         # Same version: on_version_update should NOT be called
         mock_update.assert_not_called()
@@ -1340,32 +1346,24 @@ class TestPeriodicVersionCheck:
         assert shared.version_info["latest"] == "0.3.0"
 
     @pytest.mark.asyncio
-    async def test_continues_after_unexpected_error(self):
+    async def test_exits_when_client_closed(self):
         from ansible_know.collections import CollectionManager
         from ansible_know.server import _periodic_version_check
         from ansible_know.state import SessionManager, SharedState
 
-        original_info = {"installed": "0.3.0", "latest": "0.3.0", "outdated": False}
-        shared = SharedState(version_info=dict(original_info))
+        shared = SharedState(version_info={"installed": "0.3.0", "latest": "0.3.0", "outdated": False})
         sessions = SessionManager(shared, collection_factory=CollectionManager)
 
-        call_count = 0
+        mock_client = MagicMock()
+        mock_client.is_closed = True
 
         async def fake_sleep(_):
-            nonlocal call_count
-            call_count += 1
-            if call_count > 1:
-                raise asyncio.CancelledError
+            pass
 
-        with patch(
-            "ansible_know.server._check_pypi_version",
-            side_effect=RuntimeError("network exploded"),
-        ):
-            with patch("asyncio.sleep", side_effect=fake_sleep):
-                with pytest.raises(asyncio.CancelledError):
-                    await _periodic_version_check(AsyncMock(), shared, sessions)
+        with patch("asyncio.sleep", side_effect=fake_sleep):
+            await _periodic_version_check(mock_client, shared, sessions)
 
-        assert shared.version_info == original_info
+        assert shared.version_info["latest"] == "0.3.0"
 
 
 class TestGetStateSessionIsolation:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -143,9 +143,9 @@ class TestSessionManager:
         )
 
         result = mgr.all_installed_collections
-        assert "community.general" in result
-        assert "ansible.posix" in result
         assert result["ansible.posix"] == "1.6.0"
+        # Last-writer-wins: session "b" overwrites session "a" for duplicates
+        assert result["community.general"] == "9.1.0"
 
     @pytest.mark.asyncio
     async def test_remove_session_calls_cleanup(self):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,5 +1,6 @@
 """Tests for ansible_know.state."""
 
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -160,6 +161,12 @@ class TestSessionManager:
         # Second get_or_create should produce a new instance
         state2 = await mgr.get_or_create("s1")
         assert state2 is not state
+
+    @pytest.mark.asyncio
+    async def test_concurrent_get_or_create_same_id(self):
+        mgr = SessionManager(SharedState(), collection_factory=CollectionManager)
+        results = await asyncio.gather(*[mgr.get_or_create("same") for _ in range(10)])
+        assert all(r is results[0] for r in results)
 
     @pytest.mark.asyncio
     async def test_remove_session_nonexistent_is_noop(self):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,7 +1,11 @@
 """Tests for ansible_know.state."""
 
+from unittest.mock import MagicMock
+
+import pytest
+
 from ansible_know.collections import CollectionManager
-from ansible_know.state import LifespanContext, ServerState
+from ansible_know.state import LifespanContext, ServerState, SessionManager, SharedState
 
 
 class TestServerState:
@@ -39,8 +43,109 @@ class TestServerState:
 class TestLifespanContext:
     def test_is_typed_dict(self):
         assert "http_client" in LifespanContext.__annotations__
-        assert "state" in LifespanContext.__annotations__
+        assert "shared" in LifespanContext.__annotations__
+        assert "sessions" in LifespanContext.__annotations__
 
     def test_required_keys(self):
         assert "http_client" in LifespanContext.__required_keys__
-        assert "state" in LifespanContext.__required_keys__
+        assert "shared" in LifespanContext.__required_keys__
+        assert "sessions" in LifespanContext.__required_keys__
+
+
+class TestSharedState:
+    def test_default_fields(self):
+        shared = SharedState()
+        assert shared.galaxy_servers == []
+        assert shared.version_info is None
+
+    def test_with_values(self):
+        servers = [MagicMock()]
+        info = {"installed": "0.4.0", "latest": "0.5.0", "outdated": True}
+        shared = SharedState(galaxy_servers=servers, version_info=info)
+        assert shared.galaxy_servers is servers
+        assert shared.version_info is info
+
+
+class TestSessionManager:
+    @pytest.mark.asyncio
+    async def test_get_or_create_returns_same_for_same_id(self):
+        mgr = SessionManager(SharedState())
+        state1 = await mgr.get_or_create("session-1")
+        state2 = await mgr.get_or_create("session-1")
+        assert state1 is state2
+
+    @pytest.mark.asyncio
+    async def test_get_or_create_returns_different_for_different_ids(self):
+        mgr = SessionManager(SharedState())
+        state_a = await mgr.get_or_create("session-a")
+        state_b = await mgr.get_or_create("session-b")
+        assert state_a is not state_b
+
+    @pytest.mark.asyncio
+    async def test_session_state_has_shared_galaxy_servers(self):
+        servers = [MagicMock()]
+        shared = SharedState(galaxy_servers=servers)
+        mgr = SessionManager(shared)
+        state = await mgr.get_or_create("session-1")
+        assert state.galaxy_servers is servers
+
+    @pytest.mark.asyncio
+    async def test_on_version_update_propagates_to_sessions(self):
+        shared = SharedState()
+        mgr = SessionManager(shared)
+        state_a = await mgr.get_or_create("a")
+        state_b = await mgr.get_or_create("b")
+
+        new_info = {"installed": "0.4.0", "latest": "0.4.0", "outdated": False}
+        await mgr.on_version_update(new_info)
+
+        assert shared.version_info is new_info
+        assert state_a.version_info is new_info
+        assert state_b.version_info is new_info
+
+    @pytest.mark.asyncio
+    async def test_on_version_update_resets_upgrade_warned(self):
+        shared = SharedState()
+        mgr = SessionManager(shared)
+        state = await mgr.get_or_create("s1")
+        state.upgrade_warned = True
+
+        outdated_info = {"installed": "0.3.0", "latest": "0.4.0", "outdated": True}
+        await mgr.on_version_update(outdated_info)
+
+        assert state.upgrade_warned is False
+
+    @pytest.mark.asyncio
+    async def test_on_version_update_no_reset_when_not_outdated(self):
+        shared = SharedState()
+        mgr = SessionManager(shared)
+        state = await mgr.get_or_create("s1")
+        state.upgrade_warned = True
+
+        up_to_date = {"installed": "0.4.0", "latest": "0.4.0", "outdated": False}
+        await mgr.on_version_update(up_to_date)
+
+        assert state.upgrade_warned is True
+
+    def test_all_installed_collections_empty(self):
+        mgr = SessionManager(SharedState())
+        assert mgr.all_installed_collections == {}
+
+    @pytest.mark.asyncio
+    async def test_all_installed_collections_union(self):
+        shared = SharedState()
+        mgr = SessionManager(shared)
+        state_a = await mgr.get_or_create("a")
+        state_b = await mgr.get_or_create("b")
+
+        state_a.collection_manager.list_installed = MagicMock(
+            return_value={"community.general": "9.0.0"},
+        )
+        state_b.collection_manager.list_installed = MagicMock(
+            return_value={"ansible.posix": "1.6.0", "community.general": "9.1.0"},
+        )
+
+        result = mgr.all_installed_collections
+        assert "community.general" in result
+        assert "ansible.posix" in result
+        assert result["ansible.posix"] == "1.6.0"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -69,14 +69,14 @@ class TestSharedState:
 class TestSessionManager:
     @pytest.mark.asyncio
     async def test_get_or_create_returns_same_for_same_id(self):
-        mgr = SessionManager(SharedState())
+        mgr = SessionManager(SharedState(), collection_factory=CollectionManager)
         state1 = await mgr.get_or_create("session-1")
         state2 = await mgr.get_or_create("session-1")
         assert state1 is state2
 
     @pytest.mark.asyncio
     async def test_get_or_create_returns_different_for_different_ids(self):
-        mgr = SessionManager(SharedState())
+        mgr = SessionManager(SharedState(), collection_factory=CollectionManager)
         state_a = await mgr.get_or_create("session-a")
         state_b = await mgr.get_or_create("session-b")
         assert state_a is not state_b
@@ -85,14 +85,14 @@ class TestSessionManager:
     async def test_session_state_has_shared_galaxy_servers(self):
         servers = [MagicMock()]
         shared = SharedState(galaxy_servers=servers)
-        mgr = SessionManager(shared)
+        mgr = SessionManager(shared, collection_factory=CollectionManager)
         state = await mgr.get_or_create("session-1")
         assert state.galaxy_servers is servers
 
     @pytest.mark.asyncio
     async def test_on_version_update_propagates_to_sessions(self):
         shared = SharedState()
-        mgr = SessionManager(shared)
+        mgr = SessionManager(shared, collection_factory=CollectionManager)
         state_a = await mgr.get_or_create("a")
         state_b = await mgr.get_or_create("b")
 
@@ -106,7 +106,7 @@ class TestSessionManager:
     @pytest.mark.asyncio
     async def test_on_version_update_resets_upgrade_warned(self):
         shared = SharedState()
-        mgr = SessionManager(shared)
+        mgr = SessionManager(shared, collection_factory=CollectionManager)
         state = await mgr.get_or_create("s1")
         state.upgrade_warned = True
 
@@ -118,7 +118,7 @@ class TestSessionManager:
     @pytest.mark.asyncio
     async def test_on_version_update_no_reset_when_not_outdated(self):
         shared = SharedState()
-        mgr = SessionManager(shared)
+        mgr = SessionManager(shared, collection_factory=CollectionManager)
         state = await mgr.get_or_create("s1")
         state.upgrade_warned = True
 
@@ -128,13 +128,13 @@ class TestSessionManager:
         assert state.upgrade_warned is True
 
     def test_all_installed_collections_empty(self):
-        mgr = SessionManager(SharedState())
+        mgr = SessionManager(SharedState(), collection_factory=CollectionManager)
         assert mgr.all_installed_collections == {}
 
     @pytest.mark.asyncio
     async def test_all_installed_collections_union(self):
         shared = SharedState()
-        mgr = SessionManager(shared)
+        mgr = SessionManager(shared, collection_factory=CollectionManager)
         state_a = await mgr.get_or_create("a")
         state_b = await mgr.get_or_create("b")
 
@@ -149,3 +149,35 @@ class TestSessionManager:
         assert "community.general" in result
         assert "ansible.posix" in result
         assert result["ansible.posix"] == "1.6.0"
+
+    @pytest.mark.asyncio
+    async def test_remove_session_calls_cleanup(self):
+        shared = SharedState()
+        mgr = SessionManager(shared, collection_factory=CollectionManager)
+        state = await mgr.get_or_create("s1")
+        state.collection_manager.cleanup = MagicMock()
+
+        await mgr.remove_session("s1")
+
+        state.collection_manager.cleanup.assert_called_once()
+        # Second get_or_create should produce a new instance
+        state2 = await mgr.get_or_create("s1")
+        assert state2 is not state
+
+    @pytest.mark.asyncio
+    async def test_remove_session_nonexistent_is_noop(self):
+        mgr = SessionManager(SharedState(), collection_factory=CollectionManager)
+        await mgr.remove_session("does-not-exist")
+
+    @pytest.mark.asyncio
+    async def test_on_version_update_with_none(self):
+        shared = SharedState(version_info={"installed": "0.3.0", "latest": "0.4.0", "outdated": True})
+        mgr = SessionManager(shared, collection_factory=CollectionManager)
+        state = await mgr.get_or_create("s1")
+        state.upgrade_warned = True
+
+        await mgr.on_version_update(None)
+
+        assert shared.version_info is None
+        assert state.version_info is None
+        assert state.upgrade_warned is True

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -14,7 +14,6 @@ class TestServerState:
         state = ServerState(collection_manager=mgr)
         assert state.collection_manager is mgr
         assert state.missing_collections == set()
-        assert state.version_info is None
         assert state.galaxy_servers == []
         assert state.upgrade_warned is False
 
@@ -90,18 +89,16 @@ class TestSessionManager:
         assert state.galaxy_servers is servers
 
     @pytest.mark.asyncio
-    async def test_on_version_update_propagates_to_sessions(self):
+    async def test_on_version_update_updates_shared(self):
         shared = SharedState()
         mgr = SessionManager(shared, collection_factory=CollectionManager)
-        state_a = await mgr.get_or_create("a")
-        state_b = await mgr.get_or_create("b")
+        await mgr.get_or_create("a")
+        await mgr.get_or_create("b")
 
         new_info = {"installed": "0.4.0", "latest": "0.4.0", "outdated": False}
         await mgr.on_version_update(new_info)
 
         assert shared.version_info is new_info
-        assert state_a.version_info is new_info
-        assert state_b.version_info is new_info
 
     @pytest.mark.asyncio
     async def test_on_version_update_resets_upgrade_warned(self):
@@ -179,5 +176,4 @@ class TestSessionManager:
         await mgr.on_version_update(None)
 
         assert shared.version_info is None
-        assert state.version_info is None
         assert state.upgrade_warned is True


### PR DESCRIPTION
## Summary

Implements per-session state isolation (#78) and periodic PyPI version check (#79) for long-lived HTTP transport servers.

- **Per-session state**: `SharedState` (process-level) holds `galaxy_servers` and `version_info`. `SessionManager` creates per-session `ServerState` via `ctx.session_id` with its own `CollectionManager`, `missing_collections`, and `upgrade_warned` flag — no cross-session interference.
- **Periodic version check**: Background `asyncio.Task` re-checks PyPI every 6 hours. Resets `upgrade_warned` across all sessions when a new version is detected. Non-blocking with proper task cancellation in lifespan cleanup.
- Uses `asyncio.Lock` (not `threading.Lock`) for coroutine safety.
- Resources show aggregate state since they don't receive `Context`.

Closes #78
Closes #79

## Test plan

- [x] All 479 existing tests pass (0 failures)
- [x] 10 new `TestSessionManager` and `TestSharedState` tests in `test_state.py`
- [x] 6 new `TestPeriodicVersionCheck` and `TestGetStateSessionIsolation` tests in `test_server.py`
- [x] Updated `TestMaybeWarnUpgrade`, `TestServerVersionResource`, `TestResourceFunctions`, `TestLifespanHttpClient` for new `LifespanContext` shape
- [x] `ruff check` passes with no issues

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>