### PR TITLE
feat: collection codex skill generation with nested layout

### DIFF
--- a/src/ansible_know/collection_manifest.py
+++ b/src/ansible_know/collection_manifest.py
@@ -17,12 +17,13 @@ if TYPE_CHECKING:
     from ansible_know.types import ModuleMetadata
 
 __all__ = [
+    "derive_tags",
     "generate_manifest",
     "load_cached_manifest",
 ]
 
 
-def _derive_tags(fqcn: str, params: list[dict[str, Any]]) -> list[str]:
+def derive_tags(fqcn: str, params: list[dict[str, Any]]) -> list[str]:
     """Heuristically derive tags from module name segments and parameters."""
     parts = fqcn.split(".")
     module_short = parts[-1] if parts else fqcn
@@ -73,13 +74,15 @@ def generate_manifest(
     if skills_dir is None:
         skills_dir = SKILLS_DIR
 
+    collection_dir = skills_dir / collection_namespace
+
     modules_list = []
     for meta in modules_metadata:
         fqcn = meta["module_name"]
         params = meta["params"]
         required_params = [p["name"] for p in params if p.get("required")]
-        skill_dir = skills_dir / fqcn
-        has_skill = (skill_dir / "SKILL.md").exists()
+        short_name = fqcn.rsplit(".", 1)[-1]
+        has_skill = (collection_dir / short_name / "SKILL.md").exists()
 
         modules_list.append({
             "fqcn": fqcn,
@@ -88,14 +91,14 @@ def generate_manifest(
             "required_params": required_params,
             "is_api_module": meta["is_api_module"],
             "has_skill": has_skill,
-            "tags": _derive_tags(fqcn, params),
+            "tags": derive_tags(fqcn, params),
         })
 
     roles_list = []
     for role_meta in (roles_metadata or []):
         fqcn = role_meta["fqcn"]
-        skill_dir = skills_dir / fqcn
-        has_skill = (skill_dir / "SKILL.md").exists()
+        short_name = fqcn.rsplit(".", 1)[-1]
+        has_skill = (collection_dir / short_name / "SKILL.md").exists()
 
         roles_list.append({
             "fqcn": fqcn,
@@ -105,19 +108,21 @@ def generate_manifest(
             "has_skill": has_skill,
         })
 
+    has_codex = (collection_dir / "SKILL.md").exists()
+
     manifest = {
         "collection": collection_namespace,
         "collection_version": collection_version,
         "generated": datetime.now(timezone.utc).isoformat(),
         "module_count": len(modules_list),
         "role_count": len(roles_list),
+        "has_codex": has_codex,
         "modules": modules_list,
         "roles": roles_list,
     }
 
-    manifest_dir = skills_dir / collection_namespace.replace(".", "/")
-    manifest_dir.mkdir(parents=True, exist_ok=True)
-    manifest_path = manifest_dir / "MANIFEST.json"
+    collection_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = collection_dir / "MANIFEST.json"
     manifest_path.write_text(json.dumps(manifest, indent=2))
 
     return manifest
@@ -136,7 +141,7 @@ def load_cached_manifest(
     if skills_dir is None:
         skills_dir = SKILLS_DIR
 
-    manifest_path = skills_dir / collection_namespace.replace(".", "/") / "MANIFEST.json"
+    manifest_path = skills_dir / collection_namespace / "MANIFEST.json"
     if not manifest_path.exists():
         return None
 

--- a/src/ansible_know/collection_manifest.py
+++ b/src/ansible_know/collection_manifest.py
@@ -108,7 +108,7 @@ def generate_manifest(
             "has_skill": has_skill,
         })
 
-    has_codex = (collection_dir / "SKILL.md").exists()
+    has_collection_skill = (collection_dir / "SKILL.md").exists()
 
     manifest = {
         "collection": collection_namespace,
@@ -116,7 +116,7 @@ def generate_manifest(
         "generated": datetime.now(timezone.utc).isoformat(),
         "module_count": len(modules_list),
         "role_count": len(roles_list),
-        "has_codex": has_codex,
+        "has_collection_skill": has_collection_skill,
         "modules": modules_list,
         "roles": roles_list,
     }

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -446,7 +446,8 @@ async def get_collection_manifest(
 
         state = await _get_state(ctx)
         installed_version = state.collection_manager.list_installed().get(collection_namespace)
-        cached = collection_manifest.load_cached_manifest(
+        cached = await run_in_executor(
+            collection_manifest.load_cached_manifest,
             collection_namespace, installed_version=installed_version,
         )
         if cached:
@@ -495,7 +496,8 @@ async def get_collection_manifest(
                 "entry_points": entry_points,
             })
 
-        return collection_manifest.generate_manifest(
+        return await run_in_executor(
+            collection_manifest.generate_manifest,
             collection_namespace, metadata_list,
             roles_metadata=roles_metadata,
             collection_version=installed_version,
@@ -595,7 +597,8 @@ async def list_skills(
             return results
 
         if collection:
-            collection_dir = SKILLS_DIR / collection
+            collection_dir = (SKILLS_DIR / collection).resolve()
+            validate_path_containment(collection_dir, SKILLS_DIR)
             if not collection_dir.is_dir():
                 return results
             for sub_dir in sorted(collection_dir.iterdir()):
@@ -805,7 +808,7 @@ async def generate_collection_skills(
     """Batch generate skills for an entire collection.
 
     Generates/updates the collection MANIFEST.json as a byproduct.
-    Returns {"succeeded": int, "failed": int, "total": int, "manifest": dict},
+    Returns {"succeeded": int, "failed": int, "total": int, "manifest": dict, "codex": str},
     or {"error": str} on failure.
     """
     logger.info("generate_collection_skills namespace=%r install_to=%r", collection_namespace, install_to)
@@ -860,7 +863,8 @@ async def generate_collection_skills(
                 logger.warning("Skill generation failed for %s: %s", module_name, exc)
                 failed += 1
 
-        manifest = collection_manifest.generate_manifest(
+        manifest = await run_in_executor(
+            collection_manifest.generate_manifest,
             collection_namespace, metadata_list, skills_dir=base_dir,
             collection_version=installed_version,
         )
@@ -906,6 +910,9 @@ def resource_skills_list() -> str:
             skill_md = skill_dir / "SKILL.md"
             if skill_md.exists():
                 skills_list.append(skill_dir.name)
+            for sub_dir in sorted(skill_dir.iterdir()) if skill_dir.is_dir() else []:
+                if sub_dir.is_dir() and (sub_dir / "SKILL.md").exists():
+                    skills_list.append(f"{skill_dir.name}.{sub_dir.name}")
     return json.dumps(skills_list, indent=2)
 
 

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 from importlib.metadata import version as pkg_version
+from pathlib import Path
 from typing import Annotated, Any
 
 import httpx
@@ -33,6 +34,7 @@ from ansible_know.validation import (
     validate_namespace,
     validate_path_containment,
     validate_query,
+    validate_skill_name,
     validate_tags,
     validate_version,
 )
@@ -557,34 +559,64 @@ async def ensure_collection(
 # --- Skill management tools ---
 
 
+def _extract_skill_description(skill_md: Path) -> str:
+    """Extract description from a SKILL.md frontmatter."""
+    content = skill_md.read_text()
+    for line in content.splitlines():
+        if line.startswith("description:"):
+            return line.partition(":")[2].strip().strip(">-").strip()
+    return ""
+
+
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-async def list_skills() -> list[dict[str, str]] | dict[str, str]:
+async def list_skills(
+    collection: Annotated[
+        str | None,
+        "Optional collection namespace to list skills within (e.g. 'netbox.netbox'). "
+        "Without this, returns collection-level codex entries and standalone skills only.",
+    ] = None,
+) -> list[dict[str, str]] | dict[str, str]:
     """List all available generated skills. Returns name, description, path for each.
 
     Returns: [{"name": str, "description": str, "path": str}, ...] or {"error": str} on failure.
     """
-    logger.info("list_skills")
+    logger.info("list_skills collection=%r", collection)
+    if collection:
+        try:
+            validate_namespace(collection)
+        except ValidationError as exc:
+            return {"error": str(exc)}
+
     try:
         from ansible_know.config import SKILLS_DIR
 
-        results = []
+        results: list[dict[str, str]] = []
         if not SKILLS_DIR.exists():
             return results
 
-        for skill_dir in sorted(SKILLS_DIR.iterdir()):
-            skill_md = skill_dir / "SKILL.md"
-            if skill_md.exists():
-                content = skill_md.read_text()
-                description = ""
-                for line in content.splitlines():
-                    if line.startswith("description:"):
-                        description = line.partition(":")[2].strip().strip(">-").strip()
-                        break
-                results.append({
-                    "name": skill_dir.name,
-                    "description": description,
-                    "path": str(skill_dir),
-                })
+        if collection:
+            collection_dir = SKILLS_DIR / collection
+            if not collection_dir.is_dir():
+                return results
+            for sub_dir in sorted(collection_dir.iterdir()):
+                skill_md = sub_dir / "SKILL.md"
+                if sub_dir.is_dir() and skill_md.exists():
+                    results.append({
+                        "name": f"{collection}.{sub_dir.name}",
+                        "description": _extract_skill_description(skill_md),
+                        "path": str(sub_dir),
+                    })
+        else:
+            for skill_dir in sorted(SKILLS_DIR.iterdir()):
+                if not skill_dir.is_dir():
+                    continue
+                skill_md = skill_dir / "SKILL.md"
+                if skill_md.exists():
+                    results.append({
+                        "name": skill_dir.name,
+                        "description": _extract_skill_description(skill_md),
+                        "path": str(skill_dir),
+                    })
 
         return results
     except Exception as exc:
@@ -602,18 +634,33 @@ async def get_skill(
     """
     logger.info("get_skill name=%r", skill_name)
     try:
-        validate_fqcn(skill_name)
+        validate_skill_name(skill_name)
     except ValidationError as exc:
         return {"error": str(exc)}
 
     try:
         from ansible_know.config import SKILLS_DIR
 
-        skill_path = (SKILLS_DIR / skill_name / "SKILL.md").resolve()
-        validate_path_containment(skill_path, SKILLS_DIR)
-        if not skill_path.exists():
-            return {"error": f"Skill '{skill_name}' not found."}
-        return truncate_response(skill_path.read_text())
+        parts = skill_name.split(".")
+        if len(parts) >= 3:
+            namespace = ".".join(parts[:2])
+            short_name = ".".join(parts[2:])
+            nested_path = (SKILLS_DIR / namespace / short_name / "SKILL.md").resolve()
+            validate_path_containment(nested_path, SKILLS_DIR)
+            if nested_path.exists():
+                return truncate_response(nested_path.read_text())
+
+            flat_path = (SKILLS_DIR / skill_name / "SKILL.md").resolve()
+            validate_path_containment(flat_path, SKILLS_DIR)
+            if flat_path.exists():
+                return truncate_response(flat_path.read_text())
+        else:
+            skill_path = (SKILLS_DIR / skill_name / "SKILL.md").resolve()
+            validate_path_containment(skill_path, SKILLS_DIR)
+            if skill_path.exists():
+                return truncate_response(skill_path.read_text())
+
+        return {"error": f"Skill '{skill_name}' not found."}
     except ValidationError as exc:
         return {"error": str(exc)}
     except Exception as exc:
@@ -663,17 +710,19 @@ async def generate_skill(
         if ctx:
             await ctx.report_progress(progress=50, total=100)
 
-        skill_name = skills.module_to_skill_name(metadata["module_name"])
+        fqcn = metadata["module_name"]
+        namespace = ".".join(fqcn.split(".")[:2])
+        short_name = fqcn.rsplit(".", 1)[-1]
         base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
-        output_dir = base_dir / skill_name
+        output_dir = base_dir / namespace / short_name
 
-        await run_in_executor(skills.write_skill_package, output_dir, metadata)
+        await run_in_executor(skills.write_module_skill_package, output_dir, metadata)
         logger.info("generate_skill wrote to %s", output_dir)
 
         if ctx:
             await ctx.report_progress(progress=100, total=100)
 
-        return truncate_response(skills.render_skill(metadata))
+        return truncate_response(skills.render_module_skill(metadata))
     except ValidationError as exc:
         return {"error": str(exc)}
     except Exception as exc:
@@ -727,8 +776,10 @@ async def generate_role_skill(
         if ctx:
             await ctx.report_progress(progress=50, total=100)
 
+        namespace = ".".join(role_name.split(".")[:2])
+        short_name = role_name.rsplit(".", 1)[-1]
         base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
-        output_dir = base_dir / role_name
+        output_dir = base_dir / namespace / short_name
 
         await run_in_executor(skills.write_role_skill_package, output_dir, metadata)
         logger.info("generate_role_skill wrote to %s", output_dir)
@@ -789,6 +840,8 @@ async def generate_collection_skills(
 
         base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
 
+        installed_version = state.collection_manager.list_installed().get(collection_namespace)
+
         for i, module_name in enumerate(sorted(modules)):
             if ctx:
                 await ctx.report_progress(progress=i, total=total)
@@ -799,9 +852,9 @@ async def generate_collection_skills(
                 metadata = parser.extract_module_metadata(raw_doc)
                 metadata_list.append(metadata)
 
-                skill_name = skills.module_to_skill_name(metadata["module_name"])
-                output_dir = base_dir / skill_name
-                await run_in_executor(skills.write_skill_package, output_dir, metadata)
+                short_name = metadata["module_name"].rsplit(".", 1)[-1]
+                output_dir = base_dir / collection_namespace / short_name
+                await run_in_executor(skills.write_module_skill_package, output_dir, metadata)
                 succeeded += 1
             except Exception as exc:
                 logger.warning("Skill generation failed for %s: %s", module_name, exc)
@@ -809,6 +862,13 @@ async def generate_collection_skills(
 
         manifest = collection_manifest.generate_manifest(
             collection_namespace, metadata_list, skills_dir=base_dir,
+            collection_version=installed_version,
+        )
+
+        await run_in_executor(
+            skills.write_collection_skill_package,
+            base_dir / collection_namespace, collection_namespace,
+            metadata_list, installed_version,
         )
 
         if ctx:
@@ -820,6 +880,7 @@ async def generate_collection_skills(
             "failed": failed,
             "total": total,
             "manifest": manifest,
+            "codex": collection_namespace,
         }
     except ValidationError:
         raise
@@ -837,37 +898,59 @@ def resource_skills_list() -> str:
 
     from ansible_know.config import SKILLS_DIR
 
-    skills = []
+    skills_list: list[str] = []
     if SKILLS_DIR.exists():
         for skill_dir in sorted(SKILLS_DIR.iterdir()):
+            if not skill_dir.is_dir():
+                continue
             skill_md = skill_dir / "SKILL.md"
             if skill_md.exists():
-                skills.append(skill_dir.name)
-    return json.dumps(skills, indent=2)
+                skills_list.append(skill_dir.name)
+    return json.dumps(skills_list, indent=2)
 
 
 @mcp.resource(
     "skills://{skill_name}",
     name="Skill Content",
-    description="Read a generated skill's SKILL.md by FQCN",
+    description="Read a generated skill's SKILL.md by FQCN or collection namespace",
 )
 def resource_skill_content(skill_name: str) -> str:
     from ansible_know.config import SKILLS_DIR
 
     try:
-        validate_fqcn(skill_name)
+        validate_skill_name(skill_name)
     except ValidationError as exc:
         return str(exc)
 
-    skill_path = (SKILLS_DIR / skill_name / "SKILL.md").resolve()
-    try:
-        validate_path_containment(skill_path, SKILLS_DIR)
-    except ValidationError as exc:
-        return str(exc)
+    parts = skill_name.split(".")
+    if len(parts) >= 3:
+        namespace = ".".join(parts[:2])
+        short_name = ".".join(parts[2:])
+        nested_path = (SKILLS_DIR / namespace / short_name / "SKILL.md").resolve()
+        try:
+            validate_path_containment(nested_path, SKILLS_DIR)
+        except ValidationError as exc:
+            return str(exc)
+        if nested_path.exists():
+            return truncate_response(nested_path.read_text())
 
-    if not skill_path.exists():
-        return f"Skill '{skill_name}' not found."
-    return truncate_response(skill_path.read_text())
+        flat_path = (SKILLS_DIR / skill_name / "SKILL.md").resolve()
+        try:
+            validate_path_containment(flat_path, SKILLS_DIR)
+        except ValidationError as exc:
+            return str(exc)
+        if flat_path.exists():
+            return truncate_response(flat_path.read_text())
+    else:
+        skill_path = (SKILLS_DIR / skill_name / "SKILL.md").resolve()
+        try:
+            validate_path_containment(skill_path, SKILLS_DIR)
+        except ValidationError as exc:
+            return str(exc)
+        if skill_path.exists():
+            return truncate_response(skill_path.read_text())
+
+    return f"Skill '{skill_name}' not found."
 
 
 @mcp.resource(

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -466,7 +466,7 @@ async def get_collection_manifest(
                 parser.list_roles, collection_filter=collection_namespace,
                 collections_path=cpath,
             )
-        except Exception as exc:
+        except (AnsibleDocError, OSError) as exc:
             logger.warning("list_roles failed for %s: %s", collection_namespace, exc)
 
         if not modules and not roles_raw:
@@ -570,12 +570,55 @@ def _extract_skill_description(skill_md: Path) -> str:
     return ""
 
 
+def _list_skills_sync(
+    skills_dir: Path, collection: str | None,
+) -> list[dict[str, str]]:
+    """Synchronous helper for list_skills — all file I/O happens here."""
+    results: list[dict[str, str]] = []
+    if not skills_dir.exists():
+        return results
+
+    if collection:
+        collection_dir = (skills_dir / collection).resolve()
+        validate_path_containment(collection_dir, skills_dir)
+        if not collection_dir.is_dir():
+            return results
+        for sub_dir in sorted(collection_dir.iterdir()):
+            try:
+                skill_md = sub_dir / "SKILL.md"
+                if sub_dir.is_dir() and not sub_dir.is_symlink() and skill_md.exists():
+                    results.append({
+                        "name": f"{collection}.{sub_dir.name}",
+                        "description": _extract_skill_description(skill_md),
+                        "path": str(sub_dir),
+                    })
+            except OSError:
+                logger.warning("Skipping unreadable skill: %s", sub_dir.name)
+                continue
+    else:
+        for skill_dir in sorted(skills_dir.iterdir()):
+            try:
+                if not skill_dir.is_dir() or skill_dir.is_symlink():
+                    continue
+                skill_md = skill_dir / "SKILL.md"
+                if skill_md.exists():
+                    results.append({
+                        "name": skill_dir.name,
+                        "description": _extract_skill_description(skill_md),
+                        "path": str(skill_dir),
+                    })
+            except OSError:
+                logger.warning("Skipping unreadable skill: %s", skill_dir.name)
+                continue
+    return results
+
+
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def list_skills(
     collection: Annotated[
         str | None,
         "Optional collection namespace to list skills within (e.g. 'netbox.netbox'). "
-        "Without this, returns collection-level codex entries and standalone skills only.",
+        "Without this, returns collection-level skill entries and standalone skills only.",
     ] = None,
 ) -> list[dict[str, str]] | dict[str, str]:
     """List all available generated skills. Returns name, description, path for each.
@@ -592,36 +635,7 @@ async def list_skills(
     try:
         from ansible_know.config import SKILLS_DIR
 
-        results: list[dict[str, str]] = []
-        if not SKILLS_DIR.exists():
-            return results
-
-        if collection:
-            collection_dir = (SKILLS_DIR / collection).resolve()
-            validate_path_containment(collection_dir, SKILLS_DIR)
-            if not collection_dir.is_dir():
-                return results
-            for sub_dir in sorted(collection_dir.iterdir()):
-                skill_md = sub_dir / "SKILL.md"
-                if sub_dir.is_dir() and skill_md.exists():
-                    results.append({
-                        "name": f"{collection}.{sub_dir.name}",
-                        "description": _extract_skill_description(skill_md),
-                        "path": str(sub_dir),
-                    })
-        else:
-            for skill_dir in sorted(SKILLS_DIR.iterdir()):
-                if not skill_dir.is_dir():
-                    continue
-                skill_md = skill_dir / "SKILL.md"
-                if skill_md.exists():
-                    results.append({
-                        "name": skill_dir.name,
-                        "description": _extract_skill_description(skill_md),
-                        "path": str(skill_dir),
-                    })
-
-        return results
+        return await run_in_executor(_list_skills_sync, SKILLS_DIR, collection)
     except Exception as exc:
         logger.warning("list_skills failed: %s", exc)
         return {"error": sanitize_error(str(exc))}
@@ -629,7 +643,11 @@ async def list_skills(
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def get_skill(
-    skill_name: Annotated[str, "Skill name (usually the module FQCN)"],
+    skill_name: Annotated[
+        str,
+        "Skill name: a module FQCN (e.g. 'netbox.netbox.netbox_device') or "
+        "a collection namespace (e.g. 'netbox.netbox') for the collection-level skill.",
+    ],
 ) -> str | dict[str, str]:
     """Read a specific skill's SKILL.md content by name.
 
@@ -808,7 +826,7 @@ async def generate_collection_skills(
     """Batch generate skills for an entire collection.
 
     Generates/updates the collection MANIFEST.json as a byproduct.
-    Returns {"succeeded": int, "failed": int, "total": int, "manifest": dict, "codex": str},
+    Returns {"succeeded": int, "failed": int, "total": int, "manifest": dict, "collection_skill": str},
     or {"error": str} on failure.
     """
     logger.info("generate_collection_skills namespace=%r install_to=%r", collection_namespace, install_to)
@@ -884,7 +902,7 @@ async def generate_collection_skills(
             "failed": failed,
             "total": total,
             "manifest": manifest,
-            "codex": collection_namespace,
+            "collection_skill": collection_namespace,
         }
     except ValidationError:
         raise
@@ -905,13 +923,13 @@ def resource_skills_list() -> str:
     skills_list: list[str] = []
     if SKILLS_DIR.exists():
         for skill_dir in sorted(SKILLS_DIR.iterdir()):
-            if not skill_dir.is_dir():
+            if not skill_dir.is_dir() or skill_dir.is_symlink():
                 continue
             skill_md = skill_dir / "SKILL.md"
             if skill_md.exists():
                 skills_list.append(skill_dir.name)
-            for sub_dir in sorted(skill_dir.iterdir()) if skill_dir.is_dir() else []:
-                if sub_dir.is_dir() and (sub_dir / "SKILL.md").exists():
+            for sub_dir in sorted(skill_dir.iterdir()):
+                if sub_dir.is_dir() and not sub_dir.is_symlink() and (sub_dir / "SKILL.md").exists():
                     skills_list.append(f"{skill_dir.name}.{sub_dir.name}")
     return json.dumps(skills_list, indent=2)
 

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -1,7 +1,7 @@
 """Skill rendering and package writing.
 
 Extracted from ansibleclawed cli.py — generates SKILL.md skill packages
-from Ansible module metadata.
+from Ansible module, role, and collection metadata.
 """
 
 from __future__ import annotations
@@ -9,17 +9,25 @@ from __future__ import annotations
 import functools
 import logging
 import stat
+from collections import Counter
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ansible_know.config import TEMPLATE_DIR
+
+if TYPE_CHECKING:
+    from ansible_know.types import CollectionSkillContext
 
 logger = logging.getLogger("ansible_know")
 
 __all__ = [
     "module_to_skill_name",
+    "render_collection_skill",
+    "render_module_skill",
     "render_role_skill",
     "render_skill",
+    "write_collection_skill_package",
+    "write_module_skill_package",
     "write_role_skill_package",
     "write_skill_package",
 ]
@@ -43,7 +51,7 @@ def module_to_skill_name(module_name: str) -> str:
     return module_name
 
 
-def _template_context(metadata: dict[str, Any]) -> dict[str, Any]:
+def _module_template_context(metadata: dict[str, Any]) -> dict[str, Any]:
     """Build the shared template context from module metadata."""
     params = metadata["params"]
     example_args = _build_example_args(params, metadata.get("examples", ""))
@@ -59,6 +67,9 @@ def _template_context(metadata: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+_template_context = _module_template_context
+
+
 def _examples_contain_play(examples: str) -> bool:
     """Check if examples YAML already defines a full play."""
     if not examples:
@@ -66,19 +77,22 @@ def _examples_contain_play(examples: str) -> bool:
     return "hosts:" in examples and "tasks:" in examples
 
 
-def render_skill(metadata: dict[str, Any]) -> str:
+def render_module_skill(metadata: dict[str, Any]) -> str:
     """Render the SKILL.md template with the given module metadata."""
     logger.debug("Rendering skill for module %s", metadata.get("module_name", "?"))
     env = _get_template_env()
     template = env.get_template("SKILL.md.j2")
-    return template.render(**_template_context(metadata))
+    return template.render(**_module_template_context(metadata))
 
 
-def write_skill_package(output_dir: Path, metadata: dict[str, Any]) -> None:
+render_skill = render_module_skill
+
+
+def write_module_skill_package(output_dir: Path, metadata: dict[str, Any]) -> None:
     """Write the full skill package: SKILL.md + scripts + assets."""
     logger.debug("Writing skill package to %s for %s", output_dir, metadata.get("module_name", "?"))
     env = _get_template_env()
-    ctx = _template_context(metadata)
+    ctx = _module_template_context(metadata)
 
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -99,6 +113,9 @@ def write_skill_package(output_dir: Path, metadata: dict[str, Any]) -> None:
 
     playbook_template = env.get_template("playbook.yml.j2")
     (assets_dir / "playbook.yml").write_text(playbook_template.render(**ctx))
+
+
+write_skill_package = write_module_skill_package
 
 
 def _build_example_args(params: list[dict[str, Any]], examples_yaml: str = "") -> str:
@@ -187,3 +204,102 @@ def write_role_skill_package(output_dir: Path, metadata: dict[str, Any]) -> None
 
     playbook_template = env.get_template("role_playbook.yml.j2")
     (assets_dir / "playbook.yml").write_text(playbook_template.render(**ctx))
+
+
+# --- Collection codex skill ---
+
+
+def _collection_template_context(
+    namespace: str,
+    metadata_list: list[dict[str, Any]],
+    collection_version: str | None = None,
+) -> CollectionSkillContext:
+    """Build template context for a collection-level codex skill."""
+    from ansible_know.collection_manifest import derive_tags
+
+    modules_by_tag: dict[str, list[dict[str, Any]]] = {}
+    for meta in metadata_list:
+        fqcn = meta["module_name"]
+        short_name = fqcn.rsplit(".", 1)[-1]
+        params = meta["params"]
+        required_params = [p for p in params if p.get("required")]
+        tags = derive_tags(fqcn, params)
+
+        entry = {
+            "fqcn": fqcn,
+            "short_name": short_name,
+            "short_description": meta["short_description"],
+            "required_params": required_params,
+            "is_api_module": meta.get("is_api_module", False),
+        }
+
+        if not tags:
+            modules_by_tag.setdefault("other", []).append(entry)
+        else:
+            for tag in tags:
+                modules_by_tag.setdefault(tag, []).append(entry)
+
+    all_api = bool(metadata_list) and all(
+        m.get("is_api_module", False) for m in metadata_list
+    )
+
+    common_params = _find_common_params(metadata_list)
+
+    return {
+        "collection_namespace": namespace,
+        "collection_version": collection_version,
+        "modules_by_tag": modules_by_tag,
+        "all_api": all_api,
+        "common_params": common_params,
+        "module_count": len(metadata_list),
+    }
+
+
+def _find_common_params(metadata_list: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Find parameters shared by >80% of modules in a collection."""
+    if not metadata_list:
+        return []
+
+    threshold = len(metadata_list) * 0.8
+    param_counts: Counter[str] = Counter()
+    param_info: dict[str, dict[str, Any]] = {}
+
+    for meta in metadata_list:
+        for p in meta["params"]:
+            name = p["name"]
+            param_counts[name] += 1
+            if name not in param_info:
+                param_info[name] = p
+
+    return [
+        param_info[name]
+        for name, count in param_counts.most_common()
+        if count >= threshold
+    ]
+
+
+def render_collection_skill(
+    namespace: str,
+    metadata_list: list[dict[str, Any]],
+    collection_version: str | None = None,
+) -> str:
+    """Render the COLLECTION_SKILL.md.j2 template for a collection codex."""
+    logger.debug("Rendering collection skill for %s", namespace)
+    env = _get_template_env()
+    template = env.get_template("COLLECTION_SKILL.md.j2")
+    ctx = _collection_template_context(namespace, metadata_list, collection_version)
+    return template.render(**ctx)
+
+
+def write_collection_skill_package(
+    output_dir: Path,
+    namespace: str,
+    metadata_list: list[dict[str, Any]],
+    collection_version: str | None = None,
+) -> None:
+    """Write the collection codex skill package: SKILL.md only (no scripts/assets)."""
+    logger.debug("Writing collection skill package to %s for %s", output_dir, namespace)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    content = render_collection_skill(namespace, metadata_list, collection_version)
+    (output_dir / "SKILL.md").write_text(content)

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -67,9 +67,6 @@ def _module_template_context(metadata: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-_template_context = _module_template_context
-
-
 def _examples_contain_play(examples: str) -> bool:
     """Check if examples YAML already defines a full play."""
     if not examples:

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 from ansible_know.config import TEMPLATE_DIR
 
 if TYPE_CHECKING:
-    from ansible_know.types import CollectionSkillContext
+    from ansible_know.types import CollectionSkillContext, ModuleTagEntry
 
 logger = logging.getLogger("ansible_know")
 
@@ -203,7 +203,7 @@ def write_role_skill_package(output_dir: Path, metadata: dict[str, Any]) -> None
     (assets_dir / "playbook.yml").write_text(playbook_template.render(**ctx))
 
 
-# --- Collection codex skill ---
+# --- Collection-level skill ---
 
 
 def _collection_template_context(
@@ -211,10 +211,10 @@ def _collection_template_context(
     metadata_list: list[dict[str, Any]],
     collection_version: str | None = None,
 ) -> CollectionSkillContext:
-    """Build template context for a collection-level codex skill."""
+    """Build template context for a collection-level skill."""
     from ansible_know.collection_manifest import derive_tags
 
-    modules_by_tag: dict[str, list[dict[str, Any]]] = {}
+    modules_by_tag: dict[str, list[ModuleTagEntry]] = {}
     for meta in metadata_list:
         fqcn = meta["module_name"]
         short_name = fqcn.rsplit(".", 1)[-1]
@@ -222,7 +222,7 @@ def _collection_template_context(
         required_params = [p for p in params if p.get("required")]
         tags = derive_tags(fqcn, params)
 
-        entry = {
+        entry: ModuleTagEntry = {
             "fqcn": fqcn,
             "short_name": short_name,
             "short_description": meta["short_description"],
@@ -280,7 +280,7 @@ def render_collection_skill(
     metadata_list: list[dict[str, Any]],
     collection_version: str | None = None,
 ) -> str:
-    """Render the COLLECTION_SKILL.md.j2 template for a collection codex."""
+    """Render the COLLECTION_SKILL.md.j2 template for a collection-level skill."""
     logger.debug("Rendering collection skill for %s", namespace)
     env = _get_template_env()
     template = env.get_template("COLLECTION_SKILL.md.j2")
@@ -294,7 +294,7 @@ def write_collection_skill_package(
     metadata_list: list[dict[str, Any]],
     collection_version: str | None = None,
 ) -> None:
-    """Write the collection codex skill package: SKILL.md only (no scripts/assets)."""
+    """Write the collection-level skill package: SKILL.md only (no scripts/assets)."""
     logger.debug("Writing collection skill package to %s for %s", output_dir, namespace)
     output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/ansible_know/templates/COLLECTION_SKILL.md.j2
+++ b/src/ansible_know/templates/COLLECTION_SKILL.md.j2
@@ -1,0 +1,123 @@
+---
+name: {{ collection_namespace }}
+description: >-
+  Guided playbook development for the {{ collection_namespace }} collection.
+  Covers {{ module_count }} module{{ "s" if module_count != 1 else "" }}{% if collection_version %} (v{{ collection_version }}){% endif %}.
+---
+
+# {{ collection_namespace }} Playbook Codex
+
+Build playbooks for the **{{ collection_namespace }}** collection{% if collection_version %} (v{{ collection_version }}){% endif %} using verified
+module documentation. This skill was generated from live module metadata —
+all parameters, defaults, and examples are version-accurate.
+
+## Phase 1 — Gather Intent
+
+Before writing any YAML, collect these requirements:
+
+{% if all_api %}
+- **Target service:** URL, API token/credentials, SSL verification
+{% endif %}
+- **Desired state:** What objects to create/update/delete
+- **Data source:** Manual variables, CSV import, discovered facts, or another system
+- **Idempotency needs:** Create-only, create-or-update, or full desired-state enforcement
+- **Error handling:** Fail on first error, or collect and report all failures
+
+If any critical info is missing, produce a safe template with `# TODO:` comments.
+
+{% if all_api %}
+### Connection Requirements
+
+All modules in this collection are **API modules**. They require:
+
+```yaml
+connection: local
+gather_facts: false
+```
+
+{% endif %}
+{% if common_params %}
+### Common Parameters
+
+These parameters are shared across most modules in this collection:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+{% for p in common_params -%}
+| `{{ p.name }}` | {{ p.type }} | {{ "yes" if p.required else "no" }} | {{ p.default if p.default is not none else "-" }} | {{ p.description }} |
+{% endfor %}
+
+Store credentials in variables, never hardcode:
+
+```yaml
+vars:
+{% for p in common_params %}{% if "token" in p.name or "url" in p.name or "password" in p.name %}
+  {{ p.name }}: "{{ '{{' }} vault_{{ p.name }} {{ '}}' }}"
+{% endif %}{% endfor %}
+```
+
+{% endif %}
+## Phase 2 — Select Modules
+
+Choose modules based on what you need to manage:
+
+{% for tag, modules in modules_by_tag | dictsort %}
+### {{ tag | capitalize }}
+
+| Module | Purpose | Key Params |
+|--------|---------|------------|
+{% for m in modules -%}
+| `{{ m.fqcn }}` | {{ m.short_description }} | {% for p in m.required_params[:4] %}`{{ p.name }}`{{ ", " if not loop.last else "" }}{% endfor %}{% if not m.required_params %}—{% endif %} |
+{% endfor %}
+
+{% endfor %}
+## Phase 3 — Design Block
+
+Before writing YAML, output a human-readable design for review:
+
+```
+Intent:       <what you want to accomplish>
+{% if all_api -%}
+Target:       <service URL> (credentials via vault)
+{% endif -%}
+Modules:      <list of modules to use>
+Variables:    <input variables needed>
+Dependencies: <ordering constraints between tasks>
+Error plan:   <fail-fast or collect-all>
+```
+
+**Wait for user confirmation before proceeding to Phase 4.**
+
+## Phase 4 — Write Playbook
+
+Apply these rules while writing YAML:
+
+### Checklist
+
+1. **FQCN** — always `{{ collection_namespace }}.*`, never short names
+2. **Idempotent** — use `state: present`/`absent` for desired-state management
+3. **No shell** — never use `shell`/`command` when a module exists for the task
+{% if all_api %}
+4. **connection: local** — all tasks run locally against the API
+5. **Credentials** — use `no_log: true` on tasks that could expose tokens
+{% endif %}
+6. **Loop efficiently** — use `loop:` with module params, not `with_items:`
+7. **Check mode** — verify all modules support `--check`
+8. **Dependencies** — order tasks by object dependency
+
+## Phase 5 — Validate
+
+Run these checks in order. Fix errors and re-run until clean:
+
+```bash
+# Syntax check
+ansible-playbook playbook.yml --syntax-check
+
+# Lint
+ansible-lint playbook.yml
+
+# Dry run{% if all_api %} (requires API connectivity){% endif %}
+ansible-playbook playbook.yml --check -v
+```
+
+Report results to the user before applying.

--- a/src/ansible_know/templates/COLLECTION_SKILL.md.j2
+++ b/src/ansible_know/templates/COLLECTION_SKILL.md.j2
@@ -5,7 +5,7 @@ description: >-
   Covers {{ module_count }} module{{ "s" if module_count != 1 else "" }}{% if collection_version %} (v{{ collection_version }}){% endif %}.
 ---
 
-# {{ collection_namespace }} Playbook Codex
+# {{ collection_namespace }} Playbook Guide
 
 Build playbooks for the **{{ collection_namespace }}** collection{% if collection_version %} (v{{ collection_version }}){% endif %} using verified
 module documentation. This skill was generated from live module metadata —

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -72,6 +72,17 @@ class SkillEntry(TypedDict):
     path: str
 
 
+class CollectionSkillContext(TypedDict):
+    """Template context for collection-level codex skill rendering."""
+
+    collection_namespace: str
+    collection_version: str | None
+    modules_by_tag: dict[str, list[dict[str, Any]]]
+    all_api: bool
+    common_params: list[dict[str, Any]]
+    module_count: int
+
+
 class _CollectionInfoBase(TypedDict):
     """Required fields for a collection search result entry."""
 

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -72,12 +72,22 @@ class SkillEntry(TypedDict):
     path: str
 
 
+class ModuleTagEntry(TypedDict):
+    """Single module entry within a tag group for collection skill rendering."""
+
+    fqcn: str
+    short_name: str
+    short_description: str
+    required_params: list[dict[str, Any]]
+    is_api_module: bool
+
+
 class CollectionSkillContext(TypedDict):
-    """Template context for collection-level codex skill rendering."""
+    """Template context for collection-level skill rendering."""
 
     collection_namespace: str
     collection_version: str | None
-    modules_by_tag: dict[str, list[dict[str, Any]]]
+    modules_by_tag: dict[str, list[ModuleTagEntry]]
     all_api: bool
     common_params: list[dict[str, Any]]
     module_count: int

--- a/src/ansible_know/validation.py
+++ b/src/ansible_know/validation.py
@@ -16,6 +16,7 @@ MAX_TAGS_LENGTH = 500
 
 _FQCN_RE = re.compile(r"^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$")
 _NAMESPACE_RE = re.compile(r"^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$")
+_SKILL_NAME_RE = re.compile(r"^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)?$")
 _VERSION_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 _TAGS_RE = re.compile(r"^[a-zA-Z0-9_,-]+$")
 _SENSITIVE_PREFIXES = ("/etc", "/usr", "/bin", "/sbin", "/boot", "/proc", "/sys", "/dev")
@@ -27,6 +28,14 @@ def validate_fqcn(name: str) -> None:
         raise ValidationError(
             "Invalid module name: expected format 'namespace.collection.module' "
             "with alphanumeric/underscore segments."
+        )
+
+
+def validate_skill_name(name: str) -> None:
+    if not name or not _SKILL_NAME_RE.match(name):
+        raise ValidationError(
+            "Invalid skill name: expected format 'namespace.collection' or "
+            "'namespace.collection.module' with alphanumeric/underscore segments."
         )
 
 

--- a/src/ansible_know/validation.py
+++ b/src/ansible_know/validation.py
@@ -31,11 +31,14 @@ def validate_fqcn(name: str) -> None:
         )
 
 
+MAX_SKILL_NAME_LENGTH = MAX_NAMESPACE_LENGTH * 2
+
+
 def validate_skill_name(name: str) -> None:
-    if not name or not _SKILL_NAME_RE.match(name):
+    if not name or len(name) > MAX_SKILL_NAME_LENGTH or not _SKILL_NAME_RE.match(name):
         raise ValidationError(
-            "Invalid skill name: expected format 'namespace.collection' or "
-            "'namespace.collection.module' with alphanumeric/underscore segments."
+            "Invalid skill name: expected a collection namespace (e.g. 'netbox.netbox') "
+            "or a fully-qualified module name (e.g. 'netbox.netbox.netbox_device')."
         )
 
 

--- a/tests/test_collection_manifest.py
+++ b/tests/test_collection_manifest.py
@@ -75,21 +75,21 @@ class TestGenerateManifest:
 
         assert manifest["modules"][0]["is_api_module"] is True
 
-    def test_has_codex_false_by_default(self, tmp_path, sample_module_doc):
+    def test_has_collection_skill_false_by_default(self, tmp_path, sample_module_doc):
         metadata = extract_module_metadata(sample_module_doc)
         manifest = generate_manifest("ansible.builtin", [metadata], skills_dir=tmp_path)
 
-        assert manifest["has_codex"] is False
+        assert manifest["has_collection_skill"] is False
 
-    def test_has_codex_true_when_exists(self, tmp_path, sample_module_doc):
-        codex_dir = tmp_path / "ansible.builtin"
-        codex_dir.mkdir(parents=True)
-        (codex_dir / "SKILL.md").write_text("codex content")
+    def test_has_collection_skill_true_when_exists(self, tmp_path, sample_module_doc):
+        skill_dir = tmp_path / "ansible.builtin"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("collection skill content")
 
         metadata = extract_module_metadata(sample_module_doc)
         manifest = generate_manifest("ansible.builtin", [metadata], skills_dir=tmp_path)
 
-        assert manifest["has_codex"] is True
+        assert manifest["has_collection_skill"] is True
 
 
 class TestGenerateManifestWithRoles:

--- a/tests/test_collection_manifest.py
+++ b/tests/test_collection_manifest.py
@@ -3,7 +3,7 @@
 import json
 
 from ansible_know.collection_manifest import (
-    _derive_tags,
+    derive_tags,
     generate_manifest,
     load_cached_manifest,
 )
@@ -12,23 +12,23 @@ from ansible_know.parser import extract_module_metadata
 
 class TestDeriveTags:
     def test_ip_address_module(self):
-        tags = _derive_tags("netbox.netbox.ip_address", [])
+        tags = derive_tags("netbox.netbox.ip_address", [])
         assert "ipam" in tags
 
     def test_device_module(self):
-        tags = _derive_tags("netbox.netbox.device", [])
+        tags = derive_tags("netbox.netbox.device", [])
         assert "dcim" in tags
 
     def test_docker_module(self):
-        tags = _derive_tags("community.docker.docker_container", [])
+        tags = derive_tags("community.docker.docker_container", [])
         assert "containers" in tags
 
     def test_no_matching_tags(self):
-        tags = _derive_tags("custom.collection.something_unique", [])
+        tags = derive_tags("custom.collection.something_unique", [])
         assert tags == []
 
     def test_multiple_tags(self):
-        tags = _derive_tags("some.collection.docker_network", [])
+        tags = derive_tags("some.collection.docker_network", [])
         assert "containers" in tags
         assert "networking" in tags
 
@@ -53,14 +53,14 @@ class TestGenerateManifest:
         metadata = extract_module_metadata(sample_module_doc)
         generate_manifest("ansible.builtin", [metadata], skills_dir=tmp_path)
 
-        manifest_path = tmp_path / "ansible" / "builtin" / "MANIFEST.json"
+        manifest_path = tmp_path / "ansible.builtin" / "MANIFEST.json"
         assert manifest_path.exists()
 
         loaded = json.loads(manifest_path.read_text())
         assert loaded["collection"] == "ansible.builtin"
 
     def test_detects_existing_skills(self, tmp_path, sample_module_doc):
-        skill_dir = tmp_path / "ansible.builtin.package"
+        skill_dir = tmp_path / "ansible.builtin" / "package"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("test")
 
@@ -74,6 +74,22 @@ class TestGenerateManifest:
         manifest = generate_manifest("netbox.netbox", [metadata], skills_dir=tmp_path)
 
         assert manifest["modules"][0]["is_api_module"] is True
+
+    def test_has_codex_false_by_default(self, tmp_path, sample_module_doc):
+        metadata = extract_module_metadata(sample_module_doc)
+        manifest = generate_manifest("ansible.builtin", [metadata], skills_dir=tmp_path)
+
+        assert manifest["has_codex"] is False
+
+    def test_has_codex_true_when_exists(self, tmp_path, sample_module_doc):
+        codex_dir = tmp_path / "ansible.builtin"
+        codex_dir.mkdir(parents=True)
+        (codex_dir / "SKILL.md").write_text("codex content")
+
+        metadata = extract_module_metadata(sample_module_doc)
+        manifest = generate_manifest("ansible.builtin", [metadata], skills_dir=tmp_path)
+
+        assert manifest["has_codex"] is True
 
 
 class TestGenerateManifestWithRoles:
@@ -124,7 +140,7 @@ class TestGenerateManifestWithRoles:
         assert manifest["roles"] == []
 
     def test_role_has_skill_detection(self, tmp_path):
-        skill_dir = tmp_path / "ansible.builtin.test_role"
+        skill_dir = tmp_path / "ansible.builtin" / "test_role"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("test")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -180,14 +180,14 @@ class TestGetSkillTool:
         assert result == "nested skill content"
 
     @pytest.mark.asyncio
-    async def test_reads_codex_by_namespace(self, tmp_path, monkeypatch):
+    async def test_reads_collection_skill_by_namespace(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
-        codex_dir = tmp_path / "netbox.netbox"
-        codex_dir.mkdir(parents=True)
-        (codex_dir / "SKILL.md").write_text("codex content")
+        coll_dir = tmp_path / "netbox.netbox"
+        coll_dir.mkdir(parents=True)
+        (coll_dir / "SKILL.md").write_text("collection skill content")
         from ansible_know.server import get_skill
         result = await get_skill("netbox.netbox")
-        assert result == "codex content"
+        assert result == "collection skill content"
 
     @pytest.mark.asyncio
     async def test_falls_back_to_flat_layout(self, tmp_path, monkeypatch):
@@ -325,12 +325,12 @@ class TestSkillNameValidation:
     @pytest.mark.asyncio
     async def test_get_skill_accepts_namespace(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
-        codex_dir = tmp_path / "netbox.netbox"
-        codex_dir.mkdir()
-        (codex_dir / "SKILL.md").write_text("codex")
+        coll_dir = tmp_path / "netbox.netbox"
+        coll_dir.mkdir()
+        (coll_dir / "SKILL.md").write_text("collection skill")
         from ansible_know.server import get_skill
         result = await get_skill("netbox.netbox")
-        assert result == "codex"
+        assert result == "collection skill"
 
     @pytest.mark.asyncio
     async def test_get_skill_rejects_single_segment(self):
@@ -661,14 +661,14 @@ class TestResourceFunctions:
         result = resource_skill_content("ansible.builtin.copy")
         assert result == "nested content"
 
-    def test_resource_skill_content_reads_codex(self, tmp_path, monkeypatch):
+    def test_resource_skill_content_reads_collection_skill(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
-        codex_dir = tmp_path / "netbox.netbox"
-        codex_dir.mkdir()
-        (codex_dir / "SKILL.md").write_text("codex content")
+        coll_dir = tmp_path / "netbox.netbox"
+        coll_dir.mkdir()
+        (coll_dir / "SKILL.md").write_text("collection skill content")
         from ansible_know.server import resource_skill_content
         result = resource_skill_content("netbox.netbox")
-        assert result == "codex content"
+        assert result == "collection skill content"
 
     def test_resource_skills_list_with_nested_skills(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -121,6 +121,28 @@ class TestListSkillsTool:
         result = await list_skills()
         assert result == []
 
+    @pytest.mark.asyncio
+    async def test_returns_top_level_skills(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        codex_dir = tmp_path / "netbox.netbox"
+        codex_dir.mkdir()
+        (codex_dir / "SKILL.md").write_text("---\nname: netbox.netbox\ndescription: Codex\n---\n")
+        from ansible_know.server import list_skills
+        result = await list_skills()
+        assert len(result) == 1
+        assert result[0]["name"] == "netbox.netbox"
+
+    @pytest.mark.asyncio
+    async def test_returns_collection_skills_with_filter(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        mod_dir = tmp_path / "netbox.netbox" / "netbox_device"
+        mod_dir.mkdir(parents=True)
+        (mod_dir / "SKILL.md").write_text("---\nname: netbox.netbox.netbox_device\ndescription: Device\n---\n")
+        from ansible_know.server import list_skills
+        result = await list_skills(collection="netbox.netbox")
+        assert len(result) == 1
+        assert result[0]["name"] == "netbox.netbox.netbox_device"
+
 
 class TestGetSkillTool:
     @pytest.mark.asyncio
@@ -131,6 +153,36 @@ class TestGetSkillTool:
         assert "error" in result
         assert "not found" in result["error"].lower()
 
+    @pytest.mark.asyncio
+    async def test_reads_nested_skill(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        nested = tmp_path / "netbox.netbox" / "netbox_device"
+        nested.mkdir(parents=True)
+        (nested / "SKILL.md").write_text("nested skill content")
+        from ansible_know.server import get_skill
+        result = await get_skill("netbox.netbox.netbox_device")
+        assert result == "nested skill content"
+
+    @pytest.mark.asyncio
+    async def test_reads_codex_by_namespace(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        codex_dir = tmp_path / "netbox.netbox"
+        codex_dir.mkdir(parents=True)
+        (codex_dir / "SKILL.md").write_text("codex content")
+        from ansible_know.server import get_skill
+        result = await get_skill("netbox.netbox")
+        assert result == "codex content"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_flat_layout(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        flat = tmp_path / "ansible.builtin.copy"
+        flat.mkdir(parents=True)
+        (flat / "SKILL.md").write_text("flat skill content")
+        from ansible_know.server import get_skill
+        result = await get_skill("ansible.builtin.copy")
+        assert result == "flat skill content"
+
 
 class TestGenerateSkillTool:
     @pytest.mark.asyncio
@@ -140,7 +192,7 @@ class TestGenerateSkillTool:
         from ansible_know.server import generate_skill
         result = await generate_skill("ansible.builtin.package")
         assert "ansible.builtin.package" in result
-        assert (tmp_path / "ansible.builtin.package" / "SKILL.md").exists()
+        assert (tmp_path / "ansible.builtin" / "package" / "SKILL.md").exists()
 
 
 class TestGenerateCollectionSkillsTool:
@@ -158,6 +210,8 @@ class TestGenerateCollectionSkillsTool:
         result = await generate_collection_skills("ansible.builtin", install_to=str(tmp_path))
         assert result["total"] == 4
         assert result["succeeded"] + result["failed"] == 4
+        assert result["codex"] == "ansible.builtin"
+        assert (tmp_path / "ansible.builtin" / "SKILL.md").exists()
 
 
 class TestFQCNValidation:
@@ -248,6 +302,24 @@ class TestQueryValidation:
     async def test_rejects_long_query(self):
         from ansible_know.server import search_docs
         result = await search_docs("a" * 501)
+        assert "error" in result
+
+
+class TestSkillNameValidation:
+    @pytest.mark.asyncio
+    async def test_get_skill_accepts_namespace(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        codex_dir = tmp_path / "netbox.netbox"
+        codex_dir.mkdir()
+        (codex_dir / "SKILL.md").write_text("codex")
+        from ansible_know.server import get_skill
+        result = await get_skill("netbox.netbox")
+        assert result == "codex"
+
+    @pytest.mark.asyncio
+    async def test_get_skill_rejects_single_segment(self):
+        from ansible_know.server import get_skill
+        result = await get_skill("copy")
         assert "error" in result
 
 
@@ -539,7 +611,7 @@ class TestGalaxyDocsFallback:
             result = await generate_skill("netbox.netbox.netbox_device")
 
         assert "netbox.netbox.netbox_device" in result
-        assert (tmp_path / "netbox.netbox.netbox_device" / "SKILL.md").exists()
+        assert (tmp_path / "netbox.netbox" / "netbox_device" / "SKILL.md").exists()
 
 
 class TestResourceFunctions:
@@ -551,18 +623,36 @@ class TestResourceFunctions:
 
     def test_resource_skills_list_with_skills(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
-        skill_dir = tmp_path / "ansible.builtin.copy"
+        skill_dir = tmp_path / "ansible.builtin"
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text("# Copy skill")
+        (skill_dir / "SKILL.md").write_text("# Codex skill")
         from ansible_know.server import resource_skills_list
         result = json.loads(resource_skills_list())
-        assert "ansible.builtin.copy" in result
+        assert "ansible.builtin" in result
 
     def test_resource_skill_content_not_found(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
         from ansible_know.server import resource_skill_content
         result = resource_skill_content("ansible.builtin.copy")
         assert "not found" in result.lower()
+
+    def test_resource_skill_content_reads_nested(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        nested = tmp_path / "ansible.builtin" / "copy"
+        nested.mkdir(parents=True)
+        (nested / "SKILL.md").write_text("nested content")
+        from ansible_know.server import resource_skill_content
+        result = resource_skill_content("ansible.builtin.copy")
+        assert result == "nested content"
+
+    def test_resource_skill_content_reads_codex(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        codex_dir = tmp_path / "netbox.netbox"
+        codex_dir.mkdir()
+        (codex_dir / "SKILL.md").write_text("codex content")
+        from ansible_know.server import resource_skill_content
+        result = resource_skill_content("netbox.netbox")
+        assert result == "codex content"
 
     def test_resource_skill_content_invalid_fqcn(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
@@ -1163,9 +1253,9 @@ class TestGenerateRoleSkillTool:
         from ansible_know.server import generate_role_skill
         result = await generate_role_skill("fedora.linux_system_roles.gfs2")
         assert "fedora.linux_system_roles.gfs2" in result
-        assert (tmp_path / "fedora.linux_system_roles.gfs2" / "SKILL.md").exists()
-        assert (tmp_path / "fedora.linux_system_roles.gfs2" / "assets" / "playbook.yml").exists()
-        assert not (tmp_path / "fedora.linux_system_roles.gfs2" / "scripts").exists()
+        assert (tmp_path / "fedora.linux_system_roles" / "gfs2" / "SKILL.md").exists()
+        assert (tmp_path / "fedora.linux_system_roles" / "gfs2" / "assets" / "playbook.yml").exists()
+        assert not (tmp_path / "fedora.linux_system_roles" / "gfs2" / "scripts").exists()
 
     @pytest.mark.asyncio
     async def test_validation_error(self):
@@ -1208,7 +1298,7 @@ class TestGenerateRoleSkillTool:
             result = await generate_role_skill("fedora.linux_system_roles.timesync")
 
         assert "fedora.linux_system_roles.timesync" in result
-        assert (tmp_path / "fedora.linux_system_roles.timesync" / "SKILL.md").exists()
+        assert (tmp_path / "fedora.linux_system_roles" / "timesync" / "SKILL.md").exists()
 
 
 class TestGetCollectionManifestWithRoles:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -124,13 +124,14 @@ class TestListSkillsTool:
     @pytest.mark.asyncio
     async def test_returns_top_level_skills(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
-        codex_dir = tmp_path / "netbox.netbox"
-        codex_dir.mkdir()
-        (codex_dir / "SKILL.md").write_text("---\nname: netbox.netbox\ndescription: Codex\n---\n")
+        skill_dir = tmp_path / "netbox.netbox"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\nname: netbox.netbox\ndescription: Collection guide\n---\n")
         from ansible_know.server import list_skills
         result = await list_skills()
         assert len(result) == 1
         assert result[0]["name"] == "netbox.netbox"
+        assert result[0]["description"] == "Collection guide"
 
     @pytest.mark.asyncio
     async def test_returns_collection_skills_with_filter(self, tmp_path, monkeypatch):
@@ -142,6 +143,21 @@ class TestListSkillsTool:
         result = await list_skills(collection="netbox.netbox")
         assert len(result) == 1
         assert result[0]["name"] == "netbox.netbox.netbox_device"
+        assert result[0]["description"] == "Device"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_nonexistent_collection(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        from ansible_know.server import list_skills
+        result = await list_skills(collection="nonexistent.collection")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_collection_name(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        from ansible_know.server import list_skills
+        result = await list_skills(collection="bad!")
+        assert "error" in result
 
 
 class TestGetSkillTool:
@@ -210,7 +226,7 @@ class TestGenerateCollectionSkillsTool:
         result = await generate_collection_skills("ansible.builtin", install_to=str(tmp_path))
         assert result["total"] == 4
         assert result["succeeded"] + result["failed"] == 4
-        assert result["codex"] == "ansible.builtin"
+        assert result["collection_skill"] == "ansible.builtin"
         assert (tmp_path / "ansible.builtin" / "SKILL.md").exists()
 
 
@@ -653,6 +669,28 @@ class TestResourceFunctions:
         from ansible_know.server import resource_skill_content
         result = resource_skill_content("netbox.netbox")
         assert result == "codex content"
+
+    def test_resource_skills_list_with_nested_skills(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        coll_dir = tmp_path / "netbox.netbox"
+        coll_dir.mkdir()
+        (coll_dir / "SKILL.md").write_text("# Collection skill")
+        mod_dir = coll_dir / "netbox_device"
+        mod_dir.mkdir()
+        (mod_dir / "SKILL.md").write_text("# Device skill")
+        from ansible_know.server import resource_skills_list
+        result = json.loads(resource_skills_list())
+        assert "netbox.netbox" in result
+        assert "netbox.netbox.netbox_device" in result
+
+    def test_resource_skill_content_flat_fallback(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        flat = tmp_path / "ansible.builtin.copy"
+        flat.mkdir(parents=True)
+        (flat / "SKILL.md").write_text("flat content")
+        from ansible_know.server import resource_skill_content
+        result = resource_skill_content("ansible.builtin.copy")
+        assert result == "flat content"
 
     def test_resource_skill_content_invalid_fqcn(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -6,6 +6,7 @@ from ansible_know.skills import (
     _build_example_args,
     _collection_template_context,
     _extract_example_values,
+    _find_common_params,
     _role_template_context,
     module_to_skill_name,
     render_collection_skill,
@@ -272,13 +273,49 @@ class TestCollectionTemplateContext:
         assert ctx["collection_version"] == "2.15.0"
 
 
+class TestFindCommonParams:
+    def test_empty_metadata(self):
+        assert _find_common_params([]) == []
+
+    def test_single_module_all_params_common(self):
+        meta = {
+            "module_name": "ns.col.mod",
+            "params": [{"name": "url", "type": "str", "required": True}],
+        }
+        result = _find_common_params([meta])
+        assert len(result) == 1
+        assert result[0]["name"] == "url"
+
+    def test_threshold_boundary_at_80_percent(self):
+        shared_param = {"name": "token", "type": "str", "required": True}
+        unique_param = {"name": "unique", "type": "str", "required": False}
+        metas = [
+            {"module_name": f"ns.col.mod{i}", "params": [shared_param]}
+            for i in range(4)
+        ]
+        metas.append({"module_name": "ns.col.mod5", "params": [unique_param]})
+        result = _find_common_params(metas)
+        names = [p["name"] for p in result]
+        assert "token" in names
+        assert "unique" not in names
+
+    def test_below_threshold_excluded(self):
+        metas = [
+            {"module_name": "ns.col.mod1", "params": [{"name": "a", "type": "str", "required": True}]},
+            {"module_name": "ns.col.mod2", "params": [{"name": "b", "type": "str", "required": True}]},
+            {"module_name": "ns.col.mod3", "params": [{"name": "c", "type": "str", "required": True}]},
+        ]
+        result = _find_common_params(metas)
+        assert result == []
+
+
 class TestRenderCollectionSkill:
     def test_renders_codex(self, sample_api_module_doc):
         metadata = extract_module_metadata(sample_api_module_doc)
         content = render_collection_skill("netbox.netbox", [metadata], collection_version="4.1.0")
 
         assert "netbox.netbox" in content
-        assert "Playbook Codex" in content
+        assert "Playbook Guide" in content
         assert "Phase 1" in content
         assert "Phase 2" in content
         assert "Phase 5" in content
@@ -307,4 +344,4 @@ class TestWriteCollectionSkillPackage:
 
         content = (output_dir / "SKILL.md").read_text()
         assert "netbox.netbox" in content
-        assert "Playbook Codex" in content
+        assert "Playbook Guide" in content

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -4,11 +4,16 @@
 from ansible_know.parser import extract_module_metadata
 from ansible_know.skills import (
     _build_example_args,
+    _collection_template_context,
     _extract_example_values,
     _role_template_context,
     module_to_skill_name,
+    render_collection_skill,
+    render_module_skill,
     render_role_skill,
     render_skill,
+    write_collection_skill_package,
+    write_module_skill_package,
     write_role_skill_package,
     write_skill_package,
 )
@@ -20,6 +25,14 @@ class TestModuleToSkillName:
 
     def test_preserves_collection_prefix(self):
         assert module_to_skill_name("netbox.netbox.netbox_device") == "netbox.netbox.netbox_device"
+
+
+class TestBackwardCompatAliases:
+    def test_render_skill_is_render_module_skill(self):
+        assert render_skill is render_module_skill
+
+    def test_write_skill_package_is_write_module_skill_package(self):
+        assert write_skill_package is write_module_skill_package
 
 
 class TestExtractExampleValues:
@@ -66,10 +79,10 @@ class TestBuildExampleArgs:
         assert "opt1=val1" in result
 
 
-class TestRenderSkill:
+class TestRenderModuleSkill:
     def test_renders_system_module(self, sample_module_doc):
         metadata = extract_module_metadata(sample_module_doc)
-        content = render_skill(metadata)
+        content = render_module_skill(metadata)
         assert "ansible.builtin.package" in content
         assert "Generic OS package manager" in content
         assert "## Parameters" in content
@@ -77,15 +90,15 @@ class TestRenderSkill:
 
     def test_renders_api_module(self, sample_api_module_doc):
         metadata = extract_module_metadata(sample_api_module_doc)
-        content = render_skill(metadata)
+        content = render_module_skill(metadata)
         assert "connection: local" in content.lower() or "connection:" in content.lower() or "API" in content
 
 
-class TestWriteSkillPackage:
+class TestWriteModuleSkillPackage:
     def test_writes_full_package(self, tmp_path, sample_module_doc):
         metadata = extract_module_metadata(sample_module_doc)
         output_dir = tmp_path / "ansible.builtin.package"
-        write_skill_package(output_dir, metadata)
+        write_module_skill_package(output_dir, metadata)
 
         assert (output_dir / "SKILL.md").exists()
         assert (output_dir / "scripts" / "run.sh").exists()
@@ -98,7 +111,7 @@ class TestWriteSkillPackage:
     def test_scripts_are_executable(self, tmp_path, sample_module_doc):
         metadata = extract_module_metadata(sample_module_doc)
         output_dir = tmp_path / "test_skill"
-        write_skill_package(output_dir, metadata)
+        write_module_skill_package(output_dir, metadata)
 
         import os
         run_sh = output_dir / "scripts" / "run.sh"
@@ -201,3 +214,97 @@ class TestWriteRoleSkillPackage:
 
         playbook_content = (output_dir / "assets" / "playbook.yml").read_text()
         assert "fedora.linux_system_roles.timesync" in playbook_content
+
+
+class TestCollectionTemplateContext:
+    def test_groups_modules_by_tag(self, sample_api_module_doc):
+        metadata = extract_module_metadata(sample_api_module_doc)
+        ctx = _collection_template_context("netbox.netbox", [metadata])
+
+        assert ctx["collection_namespace"] == "netbox.netbox"
+        assert ctx["module_count"] == 1
+        assert isinstance(ctx["modules_by_tag"], dict)
+        found = False
+        for modules in ctx["modules_by_tag"].values():
+            for m in modules:
+                if m["fqcn"] == "netbox.netbox.netbox_device":
+                    found = True
+        assert found
+
+    def test_all_api_detection(self, sample_api_module_doc):
+        metadata = extract_module_metadata(sample_api_module_doc)
+        ctx = _collection_template_context("netbox.netbox", [metadata])
+        assert ctx["all_api"] is True
+
+    def test_all_api_false_for_mixed(self, sample_module_doc, sample_api_module_doc):
+        meta1 = extract_module_metadata(sample_module_doc)
+        meta2 = extract_module_metadata(sample_api_module_doc)
+        ctx = _collection_template_context("mixed.collection", [meta1, meta2])
+        assert ctx["all_api"] is False
+
+    def test_common_params_detection(self, sample_api_module_doc):
+        metadata = extract_module_metadata(sample_api_module_doc)
+        ctx = _collection_template_context("netbox.netbox", [metadata])
+        common_names = [p["name"] for p in ctx["common_params"]]
+        assert "data" in common_names or "netbox_url" in common_names
+
+    def test_empty_metadata_list(self):
+        ctx = _collection_template_context("empty.collection", [])
+        assert ctx["module_count"] == 0
+        assert ctx["all_api"] is False
+        assert ctx["common_params"] == []
+        assert ctx["modules_by_tag"] == {}
+
+    def test_untagged_modules_go_to_other(self):
+        metadata = {
+            "module_name": "custom.collection.something_unique",
+            "short_description": "A unique module",
+            "params": [],
+            "examples": "",
+            "is_api_module": False,
+        }
+        ctx = _collection_template_context("custom.collection", [metadata])
+        assert "other" in ctx["modules_by_tag"]
+
+    def test_collection_version(self, sample_module_doc):
+        metadata = extract_module_metadata(sample_module_doc)
+        ctx = _collection_template_context("ansible.builtin", [metadata], collection_version="2.15.0")
+        assert ctx["collection_version"] == "2.15.0"
+
+
+class TestRenderCollectionSkill:
+    def test_renders_codex(self, sample_api_module_doc):
+        metadata = extract_module_metadata(sample_api_module_doc)
+        content = render_collection_skill("netbox.netbox", [metadata], collection_version="4.1.0")
+
+        assert "netbox.netbox" in content
+        assert "Playbook Codex" in content
+        assert "Phase 1" in content
+        assert "Phase 2" in content
+        assert "Phase 5" in content
+        assert "v4.1.0" in content
+
+    def test_renders_api_connection_requirements(self, sample_api_module_doc):
+        metadata = extract_module_metadata(sample_api_module_doc)
+        content = render_collection_skill("netbox.netbox", [metadata])
+        assert "connection: local" in content
+
+    def test_renders_without_api_section_for_system_modules(self, sample_module_doc):
+        metadata = extract_module_metadata(sample_module_doc)
+        content = render_collection_skill("ansible.builtin", [metadata])
+        assert "connection: local" not in content
+
+
+class TestWriteCollectionSkillPackage:
+    def test_writes_skill_md_only(self, tmp_path, sample_api_module_doc):
+        metadata = extract_module_metadata(sample_api_module_doc)
+        output_dir = tmp_path / "netbox.netbox"
+        write_collection_skill_package(output_dir, "netbox.netbox", [metadata])
+
+        assert (output_dir / "SKILL.md").exists()
+        assert not (output_dir / "scripts").exists()
+        assert not (output_dir / "assets").exists()
+
+        content = (output_dir / "SKILL.md").read_text()
+        assert "netbox.netbox" in content
+        assert "Playbook Codex" in content

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -310,7 +310,7 @@ class TestFindCommonParams:
 
 
 class TestRenderCollectionSkill:
-    def test_renders_codex(self, sample_api_module_doc):
+    def test_renders_collection_skill(self, sample_api_module_doc):
         metadata = extract_module_metadata(sample_api_module_doc)
         content = render_collection_skill("netbox.netbox", [metadata], collection_version="4.1.0")
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -10,6 +10,7 @@ from ansible_know.validation import (
     MAX_NAMESPACE_LENGTH,
     MAX_QUERY_LENGTH,
     MAX_RESPONSE_SIZE,
+    MAX_SKILL_NAME_LENGTH,
     MAX_TAGS_LENGTH,
     MAX_VERSION_LENGTH,
     sanitize_error,
@@ -20,6 +21,7 @@ from ansible_know.validation import (
     validate_namespace,
     validate_path_containment,
     validate_query,
+    validate_skill_name,
     validate_tags,
     validate_version,
 )
@@ -116,6 +118,58 @@ class TestValidateNamespace:
         too_long = "a" * 64 + "." + "b" * 64
         with pytest.raises(ValidationError):
             validate_namespace(too_long)
+
+
+class TestValidateSkillName:
+    def test_valid_two_segments(self):
+        validate_skill_name("netbox.netbox")
+
+    def test_valid_three_segments(self):
+        validate_skill_name("netbox.netbox.netbox_device")
+
+    def test_valid_with_underscores(self):
+        validate_skill_name("my_ns.my_col.my_mod")
+
+    def test_valid_with_numbers(self):
+        validate_skill_name("ns1.col2.mod3")
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValidationError):
+            validate_skill_name("")
+
+    def test_rejects_single_segment(self):
+        with pytest.raises(ValidationError):
+            validate_skill_name("copy")
+
+    def test_rejects_four_segments(self):
+        with pytest.raises(ValidationError):
+            validate_skill_name("a.b.c.d")
+
+    def test_rejects_dashes(self):
+        with pytest.raises(ValidationError):
+            validate_skill_name("my-ns.my-col")
+
+    def test_rejects_path_traversal(self):
+        with pytest.raises(ValidationError):
+            validate_skill_name("../../etc/passwd")
+
+    def test_rejects_shell_metacharacters(self):
+        for char in [";", "|", "&", "$", "`"]:
+            with pytest.raises(ValidationError):
+                validate_skill_name(f"a.b{char}rm")
+
+    def test_rejects_over_max_length(self):
+        valid = "a" * 100 + "." + "b" * 100
+        assert len(valid) < MAX_SKILL_NAME_LENGTH
+        validate_skill_name(valid)
+
+        too_long = "a" * 128 + "." + "b" * 128
+        with pytest.raises(ValidationError):
+            validate_skill_name(too_long)
+
+    def test_rejects_slashes(self):
+        with pytest.raises(ValidationError):
+            validate_skill_name("a/b.c")
 
 
 class TestValidateKeyword:


### PR DESCRIPTION
## Summary

Closes #82

- Add collection-level codex skill generation — a single SKILL.md per collection that guides agents through 5-phase playbook development (gather intent → select modules → design → write → validate)
- Restructure skill directory layout from flat (`skills/netbox.netbox.netbox_device/`) to nested by collection namespace (`skills/netbox.netbox/netbox_device/`)
- Codex lives at `skills/{namespace}/SKILL.md`, generated from the same `metadata_list` already collected during `generate_collection_skills`

### API changes

- `list_skills()` default returns collection-level entries only; new `collection` param drills into module skills
- `get_skill("netbox.netbox")` returns codex; `get_skill("netbox.netbox.netbox_device")` resolves nested path with flat fallback
- `generate_collection_skills` result includes `"codex": namespace` field
- Internal renames: `render_skill` → `render_module_skill`, `write_skill_package` → `write_module_skill_package` (backward-compat aliases preserved)

### Migration note

**Breaking change:** Skills directory layout changed from flat (`skills/ns.coll.module/`) to nested (`skills/ns.coll/module/`). Existing flat-layout skills remain readable via `get_skill()` (flat fallback), but `list_skills(collection=...)` only finds nested-layout skills. To migrate: regenerate skills with `generate_collection_skills()`.

### Architecture review

- Made `_derive_tags` public (`derive_tags()`) to avoid private function import across Domain modules (V-L5)
- Added `CollectionSkillContext` TypedDict (V-D6)
- `validate_path_containment()` applied after nested path construction in all resolution branches
- `write_collection_skill_package()` wrapped in `run_in_executor()` for async safety
- Wrapped `generate_manifest()` and `load_cached_manifest()` in `run_in_executor()` (pre-existing blocking I/O fix)
- Updated `resource_skills_list()` to include nested module skills (consistency with `list_skills()`)
- Follow-up: #89 (move `derive_tags()` to Foundation layer to eliminate Domain→Domain cross-import)

## Test plan

- [x] All 487 tests pass (`pytest tests/ -q`)
- [x] Ruff clean (`ruff check src/ tests/`)
- [x] New tests: collection template context, render/write codex, nested skill resolution, flat fallback, list_skills with collection filter
- [ ] Integration test: `generate_collection_skills("netbox.netbox")` produces nested layout + codex (needs ansible-core + network)

Assisted-by: Claude Opus 4.6