### PR TITLE
fix: mention resources in MCP server instructions

### DIFF
--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -149,7 +149,11 @@ mcp = FastMCP(
         "(3) search_modules/get_collection_manifest to find modules and roles, "
         "(4) get_module_doc or get_role_doc for structured docs, "
         "(5) search_docs for conceptual guides, "
-        "(6) generate_skill or generate_role_skill to create skill packages."
+        "(6) generate_skill or generate_role_skill to create skill packages. "
+        "Resources: server://version for version and upgrade status, "
+        "galaxy://installed for session collections, "
+        "docs://sources for configured doc sources, "
+        "skills://list for generated skills."
     ),
     lifespan=app_lifespan,
 )


### PR DESCRIPTION
## Summary
- The MCP server `instructions` field only described the tool workflow, so agents never reached for resources like `server://version` when asked about version info
- Added all four resources (`server://version`, `galaxy://installed`, `docs://sources`, `skills://list`) to the instructions string so they appear in the system prompt alongside the tool workflow

## Test plan
- [ ] Verify the instructions string renders correctly in a new Claude Code session's system prompt
- [ ] Ask "what version is ansible-know?" and confirm Claude reads `server://version` first

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>