### PR TITLE
fix: TypedDict import breaks Python 3.10-3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "httpx>=0.27",
     "jinja2>=3.1",
     "pyyaml>=6.0",
+    "typing_extensions>=4.0; python_version < '3.12'",
 ]
 
 [project.urls]

--- a/src/ansible_know/state.py
+++ b/src/ansible_know/state.py
@@ -9,10 +9,16 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import sys
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
+
+if sys.version_info >= (3, 12):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
     import httpx

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol, TypedDict
+import sys
+from typing import TYPE_CHECKING, Any, Protocol
+
+if sys.version_info >= (3, 12):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
     import httpx


### PR DESCRIPTION
## Summary

Fixes CI failure on Python 3.10-3.11 introduced by the TypedDict refactors in PRs #104-106.

Pydantic requires `typing_extensions.TypedDict` on Python < 3.12 — the stdlib `typing.TypedDict` lacks `__pydantic_core_schema__`, causing a collection error in `test_mcp_e2e.py`.

## Changes

- `types.py`: conditional import — `typing.TypedDict` on 3.12+, `typing_extensions.TypedDict` on older
- `state.py`: same conditional import
- `pyproject.toml`: add `typing_extensions>=4.0; python_version < '3.12'` dependency

## Test plan

- [x] 565 tests pass locally (Python 3.13)
- [x] `ruff check` clean
- [ ] CI passes on Python 3.10, 3.11, 3.12, 3.13

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>