### PR TITLE
feat: add plugin discovery, documentation, and skill generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Runtime requirement: `ansible-core` must be installed in the same environment (f
 
 ```
 src/ansible_know/
-├── server.py              # FastMCP server: 17 tools, 5 resources, 5 prompts (entrypoint)
+├── server.py              # FastMCP server: 17 tools, 6 resources, 5 prompts (entrypoint)
 ├── parser.py              # ansible-doc wrapper — module discovery and metadata extraction
 ├── resolution.py          # local-then-Galaxy doc resolution + multi-server search
 ├── readme_parser.py       # Parse Galaxy role README HTML into structured data
@@ -64,6 +64,7 @@ src/ansible_know/
 | `skills://list` | List all generated skill packages |
 | `skills://{skill_name}` | Read a skill's SKILL.md by FQCN |
 | `galaxy://installed` | List collections installed in this session |
+| `galaxy://servers` | List configured Galaxy servers with auth type |
 | `server://version` | Installed/latest version info with upgrade status |
 | `docs://sources` | List configured doc manifest sources |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Runtime requirement: `ansible-core` must be installed in the same environment (f
 
 ```
 src/ansible_know/
-├── server.py              # FastMCP server: 14 tools, 5 resources, 4 prompts (entrypoint)
+├── server.py              # FastMCP server: 17 tools, 5 resources, 5 prompts (entrypoint)
 ├── parser.py              # ansible-doc wrapper — module discovery and metadata extraction
 ├── resolution.py          # local-then-Galaxy doc resolution + multi-server search
 ├── readme_parser.py       # Parse Galaxy role README HTML into structured data
@@ -40,7 +40,9 @@ src/ansible_know/
 | Tool | Type | Description |
 |------|------|-------------|
 | `search_modules` | read-only | Find modules by keyword |
+| `search_plugins` | read-only | Find plugins by keyword (lookup, filter, inventory, etc.) |
 | `get_module_doc` | read-only | Get full module documentation |
+| `get_plugin_doc` | read-only | Get full plugin documentation |
 | `get_role_doc` | read-only | Get full role documentation (local or Galaxy README) |
 | `search_docs` | read-only | Search conceptual doc manifests |
 | `fetch_doc` | read-only | Fetch a docs.ansible.com page as clean Markdown |
@@ -50,6 +52,7 @@ src/ansible_know/
 | `list_skills` | read-only | List generated skills |
 | `get_skill` | read-only | Read a skill's content |
 | `generate_skill` | idempotent write | Generate a skill package for one module |
+| `generate_plugin_skill` | idempotent write | Generate a skill package for one plugin |
 | `generate_role_skill` | idempotent write | Generate a skill package for one role |
 | `generate_collection_skills` | idempotent write | Batch generate skills for a collection |
 | `clear_cache` | idempotent write | Clear Galaxy and/or doc manifest caches |
@@ -70,6 +73,7 @@ src/ansible_know/
 |--------|-------------|
 | `review_playbook` | Review a playbook against module docs |
 | `explain_module` | Detailed module explanation with examples |
+| `explain_plugin` | Detailed plugin explanation with usage examples |
 | `generate_role` | Generate a role skeleton using specified modules |
 | `find_collection` | Guide through search, install, and explore workflow |
 

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -87,7 +87,7 @@ decorated tool, resource, and prompt handler functions. FastMCP manages:
 | ID | Severity | Description | Location |
 |----|----------|-------------|----------|
 | ~~V-T1~~ | ~~Warning~~ | ~~Lifespan context is an untyped `dict[str, Any]` accessed by string keys.~~ **Fixed in PR #87** — `LifespanContext` TypedDict with typed keys (`http_client`, `shared`, `sessions`). | ~~`server.py:103-108`~~ → `state.py` |
-| V-T2 | Warning | `_run_in_executor()` uses deprecated `asyncio.get_event_loop()`. Should use `asyncio.get_running_loop()` — the function is only called from async context. | `server.py:126-129` |
+| ~~V-T2~~ | ~~Warning~~ | ~~`_run_in_executor()` uses deprecated `asyncio.get_event_loop()`. Should use `asyncio.get_running_loop()` — the function is only called from async context.~~ **Fixed** — `async_utils.py` uses `asyncio.get_running_loop()`. `_run_in_executor` was moved from `server.py` to `async_utils.py` in PR #89. | ~~`server.py:126-129`~~ → `async_utils.py` |
 | ~~V-T3~~ | ~~Info~~ | ~~Tool return types are `dict[str, Any]` rather than typed dicts.~~ **Fixed in PR #105** — all 12 tool handlers now use specific TypedDicts (`GetModuleDocResult`, `GetRoleDocResult`, `CollectionSearchResult`, etc.) with `| ErrorResponse` unions. Safe because `from __future__ import annotations` makes annotations strings at runtime — FastMCP never sees the TypedDict classes. Note: PR #60 originally reverted TypedDict annotations to `dict[str, Any]` over FastMCP wrapping concerns, but that concern is moot with stringified annotations. | ~~All tool handlers~~ → `types.py`, `server.py` |
 
 ---
@@ -139,7 +139,7 @@ business logic. Domain modules are imported lazily to avoid loading
 
 | ID | Severity | Description | Location |
 |----|----------|-------------|----------|
-| V-D1 | Warning | `server.py` calls `skills._module_to_skill_name()` — a private function (leading underscore). This crosses the public API boundary. Should be exposed as a public function or the skill name derivation should be the caller's responsibility. | `server.py:753`, `server.py:880` |
+| ~~V-D1~~ | ~~Warning~~ | ~~`server.py` calls `skills._module_to_skill_name()` — a private function (leading underscore). This crosses the public API boundary.~~ **Fixed** — renamed to `module_to_skill_name()` (public, in `skills.__all__`). `server.py` no longer calls it; namespace/short_name extraction is inlined at the call site. | ~~`server.py:753`, `server.py:880`~~ |
 | ~~V-D2~~ | ~~Warning~~ | ~~`parser.py` does not define `__all__`. All module-level functions are implicitly public, including internal helpers like `_get_module_name()` and `_run_ansible_doc()`.~~ **Fixed** — `parser.py` now defines `__all__`. | ~~`parser.py`~~ |
 | ~~V-D3~~ | ~~Warning~~ | ~~`skills.py` does not define `__all__`.~~ **Fixed** — `skills.py` now defines `__all__`. | ~~`skills.py`~~ |
 | ~~V-D4~~ | ~~Warning~~ | ~~`collection_manifest.py` does not define `__all__`.~~ **Fixed** — `collection_manifest.py` now defines `__all__`. | ~~`collection_manifest.py`~~ |
@@ -199,7 +199,7 @@ layer and `_ReadmeParser` in `readme_parser.py` are the other classes.)
 | ~~V-E1~~ | ~~Error~~ | ~~`server.py` calls `GalaxyClient` directly in `search_collections()` and `_try_galaxy_servers()`, bypassing the Domain layer entirely. Galaxy access should be mediated through a domain-level service.~~ **Fixed in PR #66** — Galaxy access is now mediated through `resolution.py`. | ~~`server.py:168-192`, `server.py:480-486`~~ |
 | ~~V-E2~~ | ~~Warning~~ | ~~`GalaxyClient` has no abstract base class or Protocol.~~ **Fixed in PR #66:** `GalaxyDocClient` Protocol and `GalaxyClientFactory` Protocol defined in `types.py`. `resolution.py` depends on the Protocol, not the concrete class. `GalaxyClient` satisfies the Protocol structurally. | ~~`galaxy.py:111`~~ → `types.py` |
 | ~~V-E3~~ | ~~Warning~~ | ~~`GalaxyClient._transform_to_ansible_doc_format()` is a static method that converts Galaxy format to ansible-doc format. This is a data transformation that belongs in the Domain layer (parser), not the External Access layer.~~ **Fixed in PR #69** — Moved to `parser.transform_galaxy_to_ansible_doc_format()`. `galaxy.py` lazy-imports it. | ~~`galaxy.py:381-417`~~ → `parser.py` |
-| V-E4 | Warning | `collections.py` module-level mutable state (`_tmp_dir`, `_installed`, `_install_locks`) makes the module impossible to test in isolation without monkeypatching globals. Should be encapsulated in a class. | `collections.py:26-29` |
+| ~~V-E4~~ | ~~Warning~~ | ~~`collections.py` module-level mutable state (`_tmp_dir`, `_installed`, `_install_locks`) makes the module impossible to test in isolation without monkeypatching globals. Should be encapsulated in a class.~~ **Fixed in PR #87** — state encapsulated in `CollectionManager` class, created per-session via `SessionManager`. | ~~`collections.py:26-29`~~ → `collections.py:CollectionManager` |
 | ~~V-E5~~ | ~~Info~~ | ~~`galaxy.py` uses `asyncio.Semaphore` for enrichment throttling but creates it lazily with event-loop detection (`_get_enrichment_semaphore`). This is fragile if the event loop changes.~~ **Fixed in PR #106** — semaphore moved to `SharedState` (created once at lifespan). `GalaxyClient` accepts it as constructor parameter. `_galaxy_factory()` closure injects it from context. | ~~`galaxy.py:40-46`~~ → `state.py`, `galaxy.py`, `server.py` |
 
 ---
@@ -269,7 +269,7 @@ AnsibleKnowError
 
 | ID | Severity | Description | Location |
 |----|----------|-------------|----------|
-| V-F1 | Warning | `config.py` evaluates `Path.cwd()` at import time for `SKILLS_DIR`. This captures the working directory at the moment the module is first imported, which may differ from the intended runtime directory. Should be a function or lazy property. | `config.py:14-17` |
+| ~~V-F1~~ | ~~Warning~~ | ~~`config.py` evaluates `Path.cwd()` at import time for `SKILLS_DIR`. This captures the working directory at the moment the module is first imported, which may differ from the intended runtime directory. Should be a function or lazy property.~~ **Fixed** — `SKILLS_DIR` now uses `__getattr__` module-level lazy evaluation with caching. | ~~`config.py:14-17`~~ → `config.py:__getattr__` |
 | ~~V-F2~~ | ~~Info~~ | ~~`types.py` `TypedDict` definitions use `dict[str, Any]` for nested structures (e.g., `params: list[dict[str, Any]]`). More specific nested types would improve type safety.~~ **Fixed in PRs #104, #106** — `params` tightened to `list[ParamDict]` (PR #104), `entry_points` tightened to `dict[str, EntryPointInfo]` (PR #106). | ~~`types.py:14`, `types.py:22`~~ → `types.py` |
 | V-F3 | Info | `galaxy_config.py` `GalaxyServerConfig` is a frozen dataclass, which is correct for an immutable configuration value object. No issues. | `galaxy_config.py:24-35` |
 
@@ -366,9 +366,10 @@ Foundation   → (no internal dependencies)
 
 3. ~~**V-T1**: Define a `LifespanContext` TypedDict or dataclass for the lifespan
    context dict.~~ **Fixed in PR #87** — `LifespanContext` TypedDict in `state.py`.
-4. **V-T2**: Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()`.
-5. **V-D1**: Make `_module_to_skill_name()` public (rename to
-   `module_to_skill_name()`).
+4. ~~**V-T2**: Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()`.~~
+   **Fixed** — `async_utils.py` uses `asyncio.get_running_loop()`.
+5. ~~**V-D1**: Make `_module_to_skill_name()` public (rename to
+   `module_to_skill_name()`).~~ **Fixed** — renamed and added to `skills.__all__`.
 6. ~~**V-D2–V-D5**: Add `__all__` to all modules.~~ **Fixed** — all modules now define `__all__`.
 7. ~~**V-D7 / V-L2**: Move `_resolve_module_doc()` and `_resolve_role_doc()` to a
    domain-level resolution module.~~ **Fixed in PR #66**.
@@ -377,13 +378,15 @@ Foundation   → (no internal dependencies)
    **Fixed in PR #66** — `GalaxyDocClient` Protocol in `types.py`.
 10. ~~**V-E3**: Move `_transform_to_ansible_doc_format()` to `parser.py`.~~
     **Fixed in PR #69** — now `parser.transform_galaxy_to_ansible_doc_format()`.
-11. **V-E4**: Encapsulate `collections.py` state in a `CollectionManager` class.
+11. ~~**V-E4**: Encapsulate `collections.py` state in a `CollectionManager` class.~~
+    **Fixed in PR #87** — `CollectionManager` class, created per-session.
 12. ~~**V-S2**: Use `asyncio.Lock` or explicit synchronization for
     `_missing_collections`.~~ **Mitigated in PR #87** — now per-session.
 13. ~~**V-S3**: Design a `ServerState` or session context that encapsulates all
     mutable state.~~ **Partially resolved in PR #87** — `SharedState` +
     `SessionManager` with per-session `ServerState`.
-14. **V-F1**: Make `SKILLS_DIR` lazy (function or descriptor).
+14. ~~**V-F1**: Make `SKILLS_DIR` lazy (function or descriptor).~~
+    **Fixed** — uses `__getattr__` lazy evaluation with caching.
 
 ### Priority 3 (Info-level, PEP 8 suggestions)
 

--- a/src/ansible_know/collection_manifest.py
+++ b/src/ansible_know/collection_manifest.py
@@ -89,9 +89,11 @@ def generate_manifest(
         "generated": datetime.now(timezone.utc).isoformat(),
         "module_count": len(modules_list),
         "role_count": len(roles_list),
+        "plugin_count": 0,
         "has_collection_skill": has_collection_skill,
         "modules": modules_list,
         "roles": roles_list,
+        "plugins": [],
     }
 
     return manifest
@@ -130,6 +132,9 @@ def load_cached_manifest(
 
     When installed_version is provided, the cache is invalidated if the
     stored collection_version doesn't match.
+
+    Backfills plugin_count and plugins fields for cached manifests
+    created before plugin support was added.
     """
     if skills_dir is None:
         skills_dir = SKILLS_DIR
@@ -141,4 +146,10 @@ def load_cached_manifest(
     manifest = json.loads(manifest_path.read_text())
     if installed_version and manifest.get("collection_version") != installed_version:
         return None
+
+    if "plugin_count" not in manifest:
+        manifest["plugin_count"] = 0
+    if "plugins" not in manifest:
+        manifest["plugins"] = []
+
     return manifest

--- a/src/ansible_know/collection_manifest.py
+++ b/src/ansible_know/collection_manifest.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ansible_know.config import SKILLS_DIR
+from ansible_know.errors import ValidationError
 from ansible_know.tagging import derive_tags
 from ansible_know.validation import validate_path_containment
 
@@ -88,7 +89,12 @@ def generate_manifest(
         fqcn = plugin_meta["fqcn"]
         ptype = plugin_meta.get("plugin_type", "")
         short_name = fqcn.rsplit(".", 1)[-1]
-        has_skill = (collection_dir / f"{ptype}__{short_name}" / "SKILL.md").exists()
+        skill_path = (collection_dir / f"{ptype}__{short_name}" / "SKILL.md").resolve()
+        try:
+            validate_path_containment(skill_path, skills_dir)
+            has_skill = skill_path.exists()
+        except (ValidationError, ValueError):
+            has_skill = False
 
         plugins_list.append({
             "fqcn": fqcn,

--- a/src/ansible_know/collection_manifest.py
+++ b/src/ansible_know/collection_manifest.py
@@ -29,15 +29,17 @@ def generate_manifest(
     collection_namespace: str,
     modules_metadata: list[ModuleMetadata],
     roles_metadata: list[dict[str, Any]] | None = None,
+    plugins_metadata: list[dict[str, Any]] | None = None,
     skills_dir: Path | None = None,
     collection_version: str | None = None,
 ) -> ManifestResult:
-    """Generate a collection manifest from module and role metadata.
+    """Generate a collection manifest from module, role, and plugin metadata.
 
     Args:
         collection_namespace: e.g. "netbox.netbox"
         modules_metadata: list of extract_module_metadata() results
         roles_metadata: list of role metadata dicts (optional)
+        plugins_metadata: list of plugin metadata dicts (optional)
         skills_dir: where to check for existing skill packages
         collection_version: installed version to store for cache invalidation
 
@@ -81,6 +83,21 @@ def generate_manifest(
             "has_skill": has_skill,
         })
 
+    plugins_list = []
+    for plugin_meta in (plugins_metadata or []):
+        fqcn = plugin_meta["fqcn"]
+        ptype = plugin_meta.get("plugin_type", "")
+        short_name = fqcn.rsplit(".", 1)[-1]
+        has_skill = (collection_dir / f"{ptype}__{short_name}" / "SKILL.md").exists()
+
+        plugins_list.append({
+            "fqcn": fqcn,
+            "plugin_type": ptype,
+            "description": plugin_meta.get("description", ""),
+            "param_count": plugin_meta.get("param_count", 0),
+            "has_skill": has_skill,
+        })
+
     has_collection_skill = (collection_dir / "SKILL.md").exists()
 
     manifest = {
@@ -89,11 +106,11 @@ def generate_manifest(
         "generated": datetime.now(timezone.utc).isoformat(),
         "module_count": len(modules_list),
         "role_count": len(roles_list),
-        "plugin_count": 0,
+        "plugin_count": len(plugins_list),
         "has_collection_skill": has_collection_skill,
         "modules": modules_list,
         "roles": roles_list,
-        "plugins": [],
+        "plugins": plugins_list,
     }
 
     return manifest

--- a/src/ansible_know/config.py
+++ b/src/ansible_know/config.py
@@ -196,3 +196,19 @@ GALAXY_BASE_URL = os.environ.get(
     "ANSIBLE_KNOW_GALAXY_URL",
     "https://galaxy.ansible.com",
 )
+
+PLUGIN_TYPES: tuple[str, ...] = (
+    "become", "cache", "callback", "cliconf", "connection",
+    "filter", "httpapi", "inventory", "lookup", "netconf",
+    "shell", "strategy", "test", "vars",
+)
+
+JINJA2_PLUGIN_TYPES: tuple[str, ...] = ("filter", "lookup", "test")
+
+PLAYBOOK_PLUGIN_TYPES: tuple[str, ...] = (
+    "become", "callback", "connection", "inventory", "strategy",
+)
+
+INFRA_PLUGIN_TYPES: tuple[str, ...] = (
+    "cache", "cliconf", "httpapi", "netconf", "shell", "vars",
+)

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -252,7 +252,10 @@ class GalaxyClient:
             role_count = sum(
                 1 for c in contents if c.get("content_type") == "role"
             )
-            plugin_count = 0
+            from ansible_know.config import PLUGIN_TYPES as _PLUGIN_TYPES
+            plugin_count = sum(
+                1 for c in contents if c.get("content_type") in _PLUGIN_TYPES
+            )
             tags_list = [t["name"] for t in cv.get("tags", []) if isinstance(t, dict)]
             candidates.append({
                 "namespace": f"{ns}.{name}",
@@ -333,6 +336,18 @@ class GalaxyClient:
         for item in blob.get("contents", []):
             if (
                 item.get("content_type") == "role"
+                and item.get("content_name") == short_name
+            ):
+                return item
+        return None
+
+    @staticmethod
+    def _find_plugin(
+        blob: dict[str, Any], short_name: str, plugin_type: str,
+    ) -> dict[str, Any] | None:
+        for item in blob.get("contents", []):
+            if (
+                item.get("content_type") == plugin_type
                 and item.get("content_name") == short_name
             ):
                 return item
@@ -438,6 +453,43 @@ class GalaxyClient:
             meta["doc_source_server"] = self.server_name
         return role_metadata, meta
 
+    async def fetch_plugin_doc(
+        self, plugin_name: str, plugin_type: str, version: str | None = None,
+    ) -> tuple[dict[str, Any], DocProvenance]:
+        """Fetch plugin documentation from Galaxy.
+
+        Returns (plugin_doc, meta) where plugin_doc mimics ansible-doc --json
+        format and meta contains provenance fields.
+        """
+        namespace, name, short_plugin = _parse_fqcn(plugin_name)
+        resolved_version = version or await self.latest_version(namespace, name)
+        is_latest = version is None
+
+        blob = await self._fetch_docs_blob(namespace, name, resolved_version)
+        plugin_entry = self._find_plugin(blob, short_plugin, plugin_type)
+        if plugin_entry is None:
+            raise GalaxyError(
+                f"Plugin '{short_plugin}' (type={plugin_type}) not found in "
+                f"{namespace}.{name} {resolved_version} docs-blob."
+            )
+
+        from ansible_know.parser import transform_galaxy_to_ansible_doc_format
+        doc = transform_galaxy_to_ansible_doc_format(plugin_name, plugin_entry)
+
+        meta: DocProvenance = {
+            "doc_source": "galaxy",
+            "doc_version": resolved_version,
+        }
+        if is_latest:
+            meta["doc_warning"] = (
+                f"Documentation sourced from Galaxy "
+                f"({namespace}.{name} {resolved_version}). "
+                f"Your installed version may differ."
+            )
+        if self.server_name:
+            meta["doc_source_server"] = self.server_name
+        return doc, meta
+
     async def list_collection_modules(
         self, collection_fqcn: str, version: str | None = None,
     ) -> tuple[dict[str, str], dict[str, str]]:
@@ -501,3 +553,44 @@ class GalaxyClient:
 
         meta = {"source": "galaxy", "version": resolved_version}
         return roles, meta
+
+    async def list_collection_plugins(
+        self, collection_fqcn: str, version: str | None = None,
+    ) -> tuple[dict[str, dict[str, str]], dict[str, str]]:
+        """List plugins in a collection from the Galaxy docs-blob.
+
+        Returns (plugins, meta) where plugins is
+        {fqcn: {"description": str, "plugin_type": str}, ...}.
+        Excludes modules and roles.
+
+        Not currently called from the MCP server — manifest generation uses
+        local parser.list_plugins instead. This method enables future Galaxy
+        fallback for manifest generation when collections are not installed
+        locally (parallel to fetch_plugin_doc which IS used for fallback).
+        """
+        from ansible_know.config import PLUGIN_TYPES
+
+        parts = collection_fqcn.split(".")
+        if len(parts) != 2:
+            raise GalaxyError(
+                f"'{collection_fqcn}' is not a valid collection FQCN "
+                f"(expected namespace.name)."
+            )
+        namespace, name = parts
+        resolved_version = version or await self.latest_version(namespace, name)
+
+        blob = await self._fetch_docs_blob(namespace, name, resolved_version)
+        plugins: dict[str, dict[str, str]] = {}
+        for item in blob.get("contents", []):
+            ct = item.get("content_type", "")
+            if ct not in PLUGIN_TYPES:
+                continue
+            short = item.get("content_name", "")
+            fqcn = f"{collection_fqcn}.{short}"
+            desc = item.get("doc_strings", {}).get("doc", {}).get(
+                "short_description", "",
+            ) or ""
+            plugins[fqcn] = {"description": desc, "plugin_type": ct}
+
+        meta = {"source": "galaxy", "version": resolved_version}
+        return plugins, meta

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -252,9 +252,9 @@ class GalaxyClient:
             role_count = sum(
                 1 for c in contents if c.get("content_type") == "role"
             )
-            from ansible_know.config import PLUGIN_TYPES as _PLUGIN_TYPES
+            from ansible_know.config import PLUGIN_TYPES
             plugin_count = sum(
-                1 for c in contents if c.get("content_type") in _PLUGIN_TYPES
+                1 for c in contents if c.get("content_type") in PLUGIN_TYPES
             )
             tags_list = [t["name"] for t in cv.get("tags", []) if isinstance(t, dict)]
             candidates.append({

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -252,6 +252,7 @@ class GalaxyClient:
             role_count = sum(
                 1 for c in contents if c.get("content_type") == "role"
             )
+            plugin_count = 0
             tags_list = [t["name"] for t in cv.get("tags", []) if isinstance(t, dict)]
             candidates.append({
                 "namespace": f"{ns}.{name}",
@@ -260,6 +261,7 @@ class GalaxyClient:
                 "latest_version": cv.get("version", ""),
                 "module_count": module_count,
                 "role_count": role_count,
+                "plugin_count": plugin_count,
                 "deprecated": False,
                 "signed": item.get("is_signed", False),
                 "_ns": ns,

--- a/src/ansible_know/parser.py
+++ b/src/ansible_know/parser.py
@@ -16,7 +16,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ansible_know.config import PLUGIN_TYPES
-from ansible_know.errors import AnsibleDocError, CollectionNotFoundError, ValidationError, is_missing_collection_error
+from ansible_know.errors import AnsibleDocError, CollectionNotFoundError, is_missing_collection_error
+from ansible_know.validation import validate_plugin_type
 
 if TYPE_CHECKING:
     from ansible_know.types import EntryPointInfo, ModuleMetadata, ParamDict, PluginMetadata, RoleMetadata
@@ -388,15 +389,6 @@ def extract_role_metadata(role_doc: dict[str, Any]) -> RoleMetadata:
     }
 
 
-def _validate_plugin_type(plugin_type: str) -> None:
-    """Raise ValidationError if plugin_type is not a recognized ansible-doc type."""
-    if plugin_type not in PLUGIN_TYPES:
-        raise ValidationError(
-            f"Invalid plugin type '{plugin_type}'. "
-            f"Valid types: {', '.join(sorted(PLUGIN_TYPES))}"
-        )
-
-
 def list_plugins(
     plugin_type: str,
     collection_filter: str | None = None,
@@ -413,7 +405,7 @@ def list_plugins(
     Returns:
         Dict mapping fully-qualified plugin names to their short descriptions.
     """
-    _validate_plugin_type(plugin_type)
+    validate_plugin_type(plugin_type)
     args = ["--list", "-t", plugin_type, "--json"]
     if collection_filter:
         args.append(collection_filter)
@@ -435,7 +427,7 @@ def get_plugin_doc(
 
     Returns the parsed JSON from `ansible-doc -t <type> <plugin> --json`.
     """
-    _validate_plugin_type(plugin_type)
+    validate_plugin_type(plugin_type)
     raw = _run_ansible_doc(
         "-t", plugin_type, plugin_name, "--json",
         collections_path=collections_path,
@@ -463,7 +455,7 @@ def search_plugins(
     REPL exploration).
     """
     if plugin_type is not None:
-        _validate_plugin_type(plugin_type)
+        validate_plugin_type(plugin_type)
         all_plugins = list_plugins(
             plugin_type, collection_filter, collections_path=collections_path,
         )

--- a/src/ansible_know/parser.py
+++ b/src/ansible_know/parser.py
@@ -15,10 +15,11 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from ansible_know.errors import AnsibleDocError, CollectionNotFoundError, is_missing_collection_error
+from ansible_know.config import PLUGIN_TYPES
+from ansible_know.errors import AnsibleDocError, CollectionNotFoundError, ValidationError, is_missing_collection_error
 
 if TYPE_CHECKING:
-    from ansible_know.types import EntryPointInfo, ModuleMetadata, ParamDict, RoleMetadata
+    from ansible_know.types import EntryPointInfo, ModuleMetadata, ParamDict, PluginMetadata, RoleMetadata
 
 logger = logging.getLogger("ansible_know")
 
@@ -26,14 +27,18 @@ __all__ = [
     "extract_examples",
     "extract_module_metadata",
     "extract_params",
+    "extract_plugin_metadata",
     "extract_role_metadata",
     "extract_short_description",
     "get_module_doc",
+    "get_plugin_doc",
     "get_role_doc",
     "is_api_module",
     "list_modules",
+    "list_plugins",
     "list_roles",
     "search_modules",
+    "search_plugins",
     "transform_galaxy_to_ansible_doc_format",
 ]
 
@@ -380,4 +385,125 @@ def extract_role_metadata(role_doc: dict[str, Any]) -> RoleMetadata:
         "role_name": role_name,
         "short_description": first_desc,
         "entry_points": entry_points,
+    }
+
+
+def _validate_plugin_type(plugin_type: str) -> None:
+    """Raise ValidationError if plugin_type is not a recognized ansible-doc type."""
+    if plugin_type not in PLUGIN_TYPES:
+        raise ValidationError(
+            f"Invalid plugin type '{plugin_type}'. "
+            f"Valid types: {', '.join(sorted(PLUGIN_TYPES))}"
+        )
+
+
+def list_plugins(
+    plugin_type: str,
+    collection_filter: str | None = None,
+    *,
+    collections_path: str | None = None,
+) -> dict[str, str]:
+    """List available plugins of a given type with short descriptions.
+
+    Args:
+        plugin_type: One of PLUGIN_TYPES (e.g., "lookup", "filter").
+        collection_filter: Optional collection filter (e.g., "netbox.netbox").
+        collections_path: Optional path to prepend to ANSIBLE_COLLECTIONS_PATH.
+
+    Returns:
+        Dict mapping fully-qualified plugin names to their short descriptions.
+    """
+    _validate_plugin_type(plugin_type)
+    args = ["--list", "-t", plugin_type, "--json"]
+    if collection_filter:
+        args.append(collection_filter)
+    raw = _run_ansible_doc(*args, collections_path=collections_path)
+    try:
+        plugins = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise AnsibleDocError(f"Failed to parse plugin list JSON: {exc}") from exc
+    return plugins
+
+
+def get_plugin_doc(
+    plugin_name: str,
+    plugin_type: str,
+    *,
+    collections_path: str | None = None,
+) -> dict[str, Any]:
+    """Fetch full documentation for a single plugin.
+
+    Returns the parsed JSON from `ansible-doc -t <type> <plugin> --json`.
+    """
+    _validate_plugin_type(plugin_type)
+    raw = _run_ansible_doc(
+        "-t", plugin_type, plugin_name, "--json",
+        collections_path=collections_path,
+    )
+    try:
+        doc = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise AnsibleDocError(f"Failed to parse plugin doc JSON: {exc}") from exc
+    return doc
+
+
+def search_plugins(
+    keyword: str,
+    plugin_type: str | None = None,
+    collection_filter: str | None = None,
+    *,
+    collections_path: str | None = None,
+) -> dict[str, str]:
+    """Search plugins by keyword in name or description.
+
+    When plugin_type is None, searches across all plugin types
+    sequentially (14 ansible-doc calls). The MCP server tool bypasses
+    this path and parallelizes across types via asyncio.gather — this
+    all-type codepath exists for direct parser callers (scripts, tests,
+    REPL exploration).
+    """
+    if plugin_type is not None:
+        _validate_plugin_type(plugin_type)
+        all_plugins = list_plugins(
+            plugin_type, collection_filter, collections_path=collections_path,
+        )
+    else:
+        all_plugins: dict[str, str] = {}
+        errors: list[str] = []
+        for ptype in PLUGIN_TYPES:
+            try:
+                found = list_plugins(
+                    ptype, collection_filter, collections_path=collections_path,
+                )
+                all_plugins.update(found)
+            except AnsibleDocError as exc:
+                errors.append(str(exc))
+                continue
+
+        if not all_plugins and errors:
+            raise AnsibleDocError(
+                f"Plugin discovery failed for all {len(errors)} types. "
+                f"Last error: {errors[-1]}"
+            )
+
+    keyword_lower = keyword.lower()
+    return {
+        name: desc
+        for name, desc in all_plugins.items()
+        if keyword_lower in name.lower() or keyword_lower in (desc or "").lower()
+    }
+
+
+def extract_plugin_metadata(
+    plugin_doc: dict[str, Any], plugin_type: str,
+) -> PluginMetadata:
+    """Extract all metadata needed for plugin skill generation."""
+    plugin_name = _get_module_name(plugin_doc)
+    logger.debug("Extracting plugin metadata for %s (type=%s)", plugin_name, plugin_type)
+    return {
+        "plugin_name": plugin_name,
+        "plugin_type": plugin_type,
+        "short_description": extract_short_description(plugin_doc),
+        "params": extract_params(plugin_doc),
+        "examples": extract_examples(plugin_doc),
     }

--- a/src/ansible_know/resolution.py
+++ b/src/ansible_know/resolution.py
@@ -16,15 +16,22 @@ if TYPE_CHECKING:
     import httpx
 
     from ansible_know.galaxy_config import GalaxyServerConfig
-    from ansible_know.types import DocProvenance, GalaxyClientFactory
+    from ansible_know.types import (
+        DocProvenance,
+        ErrorResponse,
+        GalaxyClientFactory,
+        GetPluginDocResult,
+        GetRoleDocResult,
+    )
 
 from ansible_know.async_utils import run_in_executor
 from ansible_know.errors import AnsibleDocError
-from ansible_know.validation import sanitize_error
+from ansible_know.validation import sanitize_error, validate_plugin_type
 
 logger = logging.getLogger("ansible_know")
 
 __all__ = [
+    "discover_collection_plugins",
     "resolve_module_doc",
     "resolve_plugin_doc",
     "resolve_role_doc",
@@ -75,6 +82,37 @@ def _get_servers(
         return galaxy_servers
     from ansible_know.galaxy_config import load_galaxy_servers
     return load_galaxy_servers()
+
+
+async def discover_collection_plugins(
+    collection_namespace: str,
+    collections_path: str | None = None,
+) -> list[tuple[str, dict[str, str]]]:
+    """Discover all plugins in a collection across all 14 plugin types.
+
+    Runs ``parser.list_plugins`` for each type in parallel via
+    ``asyncio.gather``. Individual type failures are logged and
+    silently return empty results.
+
+    Returns a list of ``(plugin_type, {fqcn: description})`` tuples.
+    """
+    from ansible_know import parser
+    from ansible_know.config import PLUGIN_TYPES
+    from ansible_know.errors import ValidationError
+
+    async def _list_one_type(ptype: str) -> tuple[str, dict[str, str]]:
+        try:
+            return ptype, await run_in_executor(
+                parser.list_plugins, ptype,
+                collection_filter=collection_namespace,
+                collections_path=collections_path,
+            )
+        except (AnsibleDocError, OSError, ValidationError):
+            return ptype, {}
+
+    return list(await asyncio.gather(
+        *[_list_one_type(pt) for pt in PLUGIN_TYPES]
+    ))
 
 
 async def resolve_module_doc(
@@ -144,13 +182,15 @@ async def resolve_plugin_doc(
     client_factory: GalaxyClientFactory | None = None,
     missing_collections: set[str] | None = None,
     collections_path: str | None = None,
-) -> dict[str, Any]:
+) -> GetPluginDocResult | ErrorResponse:
     """Try local ansible-doc -t <type>, fall back to Galaxy.
 
     Returns the complete tool response dict including doc_source and plugin_type.
     """
     from ansible_know import parser
     from ansible_know.errors import CollectionNotFoundError, GalaxyError
+
+    validate_plugin_type(plugin_type)
 
     servers = _get_servers(galaxy_servers)
     namespace = ".".join(plugin_name.split(".")[:2]) if "." in plugin_name else None
@@ -222,7 +262,7 @@ async def resolve_role_doc(
     client_factory: GalaxyClientFactory | None = None,
     missing_collections: set[str] | None = None,
     collections_path: str | None = None,
-) -> dict[str, Any]:
+) -> GetRoleDocResult | ErrorResponse:
     """Try local ansible-doc -t role, fall back to Galaxy readme_html.
 
     Returns the complete tool response dict including doc_source and content_type.

--- a/src/ansible_know/resolution.py
+++ b/src/ansible_know/resolution.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 from ansible_know.async_utils import run_in_executor
 from ansible_know.errors import AnsibleDocError
-from ansible_know.validation import sanitize_error, validate_plugin_type
+from ansible_know.validation import extract_namespace, sanitize_error, validate_plugin_type
 
 logger = logging.getLogger("ansible_know")
 
@@ -132,7 +132,7 @@ async def resolve_module_doc(
     from ansible_know.errors import CollectionNotFoundError, GalaxyError
 
     servers = _get_servers(galaxy_servers)
-    namespace = ".".join(module_name.split(".")[:2]) if "." in module_name else None
+    namespace = extract_namespace(module_name)
     cpath = collections_path
 
     async def _fetch_from_galaxy(client):
@@ -193,7 +193,7 @@ async def resolve_plugin_doc(
     validate_plugin_type(plugin_type)
 
     servers = _get_servers(galaxy_servers)
-    namespace = ".".join(plugin_name.split(".")[:2]) if "." in plugin_name else None
+    namespace = extract_namespace(plugin_name)
     cpath = collections_path
 
     local_doc: dict[str, Any] = {}
@@ -271,7 +271,7 @@ async def resolve_role_doc(
     from ansible_know.errors import CollectionNotFoundError, GalaxyError
 
     servers = _get_servers(galaxy_servers)
-    namespace = ".".join(role_name.split(".")[:2]) if "." in role_name else None
+    namespace = extract_namespace(role_name)
     cpath = collections_path
 
     local_doc: dict[str, Any] = {}

--- a/src/ansible_know/resolution.py
+++ b/src/ansible_know/resolution.py
@@ -26,6 +26,7 @@ logger = logging.getLogger("ansible_know")
 
 __all__ = [
     "resolve_module_doc",
+    "resolve_plugin_doc",
     "resolve_role_doc",
     "search_galaxy_collections",
 ]
@@ -133,6 +134,85 @@ async def resolve_module_doc(
         except GalaxyError as galaxy_exc:
             logger.warning("Galaxy fallback also failed: %s", galaxy_exc)
             raise local_exc from galaxy_exc
+
+
+async def resolve_plugin_doc(
+    plugin_name: str,
+    plugin_type: str,
+    http_client: httpx.AsyncClient | None = None,
+    galaxy_servers: list[GalaxyServerConfig] | None = None,
+    client_factory: GalaxyClientFactory | None = None,
+    missing_collections: set[str] | None = None,
+    collections_path: str | None = None,
+) -> dict[str, Any]:
+    """Try local ansible-doc -t <type>, fall back to Galaxy.
+
+    Returns the complete tool response dict including doc_source and plugin_type.
+    """
+    from ansible_know import parser
+    from ansible_know.errors import CollectionNotFoundError, GalaxyError
+
+    servers = _get_servers(galaxy_servers)
+    namespace = ".".join(plugin_name.split(".")[:2]) if "." in plugin_name else None
+    cpath = collections_path
+
+    local_doc: dict[str, Any] = {}
+
+    if not (namespace and missing_collections is not None and namespace in missing_collections):
+        try:
+            local_doc = await run_in_executor(
+                parser.get_plugin_doc, plugin_name, plugin_type,
+                collections_path=cpath,
+            )
+        except CollectionNotFoundError:
+            if namespace and missing_collections is not None:
+                missing_collections.add(namespace)
+            local_doc = {}
+        except AnsibleDocError as exc:
+            logger.warning("Local plugin doc failed for %s: %s", plugin_name, exc)
+            local_doc = {}
+
+    if local_doc:
+        metadata = parser.extract_plugin_metadata(local_doc, plugin_type)
+        metadata["content_type"] = "plugin"
+        metadata["doc_source"] = "local"
+        return metadata
+
+    if client_factory is None:
+        return {
+            "plugin_name": plugin_name,
+            "plugin_type": plugin_type,
+            "content_type": "plugin",
+            "doc_source": "unavailable",
+            "error": "No Galaxy client configured for fallback",
+            "params": [],
+        }
+
+    try:
+        async def _fetch(client):
+            return await client.fetch_plugin_doc(plugin_name, plugin_type)
+        galaxy_doc, galaxy_meta = await _try_galaxy_servers(
+            servers, _fetch, client_factory, http_client,
+        )
+        metadata = parser.extract_plugin_metadata(galaxy_doc, plugin_type)
+        result = dict(metadata)
+        result["content_type"] = "plugin"
+        result["doc_source"] = "galaxy"
+        result["doc_version"] = galaxy_meta.get("doc_version", "")
+        if "doc_warning" in galaxy_meta:
+            result["doc_warning"] = galaxy_meta["doc_warning"]
+        if "doc_source_server" in galaxy_meta:
+            result["doc_source_server"] = galaxy_meta["doc_source_server"]
+        return result
+    except GalaxyError as galaxy_exc:
+        return {
+            "plugin_name": plugin_name,
+            "plugin_type": plugin_type,
+            "content_type": "plugin",
+            "doc_source": "unavailable",
+            "error": sanitize_error(str(galaxy_exc)),
+            "params": [],
+        }
 
 
 async def resolve_role_doc(

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -49,6 +49,7 @@ from ansible_know.validation import (
     validate_keyword,
     validate_namespace,
     validate_path_containment,
+    validate_plugin_type,
     validate_query,
     validate_skill_name,
     validate_tags,
@@ -339,9 +340,7 @@ async def search_plugins(
         if namespace:
             validate_namespace(namespace)
         if plugin_type:
-            from ansible_know.config import PLUGIN_TYPES
-            if plugin_type not in PLUGIN_TYPES:
-                return {"error": f"Invalid plugin type '{plugin_type}'. Valid: {', '.join(sorted(PLUGIN_TYPES))}"}
+            validate_plugin_type(plugin_type)
     except ValidationError as exc:
         return {"error": str(exc)}
 
@@ -497,9 +496,7 @@ async def get_plugin_doc(
     await _maybe_warn_upgrade(ctx)
     try:
         validate_fqcn(plugin_name)
-        from ansible_know.config import PLUGIN_TYPES
-        if plugin_type not in PLUGIN_TYPES:
-            return {"error": f"Invalid plugin type '{plugin_type}'. Valid: {', '.join(sorted(PLUGIN_TYPES))}"}
+        validate_plugin_type(plugin_type)
     except ValidationError as exc:
         return {"error": str(exc)}
 
@@ -651,7 +648,7 @@ async def get_collection_manifest(
 
     await _maybe_warn_upgrade(ctx)
     try:
-        from ansible_know import collection_manifest, parser
+        from ansible_know import collection_manifest, parser, resolution
 
         state = await _get_state(ctx)
         installed_version = state.collection_manager.list_installed().get(collection_namespace)
@@ -678,21 +675,8 @@ async def get_collection_manifest(
         except (AnsibleDocError, OSError) as exc:
             logger.warning("list_roles failed for %s: %s", collection_namespace, exc)
 
-        # Discover plugins across all types (parallel — 14 types via asyncio.gather)
-        from ansible_know.config import PLUGIN_TYPES
-
-        async def _list_one_plugin_type(ptype):
-            try:
-                return ptype, await run_in_executor(
-                    parser.list_plugins, ptype,
-                    collection_filter=collection_namespace,
-                    collections_path=cpath,
-                )
-            except (AnsibleDocError, OSError, ValidationError):
-                return ptype, {}
-
-        plugin_results = await asyncio.gather(
-            *[_list_one_plugin_type(pt) for pt in PLUGIN_TYPES]
+        plugin_results = await resolution.discover_collection_plugins(
+            collection_namespace, collections_path=cpath,
         )
         plugins_raw: dict[str, dict[str, str]] = {}
         for ptype, type_plugins in plugin_results:
@@ -1116,9 +1100,7 @@ async def generate_plugin_skill(
     await _maybe_warn_upgrade(ctx)
     try:
         validate_fqcn(plugin_name)
-        from ansible_know.config import PLUGIN_TYPES
-        if plugin_type not in PLUGIN_TYPES:
-            return {"error": f"Invalid plugin type '{plugin_type}'. Valid: {', '.join(sorted(PLUGIN_TYPES))}"}
+        validate_plugin_type(plugin_type)
         if install_to:
             validate_install_path(install_to)
     except ValidationError as exc:
@@ -1189,7 +1171,7 @@ async def generate_collection_skills(
         return {"error": str(exc)}
 
     try:
-        from ansible_know import collection_manifest, parser, skills
+        from ansible_know import collection_manifest, parser, resolution, skills
         from ansible_know.config import SKILLS_DIR
 
         state = await _get_state(ctx)
@@ -1211,21 +1193,8 @@ async def generate_collection_skills(
         except (AnsibleDocError, OSError) as exc:
             logger.warning("list_roles failed for %s: %s", collection_namespace, exc)
 
-        # Discover plugins across all types (parallel)
-        from ansible_know.config import PLUGIN_TYPES
-
-        async def _list_plugin_type(ptype):
-            try:
-                return ptype, await run_in_executor(
-                    parser.list_plugins, ptype,
-                    collection_filter=collection_namespace,
-                    collections_path=cpath,
-                )
-            except (AnsibleDocError, OSError, ValidationError):
-                return ptype, {}
-
-        plugin_list_results = await asyncio.gather(
-            *[_list_plugin_type(pt) for pt in PLUGIN_TYPES]
+        plugin_list_results = await resolution.discover_collection_plugins(
+            collection_namespace, collections_path=cpath,
         )
 
         # Combined guard — reject only if ALL content types are empty

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1,6 +1,6 @@
 """Ansible Know MCP Server.
 
-Provides 17 tools, 5 resources, and 5 prompts for module, role, and plugin discovery,
+Provides 17 tools, 6 resources, and 5 prompts for module, role, and plugin discovery,
 documentation search, Galaxy collection discovery, and skill generation
 via the Model Context Protocol.
 """

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1,6 +1,6 @@
 """Ansible Know MCP Server.
 
-Provides 14 tools, 5 resources, and 4 prompts for module and role discovery,
+Provides 17 tools, 5 resources, and 5 prompts for module, role, and plugin discovery,
 documentation search, Galaxy collection discovery, and skill generation
 via the Model Context Protocol.
 """
@@ -12,6 +12,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 from importlib.metadata import version as pkg_version
 from pathlib import Path
 from typing import Annotated, Any
@@ -32,6 +33,7 @@ from ansible_know.types import (
     FetchDocResult,
     GenerateCollectionSkillsResult,
     GetModuleDocResult,
+    GetPluginDocResult,
     GetRoleDocResult,
     ManifestResult,
     SearchDocsEntry,
@@ -56,6 +58,8 @@ from ansible_know.validation import (
 logger = logging.getLogger("ansible_know")
 
 _VERSION = pkg_version("ansible-know-mcp")
+
+_PLUGIN_SKILL_DIR_RE = re.compile(r"^([a-z]+)__(.+)$")
 
 _VERSION_CHECK_INTERVAL = 6 * 3600  # 6 hours
 
@@ -145,13 +149,13 @@ mcp = FastMCP(
     name="Ansible Know",
     version=_VERSION,
     instructions=(
-        "Ansible module and role discovery, documentation, and skill generation. "
+        "Ansible module, role, and plugin discovery, documentation, and skill generation. "
         "Workflow: (1) search_collections to discover collections on Galaxy, "
         "(2) ensure_collection to install one for this session, "
-        "(3) search_modules/get_collection_manifest to find modules and roles, "
-        "(4) get_module_doc or get_role_doc for structured docs, "
+        "(3) search_modules/search_plugins/get_collection_manifest to find content, "
+        "(4) get_module_doc, get_role_doc, or get_plugin_doc for structured docs, "
         "(5) search_docs for conceptual guides, then fetch_doc to retrieve full content, "
-        "(6) generate_skill or generate_role_skill to create skill packages. "
+        "(6) generate_skill, generate_role_skill, or generate_plugin_skill for skill packages. "
         "Resources: server://version for version and upgrade status, "
         "galaxy://installed for session collections, "
         "docs://sources for configured doc sources, "
@@ -314,6 +318,79 @@ async def search_modules(
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def search_plugins(
+    keyword: Annotated[str, "Search term to match against plugin names and descriptions"],
+    plugin_type: Annotated[
+        str | None,
+        "Plugin type filter (e.g. 'lookup', 'filter'). If omitted, searches all types.",
+    ] = None,
+    namespace: Annotated[str | None, "Optional collection namespace filter (e.g. 'netbox.netbox')"] = None,
+    ctx: Context | None = None,
+) -> dict[str, str] | ErrorResponse:
+    """Find Ansible plugins by keyword. Returns up to 50 matches as {fqcn: short_description}.
+
+    Plugin types: lookup, filter, test, connection, become, strategy,
+    callback, inventory, cache, cliconf, httpapi, netconf, shell, vars.
+    On failure returns {"error": str}.
+    """
+    logger.info("search_plugins keyword=%r type=%r namespace=%r", keyword, plugin_type, namespace)
+    try:
+        validate_keyword(keyword)
+        if namespace:
+            validate_namespace(namespace)
+        if plugin_type:
+            from ansible_know.config import PLUGIN_TYPES
+            if plugin_type not in PLUGIN_TYPES:
+                return {"error": f"Invalid plugin type '{plugin_type}'. Valid: {', '.join(sorted(PLUGIN_TYPES))}"}
+    except ValidationError as exc:
+        return {"error": str(exc)}
+
+    try:
+        from ansible_know import parser
+        from ansible_know.config import PLUGIN_TYPES, SEARCH_MODULES_LIMIT
+
+        state = await _get_state(ctx)
+        cpath = state.collection_manager.get_collections_path()
+
+        if plugin_type is not None:
+            results = await run_in_executor(
+                parser.search_plugins, keyword, plugin_type=plugin_type,
+                collection_filter=namespace, collections_path=cpath,
+            )
+        else:
+            # Parallelize across all 14 types
+            async def _search_one_type(pt):
+                try:
+                    return await run_in_executor(
+                        parser.search_plugins, keyword, plugin_type=pt,
+                        collection_filter=namespace, collections_path=cpath,
+                    )
+                except (AnsibleDocError, OSError, ValidationError):
+                    return None
+
+            type_results = await asyncio.gather(
+                *[_search_one_type(pt) for pt in PLUGIN_TYPES]
+            )
+            results = {}
+            error_count = 0
+            for r in type_results:
+                if r is None:
+                    error_count += 1
+                else:
+                    results.update(r)
+
+            if not results and error_count == len(PLUGIN_TYPES):
+                return {"error": "Plugin discovery failed for all plugin types. Check ansible-core installation."}
+
+        if len(results) > SEARCH_MODULES_LIMIT:
+            results = dict(list(results.items())[:SEARCH_MODULES_LIMIT])
+        return results
+    except Exception as exc:
+        logger.warning("search_plugins failed: %s", exc)
+        return {"error": maybe_add_hint(sanitize_error(str(exc)), namespace)}
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def get_module_doc(
     module_name: Annotated[str, "Fully-qualified collection name (e.g. 'ansible.builtin.copy')"],
     ctx: Context | None = None,
@@ -395,6 +472,52 @@ async def get_role_doc(
     except Exception as exc:
         logger.warning("get_role_doc failed: %s", exc)
         ns = ".".join(role_name.split(".")[:2]) if "." in role_name else None
+        return {"error": maybe_add_hint(sanitize_error(str(exc)), ns)}
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def get_plugin_doc(
+    plugin_name: Annotated[str, "Fully-qualified plugin name (e.g. 'netbox.netbox.nb_lookup')"],
+    plugin_type: Annotated[
+        str,
+        "Plugin type (lookup, filter, test, connection, become, "
+        "strategy, callback, inventory, cache, cliconf, httpapi, "
+        "netconf, shell, or vars)",
+    ],
+    ctx: Context | None = None,
+) -> GetPluginDocResult | ErrorResponse:
+    """Get full structured documentation for one plugin.
+
+    Returns: plugin_name, plugin_type, short_description, params, examples,
+    doc_source ('local' or 'galaxy').
+    Falls back to Galaxy if collection is not installed locally.
+    On failure returns {"error": str}.
+    """
+    logger.info("get_plugin_doc plugin=%r type=%r", plugin_name, plugin_type)
+    await _maybe_warn_upgrade(ctx)
+    try:
+        validate_fqcn(plugin_name)
+        from ansible_know.config import PLUGIN_TYPES
+        if plugin_type not in PLUGIN_TYPES:
+            return {"error": f"Invalid plugin type '{plugin_type}'. Valid: {', '.join(sorted(PLUGIN_TYPES))}"}
+    except ValidationError as exc:
+        return {"error": str(exc)}
+
+    try:
+        from ansible_know import resolution
+
+        state = await _get_state(ctx)
+        http_client = _get_http_client(ctx)
+        return await resolution.resolve_plugin_doc(
+            plugin_name, plugin_type,
+            http_client=http_client, galaxy_servers=state.galaxy_servers,
+            client_factory=_galaxy_factory(ctx),
+            missing_collections=state.missing_collections,
+            collections_path=state.collection_manager.get_collections_path(),
+        )
+    except Exception as exc:
+        logger.warning("get_plugin_doc failed: %s", exc)
+        ns = ".".join(plugin_name.split(".")[:2]) if "." in plugin_name else None
         return {"error": maybe_add_hint(sanitize_error(str(exc)), ns)}
 
 
@@ -555,9 +678,30 @@ async def get_collection_manifest(
         except (AnsibleDocError, OSError) as exc:
             logger.warning("list_roles failed for %s: %s", collection_namespace, exc)
 
-        if not modules and not roles_raw:
+        # Discover plugins across all types (parallel — 14 types via asyncio.gather)
+        from ansible_know.config import PLUGIN_TYPES
+
+        async def _list_one_plugin_type(ptype):
+            try:
+                return ptype, await run_in_executor(
+                    parser.list_plugins, ptype,
+                    collection_filter=collection_namespace,
+                    collections_path=cpath,
+                )
+            except (AnsibleDocError, OSError, ValidationError):
+                return ptype, {}
+
+        plugin_results = await asyncio.gather(
+            *[_list_one_plugin_type(pt) for pt in PLUGIN_TYPES]
+        )
+        plugins_raw: dict[str, dict[str, str]] = {}
+        for ptype, type_plugins in plugin_results:
+            for pfqcn, pdesc in type_plugins.items():
+                plugins_raw[pfqcn] = {"description": pdesc, "plugin_type": ptype}
+
+        if not modules and not roles_raw and not plugins_raw:
             return {"error": (
-                f"No modules or roles found in collection '{collection_namespace}'."
+                f"No modules, roles, or plugins found in collection '{collection_namespace}'."
                 + collection_hint(collection_namespace)
             )}
 
@@ -582,10 +726,20 @@ async def get_collection_manifest(
                 "entry_points": entry_points,
             })
 
+        plugins_metadata = []
+        for pfqcn, pinfo in sorted(plugins_raw.items()):
+            plugins_metadata.append({
+                "fqcn": pfqcn,
+                "plugin_type": pinfo["plugin_type"],
+                "description": pinfo["description"],
+                "param_count": 0,
+            })
+
         manifest = await run_in_executor(
             collection_manifest.generate_manifest,
             collection_namespace, metadata_list,
             roles_metadata=roles_metadata,
+            plugins_metadata=plugins_metadata,
             collection_version=installed_version,
         )
         await run_in_executor(
@@ -678,8 +832,16 @@ def _list_skills_sync(
             try:
                 skill_md = sub_dir / "SKILL.md"
                 if sub_dir.is_dir() and not sub_dir.is_symlink() and skill_md.exists():
+                    dir_name = sub_dir.name
+                    # Strip {type}__ prefix for plugin skills
+                    from ansible_know.config import PLUGIN_TYPES
+                    match = _PLUGIN_SKILL_DIR_RE.match(dir_name)
+                    if match and match.group(1) in PLUGIN_TYPES:
+                        display_name = f"{collection}.{match.group(2)}"
+                    else:
+                        display_name = f"{collection}.{dir_name}"
                     results.append({
-                        "name": f"{collection}.{sub_dir.name}",
+                        "name": display_name,
                         "description": _extract_skill_description(skill_md),
                         "path": str(sub_dir),
                     })
@@ -746,10 +908,20 @@ def _get_skill_sync(skills_dir: Path, skill_name: str) -> str:
     if len(parts) >= 3:
         namespace = ".".join(parts[:2])
         short_name = ".".join(parts[2:])
+
+        # Module/role skill (direct short_name)
         nested_path = (skills_dir / namespace / short_name / "SKILL.md").resolve()
         validate_path_containment(nested_path, skills_dir)
         if nested_path.exists():
             return truncate_response(nested_path.read_text())
+
+        # Plugin skill ({type}__{short_name} convention)
+        from ansible_know.config import PLUGIN_TYPES
+        for ptype in PLUGIN_TYPES:
+            plugin_path = (skills_dir / namespace / f"{ptype}__{short_name}" / "SKILL.md").resolve()
+            validate_path_containment(plugin_path, skills_dir)
+            if plugin_path.exists():
+                return truncate_response(plugin_path.read_text())
 
         flat_path = (skills_dir / skill_name / "SKILL.md").resolve()
         validate_path_containment(flat_path, skills_dir)
@@ -924,6 +1096,78 @@ async def generate_role_skill(
 
 
 @mcp.tool(annotations=ToolAnnotations(idempotentHint=True))
+async def generate_plugin_skill(
+    plugin_name: Annotated[str, "Fully-qualified plugin name (e.g. 'netbox.netbox.nb_lookup')"],
+    plugin_type: Annotated[
+        str,
+        "Plugin type (lookup, filter, test, connection, become, "
+        "strategy, callback, inventory, cache, cliconf, httpapi, "
+        "netconf, shell, or vars)",
+    ],
+    install_to: Annotated[str | None, "Optional absolute path to install the skill to"] = None,
+    ctx: Context | None = None,
+) -> str | ErrorResponse:
+    """Generate a skill package for one plugin.
+
+    Writes SKILL.md to disk (no scripts/ or assets/).
+    Returns the SKILL.md content as str, or {"error": str} on failure.
+    """
+    logger.info("generate_plugin_skill plugin=%r type=%r install_to=%r", plugin_name, plugin_type, install_to)
+    await _maybe_warn_upgrade(ctx)
+    try:
+        validate_fqcn(plugin_name)
+        from ansible_know.config import PLUGIN_TYPES
+        if plugin_type not in PLUGIN_TYPES:
+            return {"error": f"Invalid plugin type '{plugin_type}'. Valid: {', '.join(sorted(PLUGIN_TYPES))}"}
+        if install_to:
+            validate_install_path(install_to)
+    except ValidationError as exc:
+        return {"error": str(exc)}
+
+    try:
+        from ansible_know import resolution, skills
+        from ansible_know.config import SKILLS_DIR
+
+        if ctx:
+            await ctx.report_progress(progress=0, total=100)
+
+        state = await _get_state(ctx)
+        http_client = _get_http_client(ctx)
+        metadata = await resolution.resolve_plugin_doc(
+            plugin_name, plugin_type,
+            http_client=http_client, galaxy_servers=state.galaxy_servers,
+            client_factory=_galaxy_factory(ctx),
+            missing_collections=state.missing_collections,
+            collections_path=state.collection_manager.get_collections_path(),
+        )
+
+        if metadata.get("doc_source") == "unavailable":
+            return {"error": metadata.get("error", f"No documentation found for plugin '{plugin_name}'.")}
+
+        if ctx:
+            await ctx.report_progress(progress=50, total=100)
+
+        namespace = ".".join(plugin_name.split(".")[:2])
+        short_name = plugin_name.rsplit(".", 1)[-1]
+        base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
+        output_dir = base_dir / namespace / f"{plugin_type}__{short_name}"
+
+        await run_in_executor(skills.write_plugin_skill_package, output_dir, metadata)
+        logger.info("generate_plugin_skill wrote to %s", output_dir)
+
+        if ctx:
+            await ctx.report_progress(progress=100, total=100)
+
+        return truncate_response(skills.render_plugin_skill(metadata))
+    except ValidationError as exc:
+        return {"error": str(exc)}
+    except Exception as exc:
+        logger.warning("generate_plugin_skill failed: %s", exc)
+        ns = ".".join(plugin_name.split(".")[:2]) if "." in plugin_name else None
+        return {"error": maybe_add_hint(sanitize_error(str(exc)), ns)}
+
+
+@mcp.tool(annotations=ToolAnnotations(idempotentHint=True))
 async def generate_collection_skills(
     collection_namespace: Annotated[str, "Collection namespace (e.g. 'netbox.netbox')"],
     install_to: Annotated[str | None, "Optional absolute path to install skills to"] = None,
@@ -950,28 +1194,64 @@ async def generate_collection_skills(
 
         state = await _get_state(ctx)
         cpath = state.collection_manager.get_collections_path()
+
+        # Discover modules
         modules = await run_in_executor(
             parser.search_modules, "", collection_filter=collection_namespace,
             collections_path=cpath,
         )
-        if not modules:
+
+        # Discover roles
+        roles_raw = {}
+        try:
+            roles_raw = await run_in_executor(
+                parser.list_roles, collection_filter=collection_namespace,
+                collections_path=cpath,
+            )
+        except (AnsibleDocError, OSError) as exc:
+            logger.warning("list_roles failed for %s: %s", collection_namespace, exc)
+
+        # Discover plugins across all types (parallel)
+        from ansible_know.config import PLUGIN_TYPES
+
+        async def _list_plugin_type(ptype):
+            try:
+                return ptype, await run_in_executor(
+                    parser.list_plugins, ptype,
+                    collection_filter=collection_namespace,
+                    collections_path=cpath,
+                )
+            except (AnsibleDocError, OSError, ValidationError):
+                return ptype, {}
+
+        plugin_list_results = await asyncio.gather(
+            *[_list_plugin_type(pt) for pt in PLUGIN_TYPES]
+        )
+
+        # Combined guard — reject only if ALL content types are empty
+        has_plugins = any(plugins for _, plugins in plugin_list_results)
+        if not modules and not roles_raw and not has_plugins:
             return {"error": (
-                f"No modules found in collection '{collection_namespace}'."
+                f"No modules, roles, or plugins found in collection '{collection_namespace}'."
                 + collection_hint(collection_namespace)
             )}
 
-        total = len(modules)
+        plugin_count = sum(len(plugins) for _, plugins in plugin_list_results)
+        total = len(modules) + len(roles_raw) + plugin_count
         succeeded = 0
         failed = 0
+        current = 0
         metadata_list = []
 
         base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
 
         installed_version = state.collection_manager.list_installed().get(collection_namespace)
 
-        for i, module_name in enumerate(sorted(modules)):
+        # Generate module skills
+        for module_name in sorted(modules):
             if ctx:
-                await ctx.report_progress(progress=i, total=total)
+                await ctx.report_progress(progress=current, total=total)
+            current += 1
             try:
                 raw_doc = await run_in_executor(
                     parser.get_module_doc, module_name, collections_path=cpath,
@@ -984,12 +1264,87 @@ async def generate_collection_skills(
                 await run_in_executor(skills.write_module_skill_package, output_dir, metadata)
                 succeeded += 1
             except Exception as exc:
-                logger.warning("Skill generation failed for %s: %s", module_name, exc)
+                logger.warning("Module skill generation failed for %s: %s", module_name, exc)
                 failed += 1
+
+        # Generate role skills
+        from ansible_know import resolution
+
+        roles_metadata = []
+        for role_fqcn, role_data in sorted(roles_raw.items()):
+            if ctx:
+                await ctx.report_progress(progress=current, total=total)
+            current += 1
+            try:
+                http_client = _get_http_client(ctx)
+                role_meta = await resolution.resolve_role_doc(
+                    role_fqcn, http_client=http_client,
+                    galaxy_servers=state.galaxy_servers,
+                    client_factory=_galaxy_factory(ctx),
+                    missing_collections=state.missing_collections,
+                    collections_path=cpath,
+                )
+
+                if role_meta.get("doc_source") == "unavailable":
+                    logger.warning("Role doc unavailable for %s, skipping skill", role_fqcn)
+                    failed += 1
+                    continue
+
+                entry_points = list(role_data.get("entry_points", {}).keys()) or ["main"]
+                has_specs = bool(role_data.get("entry_points", {}))
+                roles_metadata.append({
+                    "fqcn": role_fqcn,
+                    "description": role_data.get("description", ""),
+                    "has_argument_specs": has_specs,
+                    "entry_points": entry_points,
+                })
+
+                short_name = role_fqcn.rsplit(".", 1)[-1]
+                output_dir = base_dir / collection_namespace / short_name
+                await run_in_executor(
+                    skills.write_role_skill_package, output_dir, role_meta,
+                )
+                succeeded += 1
+            except Exception as exc:
+                logger.warning("Role skill generation failed for %s: %s", role_fqcn, exc)
+                failed += 1
+
+        # Generate plugin skills
+        plugins_metadata = []
+        for ptype, type_plugins in plugin_list_results:
+            for pfqcn in sorted(type_plugins):
+                if ctx:
+                    await ctx.report_progress(progress=current, total=total)
+                current += 1
+                try:
+                    raw_doc = await run_in_executor(
+                        parser.get_plugin_doc, pfqcn, ptype,
+                        collections_path=cpath,
+                    )
+                    meta = parser.extract_plugin_metadata(raw_doc, ptype)
+                    plugins_metadata.append({
+                        "fqcn": pfqcn,
+                        "plugin_type": ptype,
+                        "description": meta["short_description"],
+                        "param_count": len(meta["params"]),
+                    })
+
+                    short_name = pfqcn.rsplit(".", 1)[-1]
+                    output_dir = base_dir / collection_namespace / f"{ptype}__{short_name}"
+                    await run_in_executor(
+                        skills.write_plugin_skill_package, output_dir, meta,
+                    )
+                    succeeded += 1
+                except Exception as exc:
+                    logger.warning("Plugin skill generation failed for %s: %s", pfqcn, exc)
+                    failed += 1
 
         manifest = await run_in_executor(
             collection_manifest.generate_manifest,
-            collection_namespace, metadata_list, skills_dir=base_dir,
+            collection_namespace, metadata_list,
+            roles_metadata=roles_metadata,
+            plugins_metadata=plugins_metadata,
+            skills_dir=base_dir,
             collection_version=installed_version,
         )
         await run_in_executor(
@@ -1000,7 +1355,7 @@ async def generate_collection_skills(
         await run_in_executor(
             skills.write_collection_skill_package,
             base_dir / collection_namespace, collection_namespace,
-            metadata_list, installed_version,
+            metadata_list, installed_version, plugins_metadata,
         )
 
         if ctx:
@@ -1063,7 +1418,7 @@ async def clear_cache(
 def resource_skills_list() -> str:
     import json
 
-    from ansible_know.config import SKILLS_DIR
+    from ansible_know.config import PLUGIN_TYPES, SKILLS_DIR
 
     skills_list: list[str] = []
     if SKILLS_DIR.exists():
@@ -1075,7 +1430,12 @@ def resource_skills_list() -> str:
                 skills_list.append(skill_dir.name)
             for sub_dir in sorted(skill_dir.iterdir()):
                 if sub_dir.is_dir() and not sub_dir.is_symlink() and (sub_dir / "SKILL.md").exists():
-                    skills_list.append(f"{skill_dir.name}.{sub_dir.name}")
+                    dir_name = sub_dir.name
+                    match = _PLUGIN_SKILL_DIR_RE.match(dir_name)
+                    if match and match.group(1) in PLUGIN_TYPES:
+                        skills_list.append(f"{skill_dir.name}.{match.group(2)}")
+                    else:
+                        skills_list.append(f"{skill_dir.name}.{dir_name}")
     return json.dumps(skills_list, indent=2)
 
 

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -41,6 +41,7 @@ from ansible_know.types import (
     VersionInfo,
 )
 from ansible_know.validation import (
+    extract_namespace,
     sanitize_error,
     truncate_response,
     validate_doc_url,
@@ -428,7 +429,7 @@ async def get_module_doc(
         return metadata
     except Exception as exc:
         logger.warning("get_module_doc failed: %s", exc)
-        ns = ".".join(module_name.split(".")[:2]) if "." in module_name else None
+        ns = extract_namespace(module_name)
         from ansible_know.errors import GalaxyError
         if isinstance(exc.__cause__, GalaxyError):
             return {"error": sanitize_error(str(exc))}
@@ -470,7 +471,7 @@ async def get_role_doc(
         )
     except Exception as exc:
         logger.warning("get_role_doc failed: %s", exc)
-        ns = ".".join(role_name.split(".")[:2]) if "." in role_name else None
+        ns = extract_namespace(role_name)
         return {"error": maybe_add_hint(sanitize_error(str(exc)), ns)}
 
 
@@ -514,7 +515,7 @@ async def get_plugin_doc(
         )
     except Exception as exc:
         logger.warning("get_plugin_doc failed: %s", exc)
-        ns = ".".join(plugin_name.split(".")[:2]) if "." in plugin_name else None
+        ns = extract_namespace(plugin_name)
         return {"error": maybe_add_hint(sanitize_error(str(exc)), ns)}
 
 
@@ -994,7 +995,7 @@ async def generate_skill(
             await ctx.report_progress(progress=50, total=100)
 
         fqcn = metadata["module_name"]
-        namespace = ".".join(fqcn.split(".")[:2])
+        namespace = extract_namespace(fqcn)
         short_name = fqcn.rsplit(".", 1)[-1]
         base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
         output_dir = base_dir / namespace / short_name
@@ -1010,7 +1011,7 @@ async def generate_skill(
         return {"error": str(exc)}
     except Exception as exc:
         logger.warning("generate_skill failed: %s", exc)
-        ns = ".".join(module_name.split(".")[:2]) if "." in module_name else None
+        ns = extract_namespace(module_name)
         from ansible_know.errors import GalaxyError
         if isinstance(exc.__cause__, GalaxyError):
             return {"error": sanitize_error(str(exc))}
@@ -1059,7 +1060,7 @@ async def generate_role_skill(
         if ctx:
             await ctx.report_progress(progress=50, total=100)
 
-        namespace = ".".join(role_name.split(".")[:2])
+        namespace = extract_namespace(role_name)
         short_name = role_name.rsplit(".", 1)[-1]
         base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
         output_dir = base_dir / namespace / short_name
@@ -1075,7 +1076,7 @@ async def generate_role_skill(
         return {"error": str(exc)}
     except Exception as exc:
         logger.warning("generate_role_skill failed: %s", exc)
-        ns = ".".join(role_name.split(".")[:2]) if "." in role_name else None
+        ns = extract_namespace(role_name)
         return {"error": maybe_add_hint(sanitize_error(str(exc)), ns)}
 
 
@@ -1129,7 +1130,7 @@ async def generate_plugin_skill(
         if ctx:
             await ctx.report_progress(progress=50, total=100)
 
-        namespace = ".".join(plugin_name.split(".")[:2])
+        namespace = extract_namespace(plugin_name)
         short_name = plugin_name.rsplit(".", 1)[-1]
         base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
         output_dir = base_dir / namespace / f"{plugin_type}__{short_name}"
@@ -1145,7 +1146,7 @@ async def generate_plugin_skill(
         return {"error": str(exc)}
     except Exception as exc:
         logger.warning("generate_plugin_skill failed: %s", exc)
-        ns = ".".join(plugin_name.split(".")[:2]) if "." in plugin_name else None
+        ns = extract_namespace(plugin_name)
         return {"error": maybe_add_hint(sanitize_error(str(exc)), ns)}
 
 

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1549,7 +1549,8 @@ def review_playbook(playbook_yaml: str) -> str:
         "Review the following Ansible playbook for correctness, best practices, "
         "and potential issues. Check that modules are used with correct parameters, "
         "FQCNs are used, and the playbook follows idempotency principles.\n\n"
-        "Use the search_modules and get_module_doc tools to verify module usage.\n\n"
+        "Use the search_modules, search_plugins, get_module_doc, and get_plugin_doc "
+        "tools to verify module and plugin usage.\n\n"
         f"```yaml\n{playbook_yaml}\n```"
     )
 
@@ -1563,6 +1564,19 @@ def explain_module(module_name: str) -> str:
         "1. What the module does and when to use it\n"
         "2. Required vs optional parameters with descriptions\n"
         "3. A practical example playbook\n"
+        "4. Common pitfalls or gotchas"
+    )
+
+
+@mcp.prompt
+def explain_plugin(plugin_name: str, plugin_type: str) -> str:
+    """Get a detailed explanation of an Ansible plugin with usage examples."""
+    return (
+        f"Explain the Ansible {plugin_type} plugin `{plugin_name}` in detail. "
+        "Use the get_plugin_doc tool to fetch its full documentation, then provide:\n\n"
+        "1. What the plugin does and when to use it instead of a module\n"
+        "2. Parameters with descriptions\n"
+        "3. A practical usage example (Jinja2 expression, inventory file, or ansible.cfg)\n"
         "4. Common pitfalls or gotchas"
     )
 
@@ -1594,7 +1608,7 @@ def find_collection(platform_or_use_case: str) -> str:
         "2. Pick the best match (prefer high download count, non-deprecated)\n"
         "3. Use ensure_collection to install it for this session\n"
         "4. Use get_collection_manifest to see all available modules and roles\n"
-        "5. Use get_module_doc or get_role_doc on relevant content to understand usage"
+        "5. Use get_module_doc, get_role_doc, or get_plugin_doc on relevant content to understand usage"
     )
 
 

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -249,6 +249,7 @@ def _collection_template_context(
     namespace: str,
     metadata_list: list[ModuleMetadata],
     collection_version: str | None = None,
+    plugins_metadata: list[dict[str, Any]] | None = None,
 ) -> CollectionSkillContext:
     """Build template context for a collection-level skill."""
     modules_by_tag: dict[str, list[ModuleTagEntry]] = {}
@@ -279,6 +280,14 @@ def _collection_template_context(
 
     common_params = _find_common_params(metadata_list)
 
+    plugins_by_type: dict[str, list[dict[str, str]]] = {}
+    for pmeta in (plugins_metadata or []):
+        ptype = pmeta.get("plugin_type", "other")
+        plugins_by_type.setdefault(ptype, []).append({
+            "fqcn": pmeta["fqcn"],
+            "short_description": pmeta.get("description", ""),
+        })
+
     return {
         "collection_namespace": namespace,
         "collection_version": collection_version,
@@ -286,6 +295,7 @@ def _collection_template_context(
         "all_api": all_api,
         "common_params": common_params,
         "module_count": len(metadata_list),
+        "plugins_by_type": plugins_by_type,
     }
 
 
@@ -322,7 +332,9 @@ def render_collection_skill(
     logger.debug("Rendering collection skill for %s", namespace)
     env = _get_template_env()
     template = env.get_template("COLLECTION_SKILL.md.j2")
-    ctx = _collection_template_context(namespace, metadata_list, collection_version)
+    ctx = _collection_template_context(
+        namespace, metadata_list, collection_version, plugins_metadata,
+    )
     return template.render(**ctx)
 
 

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -25,10 +25,12 @@ __all__ = [
     "module_to_skill_name",
     "render_collection_skill",
     "render_module_skill",
+    "render_plugin_skill",
     "render_role_skill",
     "render_skill",
     "write_collection_skill_package",
     "write_module_skill_package",
+    "write_plugin_skill_package",
     "write_role_skill_package",
     "write_skill_package",
 ]
@@ -204,6 +206,42 @@ def write_role_skill_package(output_dir: Path, metadata: dict[str, Any]) -> None
     (assets_dir / "playbook.yml").write_text(playbook_template.render(**ctx))
 
 
+# --- Plugin-level skill ---
+
+
+def _plugin_template_context(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Build template context from plugin metadata."""
+    plugin_name = metadata["plugin_name"]
+    return {
+        "plugin_name": plugin_name,
+        "plugin_type": metadata["plugin_type"],
+        "skill_name": plugin_name.rsplit(".", 1)[-1],
+        "short_description": metadata.get("short_description", ""),
+        "params": metadata.get("params", []),
+        "examples": metadata.get("examples", "").strip(),
+    }
+
+
+def render_plugin_skill(metadata: dict[str, Any]) -> str:
+    """Render the PLUGIN_SKILL.md.j2 template with plugin metadata."""
+    logger.debug("Rendering plugin skill for %s", metadata.get("plugin_name", "?"))
+    env = _get_template_env()
+    template = env.get_template("PLUGIN_SKILL.md.j2")
+    return template.render(**_plugin_template_context(metadata))
+
+
+def write_plugin_skill_package(output_dir: Path, metadata: dict[str, Any]) -> None:
+    """Write the plugin skill package: SKILL.md only (no scripts/ or assets/)."""
+    logger.debug(
+        "Writing plugin skill package to %s for %s",
+        output_dir, metadata.get("plugin_name", "?"),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    content = render_plugin_skill(metadata)
+    (output_dir / "SKILL.md").write_text(content)
+
+
 # --- Collection-level skill ---
 
 
@@ -278,6 +316,7 @@ def render_collection_skill(
     namespace: str,
     metadata_list: list[ModuleMetadata],
     collection_version: str | None = None,
+    plugins_metadata: list[dict[str, Any]] | None = None,
 ) -> str:
     """Render the COLLECTION_SKILL.md.j2 template for a collection-level skill."""
     logger.debug("Rendering collection skill for %s", namespace)
@@ -292,10 +331,13 @@ def write_collection_skill_package(
     namespace: str,
     metadata_list: list[ModuleMetadata],
     collection_version: str | None = None,
+    plugins_metadata: list[dict[str, Any]] | None = None,
 ) -> None:
     """Write the collection-level skill package: SKILL.md only (no scripts/assets)."""
     logger.debug("Writing collection skill package to %s for %s", output_dir, namespace)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    content = render_collection_skill(namespace, metadata_list, collection_version)
+    content = render_collection_skill(
+        namespace, metadata_list, collection_version, plugins_metadata,
+    )
     (output_dir / "SKILL.md").write_text(content)

--- a/src/ansible_know/templates/COLLECTION_SKILL.md.j2
+++ b/src/ansible_know/templates/COLLECTION_SKILL.md.j2
@@ -71,6 +71,24 @@ Choose modules based on what you need to manage:
 {% endfor %}
 
 {% endfor %}
+{% if plugins_by_type %}
+## Available Plugins
+
+These plugins provide data retrieval, transformation, and infrastructure integration.
+**Use plugins instead of raw modules** when a plugin exists for your use case —
+they are more concise and integrate naturally with Jinja2.
+
+{% for ptype, plugins in plugins_by_type | dictsort %}
+### {{ ptype | capitalize }} Plugins
+
+| Plugin | Purpose |
+|--------|---------|
+{% for p in plugins -%}
+| `{{ p.fqcn }}` | {{ p.short_description }} |
+{% endfor %}
+
+{% endfor %}
+{% endif %}
 ## Phase 3 — Design Block
 
 Before writing YAML, output a human-readable design for review:

--- a/src/ansible_know/templates/PLUGIN_SKILL.md.j2
+++ b/src/ansible_know/templates/PLUGIN_SKILL.md.j2
@@ -1,0 +1,194 @@
+{# src/ansible_know/templates/PLUGIN_SKILL.md.j2 #}
+---
+name: {{ plugin_name }}
+description: >-
+  {{ short_description }}
+  Use when you need the {{ skill_name | replace('_', ' ') }} {{ plugin_type }} plugin in Ansible.
+---
+
+# {{ plugin_name }} ({{ plugin_type }} plugin)
+
+{{ short_description }}
+
+## When to Use This Skill
+
+{% if plugin_type == "lookup" %}
+Use the `{{ plugin_name }}` lookup plugin to **retrieve data** from external sources during playbook execution. Lookup plugins run on the **control node** and return data that can be used in variables, templates, and task arguments.
+
+Prefer this over `ansible.builtin.uri` + `register` + JSON parsing when a dedicated lookup exists — it's more concise, handles pagination and auth, and integrates with Jinja2 naturally.
+{% elif plugin_type == "filter" %}
+Use the `{{ plugin_name }}` filter plugin to **transform data** inline within Jinja2 expressions. Filters are chainable and run on the control node during template rendering.
+{% elif plugin_type == "test" %}
+Use the `{{ plugin_name }}` test plugin in Jinja2 `{% raw %}{% if %}{% endraw %}` and `when:` conditionals. Tests return boolean values and are used with `is` syntax.
+{% elif plugin_type == "connection" %}
+Use the `{{ plugin_name }}` connection plugin to define **how Ansible connects** to managed hosts. Set it at play level or in inventory.
+{% elif plugin_type == "become" %}
+Use the `{{ plugin_name }}` become plugin to define **how Ansible escalates privileges** on managed hosts.
+{% elif plugin_type == "strategy" %}
+Use the `{{ plugin_name }}` strategy plugin to control **how Ansible executes tasks** across hosts (linear, free, etc.).
+{% elif plugin_type == "callback" %}
+Use the `{{ plugin_name }}` callback plugin to **customize output** or trigger actions on playbook events. Configure in `ansible.cfg`.
+{% elif plugin_type == "inventory" %}
+Use the `{{ plugin_name }}` inventory plugin to **dynamically discover hosts** from an external source. Configure as a YAML inventory source file.
+{% elif plugin_type == "cache" %}
+Use the `{{ plugin_name }}` cache plugin to **persist gathered facts** between playbook runs. Configure in `ansible.cfg`.
+{% else %}
+Use the `{{ plugin_name }}` {{ plugin_type }} plugin when the standard Ansible behavior needs to be extended or customized for your environment.
+{% endif %}
+
+{% if params %}
+## Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+{% for p in params -%}
+| `{{ p.name }}` | {{ p.type }} | {{ "yes" if p.required else "no" }} | {{ p.default if p.default is not none else "-" }} | {{ p.description }} |
+{% endfor %}
+{% if params | selectattr("choices") | list %}
+### Parameter Choices
+
+{% for p in params %}{% if p.choices %}
+- **{{ p.name }}**: {{ p.choices | join(", ") }}
+{% endif %}{% endfor %}
+{% endif %}
+{% endif %}
+
+## Usage
+
+{% if plugin_type == "lookup" %}
+### In a playbook task (query form — recommended)
+
+```yaml
+- name: Get data via {{ skill_name }}
+  ansible.builtin.debug:
+    msg: "{{ '{{' }} query('{{ plugin_name }}'{% if params %}, {% for p in params %}{% if p.required %}{{ p.name }}='<{{ p.name }}>'{% if not loop.last %}, {% endif %}{% endif %}{% endfor %}{% endif %}) {{ '}}' }}"
+```
+
+### In a variable definition
+
+```yaml
+vars:
+  my_data: "{{ '{{' }} lookup('{{ plugin_name }}'{% if params %}, {% for p in params %}{% if p.required %}{{ p.name }}='<{{ p.name }}>'{% if not loop.last %}, {% endif %}{% endif %}{% endfor %}{% endif %}) {{ '}}' }}"
+```
+
+### In a loop
+
+```yaml
+- name: Process each item from {{ skill_name }}
+  ansible.builtin.debug:
+    msg: "{{ '{{' }} item {{ '}}' }}"
+  loop: "{{ '{{' }} query('{{ plugin_name }}'{% if params %}, {% for p in params %}{% if p.required %}{{ p.name }}='<{{ p.name }}>'{% if not loop.last %}, {% endif %}{% endif %}{% endfor %}{% endif %}) {{ '}}' }}"
+```
+{% elif plugin_type == "filter" %}
+### Inline in Jinja2
+
+```yaml
+- name: Transform data with {{ skill_name }}
+  ansible.builtin.debug:
+    msg: "{{ '{{' }} my_data | {{ plugin_name }}({% for p in params %}{% if p.required %}<{{ p.name }}>{% if not loop.last %}, {% endif %}{% endif %}{% endfor %}) {{ '}}' }}"
+```
+{% elif plugin_type == "test" %}
+### In a when conditional
+
+```yaml
+- name: Check condition with {{ skill_name }}
+  ansible.builtin.debug:
+    msg: "Condition met"
+  when: my_value is {{ plugin_name }}({% for p in params %}{% if p.required %}<{{ p.name }}>{% if not loop.last %}, {% endif %}{% endif %}{% endfor %})
+```
+{% elif plugin_type == "connection" %}
+### In a play
+
+```yaml
+- hosts: target_hosts
+  connection: {{ plugin_name }}
+  tasks:
+    - name: Run task via {{ skill_name }}
+      ansible.builtin.command: hostname
+```
+{% elif plugin_type == "become" %}
+### In a play
+
+```yaml
+- hosts: target_hosts
+  become: true
+  become_method: {{ plugin_name }}
+  tasks:
+    - name: Run privileged task
+      ansible.builtin.command: whoami
+```
+{% elif plugin_type == "callback" %}
+### In ansible.cfg
+
+```ini
+[defaults]
+{% if "stdout" in skill_name %}
+stdout_callback = {{ plugin_name }}
+{% else %}
+callbacks_enabled = {{ plugin_name }}
+{% endif %}
+```
+
+### Via environment variable
+
+```bash
+{% if "stdout" in skill_name %}
+ANSIBLE_STDOUT_CALLBACK={{ plugin_name }} ansible-playbook playbook.yml
+{% else %}
+ANSIBLE_CALLBACKS_ENABLED={{ plugin_name }} ansible-playbook playbook.yml
+{% endif %}
+```
+{% elif plugin_type == "inventory" %}
+### Inventory source file (e.g. `my_inventory.{{ skill_name }}.yml`)
+
+```yaml
+plugin: {{ plugin_name }}
+{% for p in params %}{% if p.required %}
+{{ p.name }}: <{{ p.name }}>
+{% endif %}{% endfor %}
+```
+
+### Usage
+
+```bash
+ansible-playbook -i my_inventory.{{ skill_name }}.yml playbook.yml
+```
+{% elif plugin_type == "strategy" %}
+### In a play
+
+```yaml
+- hosts: all
+  strategy: {{ plugin_name }}
+  tasks:
+    - name: Run with {{ skill_name }} strategy
+      ansible.builtin.debug:
+        msg: "Hello"
+```
+{% elif plugin_type == "cache" %}
+### In ansible.cfg
+
+```ini
+[defaults]
+gathering = smart
+fact_caching = {{ plugin_name }}
+fact_caching_timeout = 3600
+```
+{% else %}
+Refer to Ansible documentation for configuration details for this {{ plugin_type }} plugin.
+{% endif %}
+
+{% if examples %}
+### Examples from Ansible Documentation
+
+```yaml
+{{ examples }}
+```
+{% endif %}
+
+## Safety
+
+{% if plugin_type in ("lookup", "inventory") %}
+- **Credentials**: This plugin communicates with an external service. Keep tokens and URLs out of version control — use environment variables or Ansible vault.
+{% endif %}
+- **Check mode**: Plugin behavior during `--check` depends on the specific plugin implementation
+- **FQCN**: Always use the fully qualified name `{{ plugin_name }}` to avoid ambiguity

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -53,6 +53,26 @@ class RoleMetadata(TypedDict):
     entry_points: dict[str, EntryPointInfo]
 
 
+class PluginMetadata(TypedDict):
+    """Plugin metadata extracted by parser.extract_plugin_metadata()."""
+
+    plugin_name: str
+    plugin_type: str
+    short_description: str
+    params: list[ParamDict]
+    examples: str
+
+
+class ManifestPluginEntry(TypedDict):
+    """Single plugin entry in a collection manifest."""
+
+    fqcn: str
+    plugin_type: str
+    description: str
+    param_count: int
+    has_skill: bool
+
+
 class _DocProvenanceBase(TypedDict):
     doc_source: str
     doc_version: str
@@ -148,9 +168,11 @@ class ManifestResult(TypedDict):
     generated: str
     module_count: int
     role_count: int
+    plugin_count: int
     has_collection_skill: bool
     modules: list[ManifestModuleEntry]
     roles: list[ManifestRoleEntry]
+    plugins: list[ManifestPluginEntry]
 
 
 class _CollectionInfoBase(TypedDict):
@@ -162,6 +184,7 @@ class _CollectionInfoBase(TypedDict):
     latest_version: str
     module_count: int
     role_count: int
+    plugin_count: int
     deprecated: bool
     signed: bool
 
@@ -228,6 +251,25 @@ class GetRoleDocResult(_GetRoleDocResultBase, total=False):
     error: str
 
 
+class _GetPluginDocResultBase(PluginMetadata):
+    """Required fields for get_plugin_doc tool return."""
+
+    content_type: str
+    doc_source: str
+
+
+class GetPluginDocResult(_GetPluginDocResultBase, total=False):
+    """Full result of get_plugin_doc tool.
+
+    Extends PluginMetadata with provenance. When doc_source is 'galaxy',
+    includes doc_version and optionally doc_warning/doc_source_server.
+    """
+
+    doc_version: str
+    doc_warning: str
+    doc_source_server: str
+
+
 class SearchDocsEntry(TypedDict):
     """Single entry from search_docs results."""
 
@@ -279,6 +321,10 @@ class GalaxyDocClient(Protocol):
 
     async def fetch_role_doc(
         self, role_name: str,
+    ) -> tuple[dict[str, Any], DocProvenance]: ...
+
+    async def fetch_plugin_doc(
+        self, plugin_name: str, plugin_type: str,
     ) -> tuple[dict[str, Any], DocProvenance]: ...
 
     async def search_collections(

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -136,6 +136,7 @@ class CollectionSkillContext(TypedDict):
     all_api: bool
     common_params: list[ParamDict]
     module_count: int
+    plugins_by_type: dict[str, list[dict[str, str]]]
 
 
 class ManifestModuleEntry(TypedDict):

--- a/src/ansible_know/validation.py
+++ b/src/ansible_know/validation.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 from ansible_know.errors import ValidationError
 
 __all__ = [
+    "extract_namespace",
     "sanitize_error",
     "truncate_response",
     "validate_doc_url",
@@ -69,6 +70,8 @@ def validate_namespace(ns: str) -> None:
 
 
 def validate_keyword(keyword: str) -> None:
+    if not keyword or not keyword.strip():
+        raise ValidationError("Keyword must not be empty.")
     if len(keyword) > MAX_KEYWORD_LENGTH:
         raise ValidationError(
             f"Keyword too long: {len(keyword)} chars (max {MAX_KEYWORD_LENGTH})."
@@ -117,6 +120,15 @@ def validate_path_containment(child: Path, parent: Path) -> None:
         child.resolve().relative_to(parent.resolve())
     except ValueError as exc:
         raise ValidationError("Path escapes the allowed directory.") from exc
+
+
+def extract_namespace(fqcn: str) -> str | None:
+    """Extract the collection namespace from a fully-qualified name.
+
+    Returns 'namespace.collection' from 'namespace.collection.name',
+    or None if the name has no dots.
+    """
+    return ".".join(fqcn.split(".")[:2]) if "." in fqcn else None
 
 
 def sanitize_error(msg: str) -> str:

--- a/src/ansible_know/validation.py
+++ b/src/ansible_know/validation.py
@@ -17,6 +17,7 @@ __all__ = [
     "validate_keyword",
     "validate_namespace",
     "validate_path_containment",
+    "validate_plugin_type",
     "validate_query",
     "validate_skill_name",
     "validate_tags",
@@ -126,6 +127,17 @@ def truncate_response(text: str) -> str:
     if len(text) > MAX_RESPONSE_SIZE:
         return text[:MAX_RESPONSE_SIZE] + "\n\n[Truncated — response exceeded size limit]"
     return text
+
+
+def validate_plugin_type(plugin_type: str) -> None:
+    """Raise ValidationError if plugin_type is not a recognized ansible-doc type."""
+    from ansible_know.config import PLUGIN_TYPES
+
+    if plugin_type not in PLUGIN_TYPES:
+        raise ValidationError(
+            f"Invalid plugin type '{plugin_type}'. "
+            f"Valid types: {', '.join(sorted(PLUGIN_TYPES))}"
+        )
 
 
 def validate_doc_url(url: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,6 +216,48 @@ SAMPLE_ROLE_README_HTML_CODEBLOCK_VARS = """
 <p>State for Docker packages.</p>
 """
 
+SAMPLE_PLUGIN_DOC = {
+    "netbox.netbox.nb_lookup": {
+        "doc": {
+            "name": "nb_lookup",
+            "short_description": "Queries and returns elements from NetBox",
+            "description": [
+                "Queries NetBox via its API to return virtually any information",
+                "capable of being stored in NetBox.",
+            ],
+            "options": {
+                "api_endpoint": {
+                    "description": ["The URL to the NetBox instance"],
+                    "type": "str",
+                    "required": True,
+                },
+                "token": {
+                    "description": ["The API token for NetBox"],
+                    "type": "str",
+                    "required": True,
+                },
+                "api_filter": {
+                    "description": ["The api_filter to use"],
+                    "type": "str",
+                    "required": False,
+                },
+            },
+        },
+        "examples": (
+            "- name: Obtain list of sites from NetBox\n"
+            "  debug:\n"
+            "    msg: \"{{ query('netbox.netbox.nb_lookup', 'sites', api_endpoint='http://localhost', token='mytoken') }}\"\n"
+        ),
+    },
+}
+
+SAMPLE_PLUGIN_LIST = {
+    "netbox.netbox.nb_lookup": "Queries and returns elements from NetBox",
+    "ansible.builtin.env": "Read the value of environment variables",
+    "ansible.builtin.file": "Return file contents",
+    "community.general.bitwarden": "Retrieve secrets from Bitwarden",
+}
+
 SAMPLE_DOCS_BLOB_WITH_ROLES = {
     "docs_blob": {
         "contents": [
@@ -310,3 +352,23 @@ def sample_role_readme_html():
 @pytest.fixture
 def sample_docs_blob_with_roles():
     return SAMPLE_DOCS_BLOB_WITH_ROLES
+
+
+@pytest.fixture
+def sample_plugin_doc():
+    return SAMPLE_PLUGIN_DOC
+
+
+@pytest.fixture
+def sample_plugin_doc_json():
+    return json.dumps(SAMPLE_PLUGIN_DOC)
+
+
+@pytest.fixture
+def sample_plugin_list():
+    return SAMPLE_PLUGIN_LIST
+
+
+@pytest.fixture
+def sample_plugin_list_json():
+    return json.dumps(SAMPLE_PLUGIN_LIST)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,7 +246,8 @@ SAMPLE_PLUGIN_DOC = {
         "examples": (
             "- name: Obtain list of sites from NetBox\n"
             "  debug:\n"
-            "    msg: \"{{ query('netbox.netbox.nb_lookup', 'sites', api_endpoint='http://localhost', token='mytoken') }}\"\n"
+            "    msg: \"{{ query('netbox.netbox.nb_lookup', 'sites', "
+            "api_endpoint='http://localhost', token='mytoken') }}\"\n"
         ),
     },
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -293,6 +293,76 @@ SAMPLE_DOCS_BLOB_WITH_ROLES = {
     },
 }
 
+SAMPLE_DOCS_BLOB_WITH_PLUGINS = {
+    "docs_blob": {
+        "contents": [
+            {
+                "content_type": "module",
+                "content_name": "netbox_device",
+                "doc_strings": {
+                    "doc": {
+                        "short_description": "Create, update or delete devices",
+                        "options": [],
+                    },
+                    "examples": "",
+                    "return": [],
+                    "metadata": {},
+                },
+            },
+            {
+                "content_type": "lookup",
+                "content_name": "nb_lookup",
+                "doc_strings": {
+                    "doc": {
+                        "short_description": "Queries and returns elements from NetBox",
+                        "description": ["Queries NetBox via its API."],
+                        "options": [
+                            {"name": "api_endpoint", "type": "str", "required": True,
+                             "description": ["The URL to the NetBox instance"]},
+                            {"name": "token", "type": "str", "required": True,
+                             "description": ["The API token"]},
+                        ],
+                    },
+                    "examples": "- debug: msg=\"{{ query('netbox.netbox.nb_lookup', 'sites') }}\"",
+                    "return": [],
+                    "metadata": {},
+                },
+            },
+            {
+                "content_type": "filter",
+                "content_name": "nb_filter",
+                "doc_strings": {
+                    "doc": {
+                        "short_description": "Filter NetBox data",
+                        "description": ["Filters NetBox query results."],
+                        "options": [],
+                    },
+                    "examples": "",
+                    "return": [],
+                    "metadata": {},
+                },
+            },
+            {
+                "content_type": "inventory",
+                "content_name": "nb_inventory",
+                "doc_strings": {
+                    "doc": {
+                        "short_description": "NetBox inventory source",
+                        "description": ["Dynamic inventory from NetBox."],
+                        "options": [
+                            {"name": "api_endpoint", "type": "str", "required": True,
+                             "description": ["The URL to the NetBox instance"]},
+                        ],
+                    },
+                    "examples": "",
+                    "return": [],
+                    "metadata": {},
+                },
+            },
+        ],
+    },
+}
+
 
 @pytest.fixture
 def sample_module_doc():
@@ -372,3 +442,8 @@ def sample_plugin_list():
 @pytest.fixture
 def sample_plugin_list_json():
     return json.dumps(SAMPLE_PLUGIN_LIST)
+
+
+@pytest.fixture
+def sample_docs_blob_with_plugins():
+    return SAMPLE_DOCS_BLOB_WITH_PLUGINS

--- a/tests/test_collection_manifest.py
+++ b/tests/test_collection_manifest.py
@@ -183,3 +183,54 @@ class TestLoadCachedManifest:
         cached = load_cached_manifest("ansible.builtin", skills_dir=tmp_path)
         assert cached is not None
         assert cached["collection"] == "ansible.builtin"
+
+
+class TestManifestPluginEntries:
+    def test_includes_plugins_in_manifest(self, tmp_path):
+        plugins_metadata = [
+            {
+                "fqcn": "netbox.netbox.nb_lookup",
+                "plugin_type": "lookup",
+                "description": "Queries NetBox",
+                "param_count": 3,
+            },
+            {
+                "fqcn": "netbox.netbox.nb_inventory",
+                "plugin_type": "inventory",
+                "description": "NetBox dynamic inventory",
+                "param_count": 5,
+            },
+        ]
+        manifest = generate_manifest(
+            "netbox.netbox", [], plugins_metadata=plugins_metadata,
+            skills_dir=tmp_path,
+        )
+        assert manifest["plugin_count"] == 2
+        assert len(manifest["plugins"]) == 2
+        lookup = next(p for p in manifest["plugins"] if p["fqcn"] == "netbox.netbox.nb_lookup")
+        assert lookup["plugin_type"] == "lookup"
+        assert lookup["has_skill"] is False
+
+    def test_empty_plugins_defaults(self, tmp_path):
+        manifest = generate_manifest("test.test", [], skills_dir=tmp_path)
+        assert manifest["plugin_count"] == 0
+        assert manifest["plugins"] == []
+
+    def test_plugin_skill_detection(self, tmp_path):
+        skill_dir = tmp_path / "netbox.netbox" / "lookup__nb_lookup"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: test\n---\n")
+
+        plugins_metadata = [
+            {
+                "fqcn": "netbox.netbox.nb_lookup",
+                "plugin_type": "lookup",
+                "description": "Queries NetBox",
+                "param_count": 3,
+            },
+        ]
+        manifest = generate_manifest(
+            "netbox.netbox", [], plugins_metadata=plugins_metadata,
+            skills_dir=tmp_path,
+        )
+        assert manifest["plugins"][0]["has_skill"] is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -84,3 +84,47 @@ class TestDocCurationConfig:
         for name, cfg in DEFAULT_DOC_SOURCES.items():
             assert "file" in cfg, f"Source '{name}' missing 'file' key"
             assert "description" in cfg
+
+
+class TestPluginTypeConstants:
+    def test_plugin_types_contains_lookup(self):
+        from ansible_know.config import PLUGIN_TYPES
+
+        assert "lookup" in PLUGIN_TYPES
+
+    def test_plugin_types_contains_filter(self):
+        from ansible_know.config import PLUGIN_TYPES
+
+        assert "filter" in PLUGIN_TYPES
+
+    def test_plugin_types_excludes_module_and_role(self):
+        from ansible_know.config import PLUGIN_TYPES
+
+        assert "module" not in PLUGIN_TYPES
+        assert "role" not in PLUGIN_TYPES
+
+    def test_plugin_types_has_14_entries(self):
+        from ansible_know.config import PLUGIN_TYPES
+
+        assert len(PLUGIN_TYPES) == 14
+
+    def test_jinja2_types(self):
+        from ansible_know.config import JINJA2_PLUGIN_TYPES
+
+        assert set(JINJA2_PLUGIN_TYPES) == {"lookup", "filter", "test"}
+
+    def test_playbook_types(self):
+        from ansible_know.config import PLAYBOOK_PLUGIN_TYPES
+
+        assert set(PLAYBOOK_PLUGIN_TYPES) == {"connection", "become", "strategy", "callback", "inventory"}
+
+    def test_infra_types(self):
+        from ansible_know.config import INFRA_PLUGIN_TYPES
+
+        assert set(INFRA_PLUGIN_TYPES) == {"cache", "cliconf", "httpapi", "netconf", "shell", "vars"}
+
+    def test_categories_cover_all_types(self):
+        from ansible_know.config import INFRA_PLUGIN_TYPES, JINJA2_PLUGIN_TYPES, PLAYBOOK_PLUGIN_TYPES, PLUGIN_TYPES
+
+        combined = set(JINJA2_PLUGIN_TYPES) | set(PLAYBOOK_PLUGIN_TYPES) | set(INFRA_PLUGIN_TYPES)
+        assert combined == set(PLUGIN_TYPES)

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -1345,3 +1345,76 @@ class TestGalaxyClientAuth:
         assert gc._token == "tok123"
         assert gc._verify is False
         assert gc.server_name == "test_hub"
+
+
+class TestFindPlugin:
+    def test_finds_lookup_plugin(self, sample_docs_blob_with_plugins):
+        blob = sample_docs_blob_with_plugins["docs_blob"]
+        result = GalaxyClient._find_plugin(blob, "nb_lookup", "lookup")
+        assert result is not None
+        assert result["content_name"] == "nb_lookup"
+
+    def test_finds_filter_plugin(self, sample_docs_blob_with_plugins):
+        blob = sample_docs_blob_with_plugins["docs_blob"]
+        result = GalaxyClient._find_plugin(blob, "nb_filter", "filter")
+        assert result is not None
+
+    def test_returns_none_for_missing(self, sample_docs_blob_with_plugins):
+        blob = sample_docs_blob_with_plugins["docs_blob"]
+        result = GalaxyClient._find_plugin(blob, "nonexistent", "lookup")
+        assert result is None
+
+    def test_does_not_match_module_as_plugin(self, sample_docs_blob_with_plugins):
+        blob = sample_docs_blob_with_plugins["docs_blob"]
+        result = GalaxyClient._find_plugin(blob, "netbox_device", "lookup")
+        assert result is None
+
+
+class TestFetchPluginDoc:
+    @pytest.mark.asyncio
+    async def test_fetches_lookup_doc(self, sample_docs_blob_with_plugins):
+        client = GalaxyClient(base_url="https://galaxy.example.com")
+        with patch.object(client, "latest_version", return_value="1.0.0"):
+            with patch.object(client, "_fetch_docs_blob",
+                              return_value=sample_docs_blob_with_plugins["docs_blob"]):
+                doc, meta = await client.fetch_plugin_doc(
+                    "netbox.netbox.nb_lookup", "lookup",
+                )
+        assert "netbox.netbox.nb_lookup" in doc
+        assert meta["doc_source"] == "galaxy"
+
+    @pytest.mark.asyncio
+    async def test_raises_on_missing_plugin(self, sample_docs_blob_with_plugins):
+        client = GalaxyClient(base_url="https://galaxy.example.com")
+        with patch.object(client, "latest_version", return_value="1.0.0"):
+            with patch.object(client, "_fetch_docs_blob",
+                              return_value=sample_docs_blob_with_plugins["docs_blob"]):
+                with pytest.raises(GalaxyError, match="not found"):
+                    await client.fetch_plugin_doc(
+                        "netbox.netbox.nonexistent", "lookup",
+                    )
+
+
+class TestListCollectionPlugins:
+    @pytest.mark.asyncio
+    async def test_lists_plugins(self, sample_docs_blob_with_plugins):
+        client = GalaxyClient(base_url="https://galaxy.example.com")
+        with patch.object(client, "latest_version", return_value="1.0.0"):
+            with patch.object(client, "_fetch_docs_blob",
+                              return_value=sample_docs_blob_with_plugins["docs_blob"]):
+                plugins, meta = await client.list_collection_plugins("netbox.netbox")
+        assert "netbox.netbox.nb_lookup" in plugins
+        assert plugins["netbox.netbox.nb_lookup"]["plugin_type"] == "lookup"
+        assert "netbox.netbox.nb_filter" in plugins
+        assert "netbox.netbox.nb_inventory" in plugins
+        assert len(plugins) == 3
+
+    @pytest.mark.asyncio
+    async def test_excludes_modules_and_roles(self, sample_docs_blob_with_plugins):
+        client = GalaxyClient(base_url="https://galaxy.example.com")
+        with patch.object(client, "latest_version", return_value="1.0.0"):
+            with patch.object(client, "_fetch_docs_blob",
+                              return_value=sample_docs_blob_with_plugins["docs_blob"]):
+                plugins, _ = await client.list_collection_plugins("netbox.netbox")
+        fqcns = list(plugins.keys())
+        assert not any("netbox_device" in f for f in fqcns)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,19 +4,23 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ansible_know.errors import AnsibleDocError, CollectionNotFoundError
+from ansible_know.errors import AnsibleDocError, CollectionNotFoundError, ValidationError
 from ansible_know.parser import (
     extract_examples,
     extract_module_metadata,
     extract_params,
+    extract_plugin_metadata,
     extract_role_metadata,
     extract_short_description,
     get_module_doc,
+    get_plugin_doc,
     get_role_doc,
     is_api_module,
     list_modules,
+    list_plugins,
     list_roles,
     search_modules,
+    search_plugins,
     transform_galaxy_to_ansible_doc_format,
 )
 
@@ -377,3 +381,81 @@ class TestTransformGalaxyToAnsibleDocFormat:
         }
         result = transform_galaxy_to_ansible_doc_format("ns.col.mod", entry)
         assert result["ns.col.mod"]["doc"]["options"] == {}
+
+
+class TestListPlugins:
+    def test_returns_plugin_dict(self, sample_plugin_list_json):
+        with patch("ansible_know.parser._run_ansible_doc", return_value=sample_plugin_list_json) as mock:
+            result = list_plugins("lookup")
+        assert "netbox.netbox.nb_lookup" in result
+        mock.assert_called_once_with("--list", "-t", "lookup", "--json", collections_path=None)
+
+    def test_passes_collection_filter(self, sample_plugin_list_json):
+        with patch("ansible_know.parser._run_ansible_doc", return_value=sample_plugin_list_json) as mock:
+            list_plugins("lookup", collection_filter="netbox.netbox")
+        mock.assert_called_once_with(
+            "--list", "-t", "lookup", "--json", "netbox.netbox",
+            collections_path=None,
+        )
+
+    def test_rejects_invalid_plugin_type(self):
+        with pytest.raises(ValidationError, match="Invalid plugin type"):
+            list_plugins("bogus")
+
+
+class TestGetPluginDoc:
+    def test_returns_parsed_json(self, sample_plugin_doc, sample_plugin_doc_json):
+        with patch("ansible_know.parser._run_ansible_doc", return_value=sample_plugin_doc_json):
+            result = get_plugin_doc("netbox.netbox.nb_lookup", "lookup")
+        assert result == sample_plugin_doc
+
+    def test_passes_type_flag(self, sample_plugin_doc_json):
+        with patch("ansible_know.parser._run_ansible_doc", return_value=sample_plugin_doc_json) as mock:
+            get_plugin_doc("netbox.netbox.nb_lookup", "lookup")
+        mock.assert_called_once_with(
+            "-t", "lookup", "netbox.netbox.nb_lookup", "--json",
+            collections_path=None,
+        )
+
+    def test_rejects_invalid_plugin_type(self):
+        with pytest.raises(ValidationError, match="Invalid plugin type"):
+            get_plugin_doc("foo.bar.baz", "bogus")
+
+
+class TestSearchPlugins:
+    def test_filters_by_keyword(self, sample_plugin_list_json):
+        with patch("ansible_know.parser._run_ansible_doc", return_value=sample_plugin_list_json):
+            result = search_plugins("netbox", plugin_type="lookup")
+        assert "netbox.netbox.nb_lookup" in result
+        assert len(result) == 1
+
+    def test_search_all_types(self, sample_plugin_list_json):
+        with patch("ansible_know.parser._run_ansible_doc", return_value=sample_plugin_list_json):
+            result = search_plugins("env")
+        assert "ansible.builtin.env" in result
+
+    def test_case_insensitive(self, sample_plugin_list_json):
+        with patch("ansible_know.parser._run_ansible_doc", return_value=sample_plugin_list_json):
+            result = search_plugins("NETBOX", plugin_type="lookup")
+        assert "netbox.netbox.nb_lookup" in result
+
+
+class TestExtractPluginMetadata:
+    def test_extracts_name_and_type(self, sample_plugin_doc):
+        meta = extract_plugin_metadata(sample_plugin_doc, "lookup")
+        assert meta["plugin_name"] == "netbox.netbox.nb_lookup"
+        assert meta["plugin_type"] == "lookup"
+
+    def test_extracts_short_description(self, sample_plugin_doc):
+        meta = extract_plugin_metadata(sample_plugin_doc, "lookup")
+        assert meta["short_description"] == "Queries and returns elements from NetBox"
+
+    def test_extracts_params(self, sample_plugin_doc):
+        meta = extract_plugin_metadata(sample_plugin_doc, "lookup")
+        names = [p["name"] for p in meta["params"]]
+        assert "api_endpoint" in names
+        assert "token" in names
+
+    def test_extracts_examples(self, sample_plugin_doc):
+        meta = extract_plugin_metadata(sample_plugin_doc, "lookup")
+        assert "nb_lookup" in meta["examples"]

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -1,11 +1,13 @@
 """Tests for ansible_know.resolution module."""
 
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from ansible_know.errors import CollectionNotFoundError
 from ansible_know.galaxy import GalaxyClient
+from ansible_know.resolution import resolve_plugin_doc
 from tests.conftest import SAMPLE_MODULE_DOC, SAMPLE_ROLE_DOC
 
 FACTORY = GalaxyClient.from_config
@@ -357,3 +359,75 @@ class TestSearchGalaxyCollections:
                 await search_galaxy_collections(
                     "net", galaxy_servers=[server], client_factory=FACTORY,
                 )
+
+
+class TestResolvePluginDoc:
+    @pytest.mark.asyncio
+    async def test_returns_local_doc(self):
+        mock_doc = {
+            "netbox.netbox.nb_lookup": {
+                "doc": {
+                    "short_description": "Queries NetBox",
+                    "options": {},
+                },
+                "examples": "",
+            },
+        }
+        with patch("ansible_know.parser.get_plugin_doc", return_value=mock_doc):
+            with patch("ansible_know.parser.extract_plugin_metadata", return_value={
+                "plugin_name": "netbox.netbox.nb_lookup",
+                "plugin_type": "lookup",
+                "short_description": "Queries NetBox",
+                "params": [],
+                "examples": "",
+            }):
+                result = await resolve_plugin_doc("netbox.netbox.nb_lookup", "lookup")
+        assert result["doc_source"] == "local"
+        assert result["plugin_type"] == "lookup"
+        assert result["plugin_name"] == "netbox.netbox.nb_lookup"
+        assert result["content_type"] == "plugin"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_galaxy(self):
+        galaxy_doc = {
+            "netbox.netbox.nb_lookup": {
+                "doc": {"short_description": "Queries NetBox", "options": {}},
+                "examples": "",
+            },
+        }
+        galaxy_meta = {"doc_source": "galaxy", "doc_version": "1.0.0"}
+
+        mock_client = AsyncMock()
+        mock_client.fetch_plugin_doc = AsyncMock(return_value=(galaxy_doc, galaxy_meta))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        def factory(config, http_client=None):
+            return mock_client
+
+        with patch("ansible_know.parser.get_plugin_doc", side_effect=CollectionNotFoundError("not found")):
+            with patch("ansible_know.parser.extract_plugin_metadata", return_value={
+                "plugin_name": "netbox.netbox.nb_lookup",
+                "plugin_type": "lookup",
+                "short_description": "Queries NetBox",
+                "params": [],
+                "examples": "",
+            }):
+                from ansible_know.galaxy_config import GalaxyServerConfig
+                servers = [GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")]
+                result = await resolve_plugin_doc(
+                    "netbox.netbox.nb_lookup", "lookup",
+                    galaxy_servers=servers,
+                    client_factory=factory,
+                )
+        assert result["doc_source"] == "galaxy"
+        assert result["content_type"] == "plugin"
+
+    @pytest.mark.asyncio
+    async def test_unavailable_when_no_client(self):
+        with patch("ansible_know.parser.get_plugin_doc", side_effect=CollectionNotFoundError("not found")):
+            result = await resolve_plugin_doc("netbox.netbox.nb_lookup", "lookup")
+        assert result["doc_source"] == "unavailable"
+        assert result["content_type"] == "plugin"
+        assert result["plugin_type"] == "lookup"
+        assert "params" in result

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -7,7 +7,7 @@ import pytest
 
 from ansible_know.errors import CollectionNotFoundError
 from ansible_know.galaxy import GalaxyClient
-from ansible_know.resolution import resolve_plugin_doc
+from ansible_know.resolution import discover_collection_plugins, resolve_plugin_doc
 from tests.conftest import SAMPLE_MODULE_DOC, SAMPLE_ROLE_DOC
 
 FACTORY = GalaxyClient.from_config
@@ -359,6 +359,49 @@ class TestSearchGalaxyCollections:
                 await search_galaxy_collections(
                     "net", galaxy_servers=[server], client_factory=FACTORY,
                 )
+
+
+class TestDiscoverCollectionPlugins:
+    @pytest.mark.asyncio
+    async def test_returns_results_for_each_type(self):
+        with patch("ansible_know.parser.list_plugins", return_value={}):
+            results = await discover_collection_plugins("netbox.netbox")
+        from ansible_know.config import PLUGIN_TYPES
+        assert len(results) == len(PLUGIN_TYPES)
+        assert all(isinstance(r, tuple) and len(r) == 2 for r in results)
+
+    @pytest.mark.asyncio
+    async def test_collects_discovered_plugins(self):
+        def fake_list(ptype, collection_filter=None, collections_path=None):
+            if ptype == "lookup":
+                return {"netbox.netbox.nb_lookup": "Query NetBox"}
+            return {}
+
+        with patch("ansible_know.parser.list_plugins", side_effect=fake_list):
+            results = await discover_collection_plugins("netbox.netbox")
+
+        lookup_results = [r for r in results if r[0] == "lookup"]
+        assert len(lookup_results) == 1
+        assert "netbox.netbox.nb_lookup" in lookup_results[0][1]
+
+    @pytest.mark.asyncio
+    async def test_handles_failures_gracefully(self):
+        from ansible_know.errors import AnsibleDocError
+
+        def failing_list(ptype, collection_filter=None, collections_path=None):
+            if ptype == "lookup":
+                return {"netbox.netbox.nb_lookup": "Query NetBox"}
+            raise AnsibleDocError("not supported")
+
+        with patch("ansible_know.parser.list_plugins", side_effect=failing_list):
+            results = await discover_collection_plugins("netbox.netbox")
+
+        from ansible_know.config import PLUGIN_TYPES
+        assert len(results) == len(PLUGIN_TYPES)
+        lookup_results = [r for r in results if r[0] == "lookup"]
+        assert lookup_results[0][1] == {"netbox.netbox.nb_lookup": "Query NetBox"}
+        failed_results = [r for r in results if r[0] != "lookup"]
+        assert all(plugins == {} for _, plugins in failed_results)
 
 
 class TestResolvePluginDoc:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1767,12 +1767,10 @@ class TestSearchPlugins:
         assert "error" in result
 
     @pytest.mark.asyncio
-    async def test_empty_keyword_returns_all(self):
-        mock_results = {"ansible.builtin.env": "Read env vars"}
-        with patch("ansible_know.parser.search_plugins", return_value=mock_results):
-            from ansible_know.server import search_plugins
-            result = await search_plugins("", plugin_type="lookup")
-        assert "ansible.builtin.env" in result
+    async def test_empty_keyword_rejected(self):
+        from ansible_know.server import search_plugins
+        result = await search_plugins("", plugin_type="lookup")
+        assert "error" in result
 
 
 class TestGetPluginDoc:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -216,13 +216,17 @@ class TestGenerateSkillTool:
 class TestGenerateCollectionSkillsTool:
     @pytest.mark.asyncio
     async def test_generates_collection_skills(self, tmp_path, mock_ansible_doc, monkeypatch):
-        mock_ansible_doc.side_effect = [
-            json.dumps(SAMPLE_MODULE_LIST),
-            json.dumps(SAMPLE_MODULE_DOC),
-            json.dumps(SAMPLE_MODULE_DOC),
-            json.dumps(SAMPLE_MODULE_DOC),
-            json.dumps(SAMPLE_MODULE_DOC),
+        # Module list, role list (empty), 14x plugin list (empty), then 4x module docs
+        responses = [
+            json.dumps(SAMPLE_MODULE_LIST),  # search_modules
+            json.dumps({}),  # list_roles
         ]
+        # 14 plugin types all return empty
+        responses.extend([json.dumps({})] * 14)
+        # 4 module doc fetches
+        responses.extend([json.dumps(SAMPLE_MODULE_DOC)] * 4)
+
+        mock_ansible_doc.side_effect = responses
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
         from ansible_know.server import generate_collection_skills
         result = await generate_collection_skills("ansible.builtin", install_to=str(tmp_path))
@@ -1743,3 +1747,134 @@ class TestClearCache:
 
         assert "error" in result
         assert "Invalid scope" in result["error"]
+
+
+class TestSearchPlugins:
+    @pytest.mark.asyncio
+    async def test_returns_matching_plugins(self):
+        mock_results = {
+            "netbox.netbox.nb_lookup": "Queries and returns elements from NetBox",
+        }
+        with patch("ansible_know.parser.search_plugins", return_value=mock_results):
+            from ansible_know.server import search_plugins
+            result = await search_plugins("netbox", plugin_type="lookup")
+        assert "netbox.netbox.nb_lookup" in result
+
+    @pytest.mark.asyncio
+    async def test_validates_plugin_type(self):
+        from ansible_know.server import search_plugins
+        result = await search_plugins("test", plugin_type="bogus_type")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_keyword_returns_all(self):
+        mock_results = {"ansible.builtin.env": "Read env vars"}
+        with patch("ansible_know.parser.search_plugins", return_value=mock_results):
+            from ansible_know.server import search_plugins
+            result = await search_plugins("", plugin_type="lookup")
+        assert "ansible.builtin.env" in result
+
+
+class TestGetPluginDoc:
+    @pytest.mark.asyncio
+    async def test_returns_plugin_metadata(self):
+        mock_result = {
+            "plugin_name": "netbox.netbox.nb_lookup",
+            "plugin_type": "lookup",
+            "short_description": "Queries NetBox",
+            "params": [],
+            "examples": "",
+            "doc_source": "local",
+            "content_type": "plugin",
+        }
+        with patch("ansible_know.resolution.resolve_plugin_doc", return_value=mock_result):
+            from ansible_know.server import get_plugin_doc
+            result = await get_plugin_doc("netbox.netbox.nb_lookup", "lookup")
+        assert result["plugin_name"] == "netbox.netbox.nb_lookup"
+        assert result["plugin_type"] == "lookup"
+
+    @pytest.mark.asyncio
+    async def test_validates_fqcn(self):
+        from ansible_know.server import get_plugin_doc
+        result = await get_plugin_doc("invalid", "lookup")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_validates_plugin_type(self):
+        from ansible_know.server import get_plugin_doc
+        result = await get_plugin_doc("ns.col.name", "bogus")
+        assert "error" in result
+
+
+class TestGeneratePluginSkill:
+    @pytest.mark.asyncio
+    async def test_returns_skill_content(self, tmp_path):
+        mock_result = {
+            "plugin_name": "netbox.netbox.nb_lookup",
+            "plugin_type": "lookup",
+            "short_description": "Queries NetBox",
+            "params": [],
+            "examples": "",
+            "doc_source": "local",
+            "content_type": "plugin",
+        }
+        with patch("ansible_know.resolution.resolve_plugin_doc", return_value=mock_result):
+            with patch("ansible_know.skills.write_plugin_skill_package"):
+                from ansible_know.server import generate_plugin_skill
+                result = await generate_plugin_skill(
+                    "netbox.netbox.nb_lookup", "lookup",
+                )
+        assert isinstance(result, str)
+        assert "nb_lookup" in result
+
+
+class TestGetPluginSkill:
+    @pytest.mark.asyncio
+    async def test_finds_plugin_skill_by_fqcn(self, tmp_path):
+        skill_dir = tmp_path / "netbox.netbox" / "lookup__nb_lookup"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: netbox.netbox.nb_lookup\n---\nlookup skill")
+        with patch("ansible_know.config.SKILLS_DIR", tmp_path):
+            from ansible_know.server import get_skill
+            result = await get_skill("netbox.netbox.nb_lookup")
+        assert "lookup skill" in result
+
+    @pytest.mark.asyncio
+    async def test_module_skill_takes_precedence(self, tmp_path):
+        # If both a module and plugin skill exist, module (direct name) wins
+        mod_dir = tmp_path / "netbox.netbox" / "nb_lookup"
+        mod_dir.mkdir(parents=True)
+        (mod_dir / "SKILL.md").write_text("module skill")
+        plugin_dir = tmp_path / "netbox.netbox" / "lookup__nb_lookup"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "SKILL.md").write_text("plugin skill")
+        with patch("ansible_know.config.SKILLS_DIR", tmp_path):
+            from ansible_know.server import get_skill
+            result = await get_skill("netbox.netbox.nb_lookup")
+        assert "module skill" in result
+
+
+class TestListPluginSkills:
+    @pytest.mark.asyncio
+    async def test_strips_type_prefix_from_name(self, tmp_path):
+        skill_dir = tmp_path / "netbox.netbox" / "lookup__nb_lookup"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: test\n---\n")
+        with patch("ansible_know.config.SKILLS_DIR", tmp_path):
+            from ansible_know.server import list_skills
+            result = await list_skills(collection="netbox.netbox")
+        names = [s["name"] for s in result]
+        assert "netbox.netbox.nb_lookup" in names
+        assert "netbox.netbox.lookup__nb_lookup" not in names
+
+
+class TestResourceSkillsListPlugins:
+    def test_strips_type_prefix_in_resource(self, tmp_path):
+        skill_dir = tmp_path / "netbox.netbox" / "lookup__nb_lookup"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: test\n---\n")
+        with patch("ansible_know.config.SKILLS_DIR", tmp_path):
+            from ansible_know.server import resource_skills_list
+            result = json.loads(resource_skills_list())
+        assert "netbox.netbox.nb_lookup" in result
+        assert "netbox.netbox.lookup__nb_lookup" not in result

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -11,10 +11,12 @@ from ansible_know.skills import (
     module_to_skill_name,
     render_collection_skill,
     render_module_skill,
+    render_plugin_skill,
     render_role_skill,
     render_skill,
     write_collection_skill_package,
     write_module_skill_package,
+    write_plugin_skill_package,
     write_role_skill_package,
     write_skill_package,
 )
@@ -385,3 +387,98 @@ class TestWriteCollectionSkillPackage:
         content = (output_dir / "SKILL.md").read_text()
         assert "netbox.netbox" in content
         assert "Playbook Guide" in content
+
+
+class TestRenderPluginSkill:
+    def test_renders_lookup_skill(self):
+        metadata = {
+            "plugin_name": "netbox.netbox.nb_lookup",
+            "plugin_type": "lookup",
+            "short_description": "Queries and returns elements from NetBox",
+            "params": [
+                {"name": "api_endpoint", "type": "str", "required": True,
+                 "default": None, "choices": None, "description": "NetBox URL", "aliases": []},
+                {"name": "token", "type": "str", "required": True,
+                 "default": None, "choices": None, "description": "API token", "aliases": []},
+            ],
+            "examples": "- debug: msg=\"{{ query('netbox.netbox.nb_lookup', 'sites') }}\"",
+        }
+        result = render_plugin_skill(metadata)
+        assert "lookup plugin" in result
+        assert "query('netbox.netbox.nb_lookup'" in result
+        assert "lookup('netbox.netbox.nb_lookup'" in result
+        assert "ansible.builtin.uri" in result  # the "prefer this over uri" guidance
+
+    def test_renders_filter_skill(self):
+        metadata = {
+            "plugin_name": "ansible.builtin.to_yaml",
+            "plugin_type": "filter",
+            "short_description": "Convert to YAML",
+            "params": [],
+            "examples": "",
+        }
+        result = render_plugin_skill(metadata)
+        assert "filter plugin" in result
+        assert "ansible.builtin.to_yaml" in result
+
+    def test_renders_inventory_skill(self):
+        metadata = {
+            "plugin_name": "netbox.netbox.nb_inventory",
+            "plugin_type": "inventory",
+            "short_description": "NetBox inventory source",
+            "params": [
+                {"name": "api_endpoint", "type": "str", "required": True,
+                 "default": None, "choices": None, "description": "NetBox URL", "aliases": []},
+            ],
+            "examples": "",
+        }
+        result = render_plugin_skill(metadata)
+        assert "inventory plugin" in result
+        assert "plugin: netbox.netbox.nb_inventory" in result
+
+    def test_renders_connection_skill(self):
+        metadata = {
+            "plugin_name": "ansible.netcommon.network_cli",
+            "plugin_type": "connection",
+            "short_description": "CLI connection to network devices",
+            "params": [],
+            "examples": "",
+        }
+        result = render_plugin_skill(metadata)
+        assert "connection plugin" in result
+        assert "connection: ansible.netcommon.network_cli" in result
+
+
+class TestWritePluginSkillPackage:
+    def test_writes_skill_md(self, tmp_path):
+        metadata = {
+            "plugin_name": "netbox.netbox.nb_lookup",
+            "plugin_type": "lookup",
+            "short_description": "Queries NetBox",
+            "params": [],
+            "examples": "",
+        }
+        write_plugin_skill_package(tmp_path / "lookup__nb_lookup", metadata)
+        assert (tmp_path / "lookup__nb_lookup" / "SKILL.md").exists()
+
+    def test_no_scripts_directory(self, tmp_path):
+        metadata = {
+            "plugin_name": "netbox.netbox.nb_lookup",
+            "plugin_type": "lookup",
+            "short_description": "Queries NetBox",
+            "params": [],
+            "examples": "",
+        }
+        write_plugin_skill_package(tmp_path / "lookup__nb_lookup", metadata)
+        assert not (tmp_path / "lookup__nb_lookup" / "scripts").exists()
+
+    def test_no_assets_directory(self, tmp_path):
+        metadata = {
+            "plugin_name": "netbox.netbox.nb_lookup",
+            "plugin_type": "lookup",
+            "short_description": "Queries NetBox",
+            "params": [],
+            "examples": "",
+        }
+        write_plugin_skill_package(tmp_path / "lookup__nb_lookup", metadata)
+        assert not (tmp_path / "lookup__nb_lookup" / "assets").exists()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -482,3 +482,40 @@ class TestWritePluginSkillPackage:
         }
         write_plugin_skill_package(tmp_path / "lookup__nb_lookup", metadata)
         assert not (tmp_path / "lookup__nb_lookup" / "assets").exists()
+
+
+class TestCollectionSkillWithPlugins:
+    def test_includes_plugins_section(self):
+        metadata_list = [{
+            "module_name": "netbox.netbox.netbox_device",
+            "short_description": "Manage devices",
+            "params": [],
+            "examples": "",
+            "is_api_module": True,
+        }]
+        plugins = [
+            {"fqcn": "netbox.netbox.nb_lookup", "plugin_type": "lookup",
+             "description": "Query NetBox"},
+            {"fqcn": "netbox.netbox.nb_inventory", "plugin_type": "inventory",
+             "description": "Dynamic inventory"},
+        ]
+        result = render_collection_skill(
+            "netbox.netbox", metadata_list,
+            plugins_metadata=plugins,
+        )
+        assert "Available Plugins" in result
+        assert "nb_lookup" in result
+        assert "nb_inventory" in result
+        assert "Lookup" in result
+        assert "Inventory" in result
+
+    def test_no_plugins_section_when_empty(self):
+        metadata_list = [{
+            "module_name": "netbox.netbox.netbox_device",
+            "short_description": "Manage devices",
+            "params": [],
+            "examples": "",
+            "is_api_module": True,
+        }]
+        result = render_collection_skill("netbox.netbox", metadata_list)
+        assert "Available Plugins" not in result

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,25 @@
+"""Tests for ansible_know.types."""
+
+from ansible_know.types import ManifestPluginEntry, PluginMetadata
+
+
+class TestPluginTypes:
+    def test_plugin_metadata_instantiation(self):
+        meta: PluginMetadata = {
+            "plugin_name": "netbox.netbox.nb_lookup",
+            "plugin_type": "lookup",
+            "short_description": "Queries NetBox via its API",
+            "params": [],
+            "examples": "",
+        }
+        assert meta["plugin_type"] == "lookup"
+
+    def test_manifest_plugin_entry(self):
+        entry: ManifestPluginEntry = {
+            "fqcn": "netbox.netbox.nb_lookup",
+            "plugin_type": "lookup",
+            "description": "Queries NetBox via its API",
+            "param_count": 3,
+            "has_skill": False,
+        }
+        assert entry["plugin_type"] == "lookup"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -177,8 +177,13 @@ class TestValidateKeyword:
     def test_valid_keyword(self):
         validate_keyword("copy")
 
-    def test_empty_keyword_allowed(self):
-        validate_keyword("")
+    def test_empty_keyword_rejected(self):
+        with pytest.raises(ValidationError):
+            validate_keyword("")
+
+    def test_whitespace_keyword_rejected(self):
+        with pytest.raises(ValidationError):
+            validate_keyword("   ")
 
     def test_exact_max_length(self):
         validate_keyword("a" * MAX_KEYWORD_LENGTH)


### PR DESCRIPTION
## Summary

Add discovery, documentation, and skill generation for all 14 Ansible plugin types
(lookup, filter, test, connection, become, strategy, callback, inventory, cache,
cliconf, httpapi, netconf, shell, vars) across the full stack.

- **3 new MCP tools**: `search_plugins`, `get_plugin_doc`, `generate_plugin_skill`
- **Plugin skill template** with type-specific usage examples (Jinja2 inline for
  lookup/filter/test, play-level directives for connection/become/strategy,
  ansible.cfg for callback/cache, inventory source files for inventory)
- **Full-stack integration**: parser → galaxy → resolution → manifest → skills → server
- **Updated `generate_collection_skills`** to also discover and generate role AND
  plugin skills (previously only generated module skills)
- **Plugin skill directory convention**: `{plugin_type}__{short_name}` to avoid
  collisions with module skills sharing the same short name

## Changes

| Layer | Files | What |
|-------|-------|------|
| Foundation | `config.py`, `types.py` | `PLUGIN_TYPES` (14), category tuples, `PluginMetadata`, `ManifestPluginEntry`, `GetPluginDocResult` TypedDicts |
| Parser | `parser.py` | `list_plugins()`, `get_plugin_doc()`, `search_plugins()`, `extract_plugin_metadata()` |
| Galaxy | `galaxy.py` | `_find_plugin()`, `fetch_plugin_doc()`, `list_collection_plugins()`, `plugin_count` in search |
| Resolution | `resolution.py` | `resolve_plugin_doc()` with local-then-Galaxy fallback |
| Manifest | `collection_manifest.py` | Plugin entries in `generate_manifest()`, backfill in `load_cached_manifest()` |
| Skills | `skills.py`, `PLUGIN_SKILL.md.j2`, `COLLECTION_SKILL.md.j2` | Plugin skill rendering, collection skill plugin listing |
| Server | `server.py` | 3 new tools, updated `get_collection_manifest`, `generate_collection_skills`, skill lookup/listing, `explain_plugin` prompt |
| Docs | `CLAUDE.md` | Updated tool/prompt tables |

## Test plan

- [x] 622 unit tests passing (57 new), 58 skipped
- [x] `ruff check src/ tests/` clean
- [x] All 14 plugin types render correctly (smoke-tested each template path)
- [x] Plugin type validation rejects invalid types with `ValidationError`
- [x] `asyncio.gather` used for parallel discovery across 14 types
- [x] Plugin skill lookup via FQCN resolves `{type}__{name}` directories
- [x] `_list_skills_sync` and `resource_skills_list` strip `{type}__` prefix consistently
- [x] Galaxy fallback works for plugin docs when collection not installed locally
- [x] Backward compatibility: `load_cached_manifest` backfills `plugin_count`/`plugins`
- [x] Existing tests updated for new required fields (`plugin_count: 0`, `plugins: []`)
- [x] Per-task code review (9 tasks, all passed)
- [x] Final whole-branch architecture review (no critical/important findings)

Closes #121

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>