### PR TITLE
feat: add clear_cache MCP tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Runtime requirement: `ansible-core` must be installed in the same environment (f
 
 ```
 src/ansible_know/
-├── server.py              # FastMCP server: 12 tools, 4 resources, 4 prompts (entrypoint)
+├── server.py              # FastMCP server: 13 tools, 4 resources, 4 prompts (entrypoint)
 ├── parser.py              # ansible-doc wrapper — module discovery and metadata extraction
 ├── resolution.py          # local-then-Galaxy doc resolution + multi-server search
 ├── readme_parser.py       # Parse Galaxy role README HTML into structured data
@@ -48,6 +48,7 @@ src/ansible_know/
 | `generate_skill` | idempotent write | Generate a skill package for one module |
 | `generate_role_skill` | idempotent write | Generate a skill package for one role |
 | `generate_collection_skills` | idempotent write | Batch generate skills for a collection |
+| `clear_cache` | idempotent write | Clear Galaxy and/or doc manifest caches |
 
 ## MCP Resources
 

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1,6 +1,6 @@
 """Ansible Know MCP Server.
 
-Provides 12 tools, 5 resources, and 4 prompts for module and role discovery,
+Provides 13 tools, 5 resources, and 4 prompts for module and role discovery,
 documentation search, Galaxy collection discovery, and skill generation
 via the Model Context Protocol.
 """
@@ -25,6 +25,7 @@ from ansible_know.async_utils import run_in_executor
 from ansible_know.errors import AnsibleDocError, ValidationError, collection_hint, maybe_add_hint
 from ansible_know.state import LifespanContext, ServerState, SessionManager, SharedState
 from ansible_know.types import (
+    ClearCacheResult,
     CollectionSearchResult,
     EnsureCollectionResult,
     ErrorResponse,
@@ -974,6 +975,41 @@ async def generate_collection_skills(
     except Exception as exc:
         logger.warning("generate_collection_skills failed: %s", exc)
         return {"error": maybe_add_hint(sanitize_error(str(exc)), collection_namespace)}
+
+
+_VALID_CACHE_SCOPES = {"galaxy", "docs"}
+
+
+@mcp.tool(annotations=ToolAnnotations(idempotentHint=True, readOnlyHint=False, destructiveHint=False))
+async def clear_cache(
+    scope: Annotated[
+        str | None,
+        "Cache scope to clear: 'galaxy' (version + docs-blob), 'docs' (doc manifests), "
+        "or omit to clear all caches.",
+    ] = None,
+) -> ClearCacheResult | ErrorResponse:
+    """Clear server caches.
+
+    Clears Galaxy version/docs-blob caches, doc manifest caches, or both.
+    Useful when cached data becomes stale during long-running sessions.
+    """
+    logger.info("clear_cache scope=%r", scope)
+    if scope is not None and scope not in _VALID_CACHE_SCOPES:
+        return {"error": f"Invalid scope '{scope}'. Must be 'galaxy', 'docs', or omitted for all."}
+
+    cleared: list[str] = []
+
+    if scope in (None, "galaxy"):
+        from ansible_know import galaxy
+        galaxy.clear_cache()
+        cleared.extend(["galaxy_versions", "galaxy_blobs"])
+
+    if scope in (None, "docs"):
+        from ansible_know import docs
+        docs.clear_cache()
+        cleared.append("doc_manifests")
+
+    return {"cleared": cleared}
 
 
 # --- Resources (read-only data) ---

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -244,6 +244,12 @@ class GenerateCollectionSkillsResult(TypedDict):
     collection_skill: str
 
 
+class ClearCacheResult(TypedDict):
+    """Result of clear_cache tool."""
+
+    cleared: list[str]
+
+
 class GalaxyDocClient(Protocol):
     """Structural interface for Galaxy documentation clients.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1692,3 +1692,52 @@ class TestGetStateSessionIsolation:
         await _get_state(ctx)
 
         mock_exit_stack.push_async_callback.assert_called_once()
+
+
+class TestClearCache:
+    """Tests for the clear_cache tool."""
+
+    @pytest.mark.asyncio
+    async def test_clear_all(self):
+        from ansible_know.server import clear_cache
+
+        with patch("ansible_know.galaxy.clear_cache") as mock_galaxy, \
+             patch("ansible_know.docs.clear_cache") as mock_docs:
+            result = await clear_cache()
+
+        assert result == {"cleared": ["galaxy_versions", "galaxy_blobs", "doc_manifests"]}
+        mock_galaxy.assert_called_once()
+        mock_docs.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_clear_galaxy_only(self):
+        from ansible_know.server import clear_cache
+
+        with patch("ansible_know.galaxy.clear_cache") as mock_galaxy, \
+             patch("ansible_know.docs.clear_cache") as mock_docs:
+            result = await clear_cache(scope="galaxy")
+
+        assert result == {"cleared": ["galaxy_versions", "galaxy_blobs"]}
+        mock_galaxy.assert_called_once()
+        mock_docs.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_clear_docs_only(self):
+        from ansible_know.server import clear_cache
+
+        with patch("ansible_know.galaxy.clear_cache") as mock_galaxy, \
+             patch("ansible_know.docs.clear_cache") as mock_docs:
+            result = await clear_cache(scope="docs")
+
+        assert result == {"cleared": ["doc_manifests"]}
+        mock_galaxy.assert_not_called()
+        mock_docs.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_invalid_scope(self):
+        from ansible_know.server import clear_cache
+
+        result = await clear_cache(scope="invalid")
+
+        assert "error" in result
+        assert "Invalid scope" in result["error"]


### PR DESCRIPTION
## Summary

- New `clear_cache` tool with optional `scope` parameter (`galaxy`, `docs`, or omit for all)
- Delegates to existing `galaxy.clear_cache()` and `docs.clear_cache()`
- Returns `{"cleared": ["galaxy_versions", "galaxy_blobs", "doc_manifests"]}`
- `ClearCacheResult` TypedDict in `types.py`
- 4 new tests (all scopes + invalid scope error)
- Tool count updated 12 → 13

## Test plan

- [x] `pytest tests/ -v` — 565 passed, 58 skipped
- [x] `ruff check src/ tests/` — clean
- [ ] Manual: verify tool appears in MCP tool list
- [ ] Manual: test with real Galaxy/docs caches populated

Closes #86

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>