### PR TITLE
refactor: tighten nested types and fix semaphore lifecycle (V-F2, V-E5)

### DIFF
--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -29,17 +29,7 @@ TIMEOUT_FAST = httpx.Timeout(10.0)
 TIMEOUT_DEFAULT = httpx.Timeout(10.0, read=30.0)
 TIMEOUT_SLOW = httpx.Timeout(10.0, read=60.0)
 
-_enrichment_semaphore: asyncio.Semaphore | None = None
-_enrichment_semaphore_loop: asyncio.AbstractEventLoop | None = None
-
-
-def _get_enrichment_semaphore() -> asyncio.Semaphore:
-    global _enrichment_semaphore, _enrichment_semaphore_loop
-    loop = asyncio.get_running_loop()
-    if _enrichment_semaphore is None or _enrichment_semaphore_loop is not loop:
-        _enrichment_semaphore = asyncio.Semaphore(5)
-        _enrichment_semaphore_loop = loop
-    return _enrichment_semaphore
+ENRICHMENT_CONCURRENCY = 5
 
 # Module-level caches shared across all GalaxyClient instances.
 # Keys include enough context (namespace, name, version) to avoid
@@ -81,6 +71,7 @@ class GalaxyClient:
         password: str | None = None,
         verify: bool = True,
         server_name: str | None = None,
+        enrichment_semaphore: asyncio.Semaphore | None = None,
     ):
         self._base = (base_url or GALAXY_BASE_URL).rstrip("/")
         self._http_client = http_client
@@ -90,10 +81,16 @@ class GalaxyClient:
         self._password = password
         self._verify = verify
         self.server_name = server_name
+        self._enrichment_semaphore = enrichment_semaphore or asyncio.Semaphore(
+            ENRICHMENT_CONCURRENCY,
+        )
 
     @classmethod
     def from_config(
-        cls, config: GalaxyServerConfig, http_client: httpx.AsyncClient | None = None,
+        cls,
+        config: GalaxyServerConfig,
+        http_client: httpx.AsyncClient | None = None,
+        enrichment_semaphore: asyncio.Semaphore | None = None,
     ) -> GalaxyClient:
         """Create a GalaxyClient from a GalaxyServerConfig."""
         return cls(
@@ -104,6 +101,7 @@ class GalaxyClient:
             password=config.password,
             verify=config.validate_certs,
             server_name=config.name,
+            enrichment_semaphore=enrichment_semaphore,
         )
 
     async def __aenter__(self) -> GalaxyClient:
@@ -269,7 +267,7 @@ class GalaxyClient:
             })
 
         async def _enrich(cand: dict) -> None:
-            async with _get_enrichment_semaphore():
+            async with self._enrichment_semaphore:
                 try:
                     detail = await self._get_collection_detail(
                         cand["_ns"], cand["_name"],

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -406,7 +406,9 @@ class GalaxyClient:
                 "type": var.get("type"),
                 "required": var.get("required"),
                 "default": var.get("default"),
+                "choices": var.get("choices"),
                 "description": var.get("description", ""),
+                "aliases": var.get("aliases", []),
             })
 
         role_metadata: dict[str, Any] = {

--- a/src/ansible_know/parser.py
+++ b/src/ansible_know/parser.py
@@ -365,7 +365,9 @@ def extract_role_metadata(role_doc: dict[str, Any]) -> RoleMetadata:
                 "type": opt_spec.get("type", "str"),
                 "required": opt_spec.get("required", False),
                 "default": opt_spec.get("default"),
+                "choices": opt_spec.get("choices"),
                 "description": opt_desc,
+                "aliases": opt_spec.get("aliases", []),
             })
         options.sort(key=lambda o: (not o["required"], o["name"]))
 

--- a/src/ansible_know/parser.py
+++ b/src/ansible_know/parser.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any
 from ansible_know.errors import AnsibleDocError, CollectionNotFoundError, is_missing_collection_error
 
 if TYPE_CHECKING:
-    from ansible_know.types import ModuleMetadata, ParamDict, RoleMetadata
+    from ansible_know.types import EntryPointInfo, ModuleMetadata, ParamDict, RoleMetadata
 
 logger = logging.getLogger("ansible_know")
 
@@ -345,7 +345,7 @@ def extract_role_metadata(role_doc: dict[str, Any]) -> RoleMetadata:
     raw_entry_points = role_data.get("entry_points", {})
 
     first_desc = ""
-    entry_points: dict[str, dict[str, Any]] = {}
+    entry_points: dict[str, EntryPointInfo] = {}
 
     for ep_name, ep_data in raw_entry_points.items():
         desc = ep_data.get("description", "")
@@ -355,7 +355,7 @@ def extract_role_metadata(role_doc: dict[str, Any]) -> RoleMetadata:
             first_desc = desc
 
         options_raw = ep_data.get("options", {})
-        options: list[dict[str, Any]] = []
+        options: list[ParamDict] = []
         for opt_name, opt_spec in options_raw.items():
             opt_desc = opt_spec.get("description", "")
             if isinstance(opt_desc, list):

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -147,10 +147,22 @@ mcp = FastMCP(
 )
 
 
-def _galaxy_factory():
-    """Lazy import of GalaxyClient.from_config for dependency injection."""
+def _galaxy_factory(ctx: Context | None = None):
+    """Return a GalaxyClient factory that injects the shared semaphore."""
     from ansible_know.galaxy import GalaxyClient
-    return GalaxyClient.from_config
+
+    semaphore = None
+    if ctx is not None:
+        shared: SharedState = ctx.lifespan_context["shared"]
+        semaphore = shared.enrichment_semaphore
+
+    def _factory(config, http_client=None):
+        return GalaxyClient.from_config(
+            config, http_client=http_client,
+            enrichment_semaphore=semaphore,
+        )
+
+    return _factory
 
 
 async def _get_state(ctx: Context | None) -> ServerState:
@@ -302,7 +314,7 @@ async def get_module_doc(
         http_client = _get_http_client(ctx)
         raw_doc, galaxy_meta = await resolution.resolve_module_doc(
             module_name, http_client=http_client, galaxy_servers=state.galaxy_servers,
-            client_factory=_galaxy_factory(),
+            client_factory=_galaxy_factory(ctx),
             missing_collections=state.missing_collections,
             collections_path=state.collection_manager.get_collections_path(),
         )
@@ -350,7 +362,7 @@ async def get_role_doc(
         http_client = _get_http_client(ctx)
         return await resolution.resolve_role_doc(
             role_name, http_client=http_client, galaxy_servers=state.galaxy_servers,
-            client_factory=_galaxy_factory(),
+            client_factory=_galaxy_factory(ctx),
             missing_collections=state.missing_collections,
             collections_path=state.collection_manager.get_collections_path(),
         )
@@ -426,7 +438,7 @@ async def search_collections(
         http_client = _get_http_client(ctx)
         return await resolution.search_galaxy_collections(
             query, tags=tags, http_client=http_client, galaxy_servers=state.galaxy_servers,
-            client_factory=_galaxy_factory(),
+            client_factory=_galaxy_factory(ctx),
         )
     except Exception as exc:
         logger.warning("search_collections failed: %s", exc)
@@ -750,7 +762,7 @@ async def generate_skill(
         http_client = _get_http_client(ctx)
         raw_doc, galaxy_meta = await resolution.resolve_module_doc(
             module_name, http_client=http_client, galaxy_servers=state.galaxy_servers,
-            client_factory=_galaxy_factory(),
+            client_factory=_galaxy_factory(ctx),
             missing_collections=state.missing_collections,
             collections_path=state.collection_manager.get_collections_path(),
         )
@@ -816,7 +828,7 @@ async def generate_role_skill(
         http_client = _get_http_client(ctx)
         metadata = await resolution.resolve_role_doc(
             role_name, http_client=http_client, galaxy_servers=state.galaxy_servers,
-            client_factory=_galaxy_factory(),
+            client_factory=_galaxy_factory(ctx),
             missing_collections=state.missing_collections,
             collections_path=state.collection_manager.get_collections_path(),
         )

--- a/src/ansible_know/state.py
+++ b/src/ansible_know/state.py
@@ -60,6 +60,7 @@ class SharedState:
 
     galaxy_servers: list[GalaxyServerConfig] = field(default_factory=list)
     version_info: VersionInfo | None = None
+    enrichment_semaphore: asyncio.Semaphore = field(default_factory=lambda: asyncio.Semaphore(5))
 
 
 class SessionManager:

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -32,12 +32,19 @@ class ModuleMetadata(TypedDict):
     is_api_module: bool
 
 
+class EntryPointInfo(TypedDict):
+    """Single role entry point with description and options list."""
+
+    description: str
+    options: list[ParamDict]
+
+
 class RoleMetadata(TypedDict):
     """Role metadata extracted by parser.extract_role_metadata()."""
 
     role_name: str
     short_description: str
-    entry_points: dict[str, dict[str, Any]]
+    entry_points: dict[str, EntryPointInfo]
 
 
 class _DocProvenanceBase(TypedDict):
@@ -171,7 +178,7 @@ class GetRoleDocResult(_GetRoleDocResultBase, total=False):
     """
 
     short_description: str
-    entry_points: dict[str, dict[str, Any]]
+    entry_points: dict[str, EntryPointInfo]
     dependencies: list[str]
     examples: str
     doc_version: str

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1230,7 +1230,10 @@ class TestLifespanHttpClient:
             from ansible_know.server import search_collections
             await search_collections("test", ctx=mock_ctx)
 
-        mock_from_config.assert_called_once_with(server, http_client=None)
+        mock_from_config.assert_called_once()
+        call_kwargs = mock_from_config.call_args
+        assert call_kwargs[0][0] == server
+        assert call_kwargs[1]["http_client"] is None
 
     @pytest.mark.asyncio
     async def test_validate_certs_true_uses_shared_client(self):
@@ -1261,7 +1264,10 @@ class TestLifespanHttpClient:
             from ansible_know.server import search_collections
             await search_collections("test", ctx=mock_ctx)
 
-        mock_from_config.assert_called_once_with(server, http_client=mock_client)
+        mock_from_config.assert_called_once()
+        call_kwargs = mock_from_config.call_args
+        assert call_kwargs[0][0] == server
+        assert call_kwargs[1]["http_client"] is mock_client
 
     @pytest.mark.asyncio
     async def test_tools_work_without_ctx(self, mock_ansible_doc):


### PR DESCRIPTION
## Summary

Two related fixes from `docs/architecture/service-contracts.md`:

### V-F2: Tighten nested dict[str, Any] types
- Add `EntryPointInfo` TypedDict (`{description: str, options: list[ParamDict]}`)
- Update `RoleMetadata.entry_points` from `dict[str, dict[str, Any]]` to `dict[str, EntryPointInfo]`
- Update `GetRoleDocResult.entry_points` to match
- Update `parser.py` local annotations to use `EntryPointInfo` and `ParamDict`
- Fix: add missing `choices` and `aliases` keys to role option extraction (found by type safety review)

### V-E5: Fix fragile semaphore creation
- Remove lazy-global semaphore pattern from `galaxy.py` (event-loop detection was fragile)
- Add `enrichment_semaphore` field to `SharedState` (created once at lifespan startup)
- `GalaxyClient` accepts `enrichment_semaphore` as constructor parameter with fallback
- `_galaxy_factory()` closure captures semaphore from context, injecting it into all clients

### Files changed
- `types.py` — add `EntryPointInfo`, update `RoleMetadata` and `GetRoleDocResult`
- `parser.py` — update annotations, add missing choices/aliases to role options
- `galaxy.py` — remove global semaphore, add instance parameter
- `state.py` — add `enrichment_semaphore` to `SharedState`
- `server.py` — `_galaxy_factory(ctx)` closure pattern
- `tests/test_server.py` — update mock assertions for new kwarg

549 tests pass, lint clean.

Closes #96

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>