### PR TITLE
refactor: move derive_tags to Foundation and wrap get_skill in executor (#89, #90)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ src/ansible_know/
 ├── collection_manifest.py # collection-level MANIFEST.json generation/caching
 ├── docs.py                # multi-manifest documentation client (httpx)
 ├── galaxy.py              # Galaxy v3 API client — search, docs-blob, format conversion
+├── tagging.py             # Tag derivation from module metadata (Foundation)
 └── templates/             # Jinja2 templates for skill packages
 ```
 

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -29,7 +29,8 @@ The server follows a 5-layer pipeline architecture adapted for MCP:
 ├─────────────────────────────────────────────────────────┤
 │  Foundation        async_utils.py, cache.py, config.py,  │
 │                    galaxy_config.py, state.py,            │
-│                    validation.py, errors.py, types.py     │
+│                    tagging.py, validation.py,             │
+│                    errors.py, types.py                    │
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -139,10 +140,10 @@ business logic. Domain modules are imported lazily to avoid loading
 | ID | Severity | Description | Location |
 |----|----------|-------------|----------|
 | V-D1 | Warning | `server.py` calls `skills._module_to_skill_name()` — a private function (leading underscore). This crosses the public API boundary. Should be exposed as a public function or the skill name derivation should be the caller's responsibility. | `server.py:753`, `server.py:880` |
-| V-D2 | Warning | `parser.py` does not define `__all__`. All module-level functions are implicitly public, including internal helpers like `_get_module_name()` and `_run_ansible_doc()`. | `parser.py` |
-| V-D3 | Warning | `skills.py` does not define `__all__`. | `skills.py` |
-| V-D4 | Warning | `collection_manifest.py` does not define `__all__`. | `collection_manifest.py` |
-| V-D5 | Warning | `docs.py` does not define `__all__`. | `docs.py` |
+| ~~V-D2~~ | ~~Warning~~ | ~~`parser.py` does not define `__all__`. All module-level functions are implicitly public, including internal helpers like `_get_module_name()` and `_run_ansible_doc()`.~~ **Fixed** — `parser.py` now defines `__all__`. | ~~`parser.py`~~ |
+| ~~V-D3~~ | ~~Warning~~ | ~~`skills.py` does not define `__all__`.~~ **Fixed** — `skills.py` now defines `__all__`. | ~~`skills.py`~~ |
+| ~~V-D4~~ | ~~Warning~~ | ~~`collection_manifest.py` does not define `__all__`.~~ **Fixed** — `collection_manifest.py` now defines `__all__`. | ~~`collection_manifest.py`~~ |
+| ~~V-D5~~ | ~~Warning~~ | ~~`docs.py` does not define `__all__`.~~ **Fixed** — `docs.py` now defines `__all__`. | ~~`docs.py`~~ |
 | V-D6 | Info | Several Domain functions return `dict[str, Any]` where TypedDicts exist. Partially addressed in PR #60 (`EnsureCollectionResult` now typed on `collections.ensure_collection()`, plus `ErrorResponse`, `SkillEntry`, `CollectionSearchResult` TypedDicts added) but not all return sites use them yet. | `parser.py:214-223`, `server.py:195-240` |
 | ~~V-D7~~ | ~~Warning~~ | ~~`_resolve_module_doc()` and `_resolve_role_doc()` in `server.py` contain significant business logic (Galaxy fallback, missing-collection caching). This logic belongs in the Domain layer, not Orchestration. The Orchestration layer should delegate to a domain-level resolution function.~~ **Fixed in PR #66** — Resolution logic moved to `resolution.py`. | ~~`server.py:195-301`~~ |
 | V-D8 | Warning | `collection_manifest.generate_manifest()` writes to disk as a side effect. A Domain function that both generates and persists violates separation of concerns — generation and persistence should be separate operations. | `collection_manifest.py:113-117` |
@@ -219,6 +220,8 @@ dependencies on upper layers.
 | `cache.py` | Thread-safe bounded LRU cache with TTL | `cache.py` |
 | `config.py` | Paths, constants, env var defaults, doc sources | `config.py` |
 | `galaxy_config.py` | Galaxy server config from `ansible.cfg` | `galaxy_config.py` |
+| `state.py` | Session state management (collection install tracking) | `state.py` |
+| `tagging.py` | Tag derivation from module FQCN segments | `tagging.py` |
 | `validation.py` | Input validation, error sanitization, response truncation | `validation.py` |
 | `errors.py` | Exception hierarchy and error helpers | `errors.py` |
 | `types.py` | `TypedDict` definitions, `GalaxyDocClient` Protocol | `types.py` |
@@ -366,7 +369,7 @@ Foundation   → (no internal dependencies)
 4. **V-T2**: Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()`.
 5. **V-D1**: Make `_module_to_skill_name()` public (rename to
    `module_to_skill_name()`).
-6. **V-D2–V-D5**: Add `__all__` to all modules.
+6. ~~**V-D2–V-D5**: Add `__all__` to all modules.~~ **Fixed** — all modules now define `__all__`.
 7. ~~**V-D7 / V-L2**: Move `_resolve_module_doc()` and `_resolve_role_doc()` to a
    domain-level resolution module.~~ **Fixed in PR #66**.
 8. **V-D8**: Split `generate_manifest()` into generation and persistence.

--- a/skills/pr-architecture-review/SKILL.md
+++ b/skills/pr-architecture-review/SKILL.md
@@ -36,6 +36,9 @@ classify each changed file into its architecture layer:
 | `src/ansible_know/cache.py` | **Foundation** |
 | `src/ansible_know/config.py` | **Foundation** |
 | `src/ansible_know/galaxy_config.py` | **Foundation** |
+| `src/ansible_know/async_utils.py` | **Foundation** |
+| `src/ansible_know/state.py` | **Foundation** |
+| `src/ansible_know/tagging.py` | **Foundation** |
 | `src/ansible_know/validation.py` | **Foundation** |
 | `src/ansible_know/errors.py` | **Foundation** |
 | `src/ansible_know/types.py` | **Foundation** |

--- a/src/ansible_know/async_utils.py
+++ b/src/ansible_know/async_utils.py
@@ -3,13 +3,19 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable, Coroutine
 from functools import partial
-from typing import Any
+from typing import Any, ParamSpec, TypeVar
 
 __all__ = ["run_in_executor"]
 
+P = ParamSpec("P")
+R = TypeVar("R")
 
-def run_in_executor(func: Any, *args: Any, **kwargs: Any) -> Any:
+
+def run_in_executor(
+    func: Callable[P, R], *args: P.args, **kwargs: P.kwargs
+) -> Coroutine[Any, Any, R]:
     """Run a blocking function in the default executor."""
     loop = asyncio.get_running_loop()
     return loop.run_in_executor(None, partial(func, *args, **kwargs))

--- a/src/ansible_know/collection_manifest.py
+++ b/src/ansible_know/collection_manifest.py
@@ -12,44 +12,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ansible_know.config import SKILLS_DIR
+from ansible_know.tagging import derive_tags
 
 if TYPE_CHECKING:
     from ansible_know.types import ModuleMetadata
 
 __all__ = [
-    "derive_tags",
     "generate_manifest",
     "load_cached_manifest",
 ]
-
-
-def derive_tags(fqcn: str, params: list[dict[str, Any]]) -> list[str]:
-    """Heuristically derive tags from module name segments and parameters."""
-    parts = fqcn.split(".")
-    module_short = parts[-1] if parts else fqcn
-
-    tags: set[str] = set()
-    tag_hints = {
-        "user": "identity", "group": "identity", "role": "identity",
-        "network": "networking", "interface": "networking", "vlan": "networking",
-        "firewall": "security", "acl": "security", "cert": "security",
-        "file": "files", "copy": "files", "template": "files",
-        "package": "packages", "apt": "packages", "yum": "packages", "dnf": "packages",
-        "service": "services", "systemd": "services",
-        "docker": "containers", "podman": "containers", "container": "containers",
-        "ip": "ipam", "prefix": "ipam", "subnet": "ipam", "address": "ipam",
-        "device": "dcim", "rack": "dcim", "site": "dcim",
-        "vm": "virtualization", "virtual": "virtualization",
-        "cloud": "cloud", "ec2": "cloud", "azure": "cloud", "gcp": "cloud",
-        "db": "database", "database": "database", "mysql": "database", "postgres": "database",
-    }
-
-    for segment in module_short.split("_"):
-        segment_lower = segment.lower()
-        if segment_lower in tag_hints:
-            tags.add(tag_hints[segment_lower])
-
-    return sorted(tags)
 
 
 def generate_manifest(

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -954,35 +954,14 @@ def resource_skill_content(skill_name: str) -> str:
     except ValidationError as exc:
         return str(exc)
 
-    parts = skill_name.split(".")
-    if len(parts) >= 3:
-        namespace = ".".join(parts[:2])
-        short_name = ".".join(parts[2:])
-        nested_path = (SKILLS_DIR / namespace / short_name / "SKILL.md").resolve()
-        try:
-            validate_path_containment(nested_path, SKILLS_DIR)
-        except ValidationError as exc:
-            return str(exc)
-        if nested_path.exists():
-            return truncate_response(nested_path.read_text())
+    try:
+        result = _get_skill_sync(SKILLS_DIR, skill_name)
+    except ValidationError as exc:
+        return str(exc)
 
-        flat_path = (SKILLS_DIR / skill_name / "SKILL.md").resolve()
-        try:
-            validate_path_containment(flat_path, SKILLS_DIR)
-        except ValidationError as exc:
-            return str(exc)
-        if flat_path.exists():
-            return truncate_response(flat_path.read_text())
-    else:
-        skill_path = (SKILLS_DIR / skill_name / "SKILL.md").resolve()
-        try:
-            validate_path_containment(skill_path, SKILLS_DIR)
-        except ValidationError as exc:
-            return str(exc)
-        if skill_path.exists():
-            return truncate_response(skill_path.read_text())
-
-    return f"Skill '{skill_name}' not found."
+    if isinstance(result, dict):
+        return result.get("error", f"Skill '{skill_name}' not found.")
+    return result
 
 
 @mcp.resource(

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -641,6 +641,32 @@ async def list_skills(
         return {"error": sanitize_error(str(exc))}
 
 
+def _get_skill_sync(
+    skills_dir: Path, skill_name: str,
+) -> str | dict[str, str]:
+    """Synchronous helper for get_skill — all file I/O happens here."""
+    parts = skill_name.split(".")
+    if len(parts) >= 3:
+        namespace = ".".join(parts[:2])
+        short_name = ".".join(parts[2:])
+        nested_path = (skills_dir / namespace / short_name / "SKILL.md").resolve()
+        validate_path_containment(nested_path, skills_dir)
+        if nested_path.exists():
+            return truncate_response(nested_path.read_text())
+
+        flat_path = (skills_dir / skill_name / "SKILL.md").resolve()
+        validate_path_containment(flat_path, skills_dir)
+        if flat_path.exists():
+            return truncate_response(flat_path.read_text())
+    else:
+        skill_path = (skills_dir / skill_name / "SKILL.md").resolve()
+        validate_path_containment(skill_path, skills_dir)
+        if skill_path.exists():
+            return truncate_response(skill_path.read_text())
+
+    return {"error": f"Skill '{skill_name}' not found."}
+
+
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def get_skill(
     skill_name: Annotated[
@@ -662,26 +688,7 @@ async def get_skill(
     try:
         from ansible_know.config import SKILLS_DIR
 
-        parts = skill_name.split(".")
-        if len(parts) >= 3:
-            namespace = ".".join(parts[:2])
-            short_name = ".".join(parts[2:])
-            nested_path = (SKILLS_DIR / namespace / short_name / "SKILL.md").resolve()
-            validate_path_containment(nested_path, SKILLS_DIR)
-            if nested_path.exists():
-                return truncate_response(nested_path.read_text())
-
-            flat_path = (SKILLS_DIR / skill_name / "SKILL.md").resolve()
-            validate_path_containment(flat_path, SKILLS_DIR)
-            if flat_path.exists():
-                return truncate_response(flat_path.read_text())
-        else:
-            skill_path = (SKILLS_DIR / skill_name / "SKILL.md").resolve()
-            validate_path_containment(skill_path, SKILLS_DIR)
-            if skill_path.exists():
-                return truncate_response(skill_path.read_text())
-
-        return {"error": f"Skill '{skill_name}' not found."}
+        return await run_in_executor(_get_skill_sync, SKILLS_DIR, skill_name)
     except ValidationError as exc:
         return {"error": str(exc)}
     except Exception as exc:

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -641,10 +641,16 @@ async def list_skills(
         return {"error": sanitize_error(str(exc))}
 
 
-def _get_skill_sync(
-    skills_dir: Path, skill_name: str,
-) -> str | dict[str, str]:
-    """Synchronous helper for get_skill — all file I/O happens here."""
+def _get_skill_sync(skills_dir: Path, skill_name: str) -> str:
+    """Read a skill's SKILL.md content from disk.
+
+    Callers MUST validate ``skill_name`` with ``validate_skill_name()`` first.
+
+    Raises:
+        FileNotFoundError: If no matching SKILL.md exists.
+        ValidationError: If a resolved path escapes ``skills_dir``.
+        OSError: On permission or I/O errors reading the file.
+    """
     parts = skill_name.split(".")
     if len(parts) >= 3:
         namespace = ".".join(parts[:2])
@@ -664,7 +670,7 @@ def _get_skill_sync(
         if skill_path.exists():
             return truncate_response(skill_path.read_text())
 
-    return {"error": f"Skill '{skill_name}' not found."}
+    raise FileNotFoundError(f"Skill '{skill_name}' not found.")
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -689,6 +695,8 @@ async def get_skill(
         from ansible_know.config import SKILLS_DIR
 
         return await run_in_executor(_get_skill_sync, SKILLS_DIR, skill_name)
+    except FileNotFoundError as exc:
+        return {"error": str(exc)}
     except ValidationError as exc:
         return {"error": str(exc)}
     except Exception as exc:
@@ -955,13 +963,13 @@ def resource_skill_content(skill_name: str) -> str:
         return str(exc)
 
     try:
-        result = _get_skill_sync(SKILLS_DIR, skill_name)
+        return _get_skill_sync(SKILLS_DIR, skill_name)
+    except FileNotFoundError as exc:
+        return str(exc)
     except ValidationError as exc:
         return str(exc)
-
-    if isinstance(result, dict):
-        return result.get("error", f"Skill '{skill_name}' not found.")
-    return result
+    except OSError as exc:
+        return sanitize_error(str(exc))
 
 
 @mcp.resource(

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ansible_know.config import TEMPLATE_DIR
+from ansible_know.tagging import derive_tags
 
 if TYPE_CHECKING:
     from ansible_know.types import CollectionSkillContext, ModuleTagEntry
@@ -212,8 +213,6 @@ def _collection_template_context(
     collection_version: str | None = None,
 ) -> CollectionSkillContext:
     """Build template context for a collection-level skill."""
-    from ansible_know.tagging import derive_tags
-
     modules_by_tag: dict[str, list[ModuleTagEntry]] = {}
     for meta in metadata_list:
         fqcn = meta["module_name"]

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -212,7 +212,7 @@ def _collection_template_context(
     collection_version: str | None = None,
 ) -> CollectionSkillContext:
     """Build template context for a collection-level skill."""
-    from ansible_know.collection_manifest import derive_tags
+    from ansible_know.tagging import derive_tags
 
     modules_by_tag: dict[str, list[ModuleTagEntry]] = {}
     for meta in metadata_list:

--- a/src/ansible_know/tagging.py
+++ b/src/ansible_know/tagging.py
@@ -26,9 +26,9 @@ def derive_tags(fqcn: str, params: list[dict[str, Any]]) -> list[str]:
 
     Contract:
         Preconditions:
-            - `fqcn` must be a string. If not, raises `AttributeError` when
-              calling `.split()` (implicit, line 59).
-            - `params` must be a list (not validated, but reserved for future use).
+            - `fqcn` must be a string. If not, raises `AttributeError` from
+              `.split()`.
+            - `params` must be a list (not validated, reserved for future use).
 
         Raises:
             AttributeError: If `fqcn` is not a string (implicit from `.split()`).

--- a/src/ansible_know/tagging.py
+++ b/src/ansible_know/tagging.py
@@ -1,0 +1,67 @@
+"""Tag derivation from module metadata (Foundation layer — no internal dependencies)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["derive_tags"]
+
+
+def derive_tags(fqcn: str, params: list[dict[str, Any]]) -> list[str]:
+    """Heuristically derive tags from module name segments and parameters.
+
+    Analyzes the module's fully-qualified collection name (FQCN) to extract
+    semantic tags based on common naming patterns. Splits the module short name
+    on underscores and maps each segment to a category tag when a match is found
+    in the predefined tag hints dictionary.
+
+    Args:
+        fqcn: Fully-qualified collection name (e.g., "netbox.netbox.ip_address").
+        params: List of parameter dictionaries (currently unused, reserved for
+            future tag derivation from parameter metadata).
+
+    Returns:
+        Sorted list of unique tag strings derived from the module name.
+        Returns empty list if no segments match any tag hints.
+
+    Contract:
+        Preconditions:
+            - `fqcn` must be a string. If not, raises `AttributeError` when
+              calling `.split()` (implicit, line 59).
+            - `params` must be a list (not validated, but reserved for future use).
+
+        Raises:
+            AttributeError: If `fqcn` is not a string (implicit from `.split()`).
+
+        Notes:
+            - Always returns a valid list (empty if no matches).
+            - Tag matching is case-insensitive via `.lower()` on segments.
+            - Multiple segments may map to the same tag — deduplication via `set`.
+            - Params parameter is reserved for future enhancement but currently
+              ignored.
+    """
+    parts = fqcn.split(".")
+    module_short = parts[-1] if parts else fqcn
+
+    tags: set[str] = set()
+    tag_hints = {
+        "user": "identity", "group": "identity", "role": "identity",
+        "network": "networking", "interface": "networking", "vlan": "networking",
+        "firewall": "security", "acl": "security", "cert": "security",
+        "file": "files", "copy": "files", "template": "files",
+        "package": "packages", "apt": "packages", "yum": "packages", "dnf": "packages",
+        "service": "services", "systemd": "services",
+        "docker": "containers", "podman": "containers", "container": "containers",
+        "ip": "ipam", "prefix": "ipam", "subnet": "ipam", "address": "ipam",
+        "device": "dcim", "rack": "dcim", "site": "dcim",
+        "vm": "virtualization", "virtual": "virtualization",
+        "cloud": "cloud", "ec2": "cloud", "azure": "cloud", "gcp": "cloud",
+        "db": "database", "database": "database", "mysql": "database", "postgres": "database",
+    }
+
+    for segment in module_short.split("_"):
+        segment_lower = segment.lower()
+        if segment_lower in tag_hints:
+            tags.add(tag_hints[segment_lower])
+
+    return sorted(tags)

--- a/tests/test_collection_manifest.py
+++ b/tests/test_collection_manifest.py
@@ -3,11 +3,11 @@
 import json
 
 from ansible_know.collection_manifest import (
-    derive_tags,
     generate_manifest,
     load_cached_manifest,
 )
 from ansible_know.parser import extract_module_metadata
+from ansible_know.tagging import derive_tags
 
 
 class TestDeriveTags:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -339,6 +339,31 @@ class TestSkillNameValidation:
         assert "error" in result
 
 
+class TestGetSkillSync:
+    def test_returns_content_for_namespace_skill(self, tmp_path):
+        from ansible_know.server import _get_skill_sync
+
+        coll_dir = tmp_path / "netbox.netbox"
+        coll_dir.mkdir()
+        (coll_dir / "SKILL.md").write_text("collection skill content")
+        assert _get_skill_sync(tmp_path, "netbox.netbox") == "collection skill content"
+
+    def test_returns_content_for_nested_module_skill(self, tmp_path):
+        from ansible_know.server import _get_skill_sync
+
+        mod_dir = tmp_path / "netbox.netbox" / "netbox_device"
+        mod_dir.mkdir(parents=True)
+        (mod_dir / "SKILL.md").write_text("module skill content")
+        assert _get_skill_sync(tmp_path, "netbox.netbox.netbox_device") == "module skill content"
+
+    def test_returns_error_for_missing_skill(self, tmp_path):
+        from ansible_know.server import _get_skill_sync
+
+        result = _get_skill_sync(tmp_path, "no.such.module")
+        assert isinstance(result, dict)
+        assert "error" in result
+
+
 class TestPathTraversal:
     @pytest.mark.asyncio
     async def test_get_skill_blocks_traversal(self, tmp_path, monkeypatch):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -356,12 +356,19 @@ class TestGetSkillSync:
         (mod_dir / "SKILL.md").write_text("module skill content")
         assert _get_skill_sync(tmp_path, "netbox.netbox.netbox_device") == "module skill content"
 
-    def test_returns_error_for_missing_skill(self, tmp_path):
+    def test_falls_back_to_flat_layout(self, tmp_path):
         from ansible_know.server import _get_skill_sync
 
-        result = _get_skill_sync(tmp_path, "no.such.module")
-        assert isinstance(result, dict)
-        assert "error" in result
+        flat_dir = tmp_path / "netbox.netbox.netbox_device"
+        flat_dir.mkdir()
+        (flat_dir / "SKILL.md").write_text("flat skill content")
+        assert _get_skill_sync(tmp_path, "netbox.netbox.netbox_device") == "flat skill content"
+
+    def test_raises_for_missing_skill(self, tmp_path):
+        from ansible_know.server import _get_skill_sync
+
+        with pytest.raises(FileNotFoundError, match="not found"):
+            _get_skill_sync(tmp_path, "no.such.module")
 
 
 class TestPathTraversal:

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,13 @@
+"""Tests for ansible_know.tagging."""
+
+from ansible_know.tagging import derive_tags
+
+
+class TestDeriveTagsFromTagging:
+    def test_import_and_basic_tag(self):
+        tags = derive_tags("netbox.netbox.ip_address", [])
+        assert "ipam" in tags
+
+    def test_no_matching_tags(self):
+        tags = derive_tags("custom.collection.something_unique", [])
+        assert tags == []


### PR DESCRIPTION
## Summary

- **#89**: Move `derive_tags()` from `collection_manifest.py` (Domain) to new `tagging.py` (Foundation) to eliminate Domain→Domain cross-import
- **#90**: Extract `get_skill()` blocking file I/O into `_get_skill_sync()` helper wrapped with `run_in_executor()`
- Deduplicate `resource_skill_content()` by reusing `_get_skill_sync()`
- Update architecture docs (`service-contracts.md`, `CLAUDE.md`, `pr-architecture-review/SKILL.md`)
- Mark stale V-D2–V-D5 violations as fixed in service contracts

## Changes

| File | Change |
|------|--------|
| `src/ansible_know/tagging.py` (new) | Foundation module with `derive_tags()` — zero internal dependencies |
| `src/ansible_know/collection_manifest.py` | Remove `derive_tags` definition, import from `tagging` |
| `src/ansible_know/skills.py` | Import `derive_tags` from `tagging` (top-level) |
| `src/ansible_know/server.py` | Add `_get_skill_sync()`, refactor `get_skill()` handler, deduplicate `resource_skill_content()` |
| `tests/test_tagging.py` (new) | Unit tests for `tagging.derive_tags` |
| `tests/test_server.py` | Direct unit tests for `_get_skill_sync` |
| `docs/architecture/service-contracts.md` | Add `tagging.py` to Foundation tables, mark V-D2–D5 fixed |
| `skills/pr-architecture-review/SKILL.md` | Add missing Foundation entries |
| `CLAUDE.md` | Add `tagging.py` to architecture diagram |

## Test plan

- [x] 536 tests pass, 58 skipped
- [x] `ruff check` clean
- [x] Architecture review: 0 errors, 0 blockers
- [x] All existing `test_get_skill_*` and `TestDeriveTags` tests pass (regression check)
- [x] New `TestGetSkillSync` tests cover namespace, nested module, and missing skill paths

Closes #89
Closes #90

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>