### PR TITLE
chore: release v0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ansible-know-mcp"
-version = "0.5.1"
+version = "0.5.2"
 description = "Ansible Knowledge MCP Server — module and role discovery, documentation, and skill generation for AI agents"
 requires-python = ">=3.10"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary

Patch release fixing Python 3.10-3.11 compatibility.

## What's new since v0.5.1

### Bug fixes
- Fix `TypedDict` import that broke Python 3.10-3.11 (#112) — Pydantic requires `typing_extensions.TypedDict` on Python < 3.12

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>