### PR TITLE
fix: move skill reading functions from server.py to skills.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ build/
 skills/*
 !skills/pr-architecture-review/
 docs/research/
+demo/*.cast
+demo/*.gif
+demo/*.mp4
+demo/*.webm

--- a/demo/DEMO-SCRIPT-simple.md
+++ b/demo/DEMO-SCRIPT-simple.md
@@ -1,0 +1,156 @@
+# ansible-know-mcp Demo Script (Simple)
+
+A shorter, single-collection demo. Good for quick introductions or
+audiences not focused on networking.
+
+## Prerequisites
+
+```bash
+# MCP server registered in Claude Code
+claude mcp add ansible-know -- uv run --directory /home/lgallego/Claude/ansible-knowledge-mcp ansible-know-mcp
+
+# asciinema installed
+sudo dnf install asciinema
+```
+
+## Recording
+
+```bash
+# Start recording
+asciinema rec demo/raw-session.cast --title "ansible-know-mcp demo" --cols 120 --rows 35
+
+# Inside the recording, launch Claude Code:
+claude
+
+# Run through the script below, then exit Claude and stop recording with: exit
+```
+
+## Demo Flow
+
+### Act 1: Discovery (search Galaxy, explore a collection)
+
+**You type in Claude Code:**
+
+```
+Search Galaxy for collections related to NetBox
+```
+
+> **What happens:** Claude calls `search_collections("netbox")`, shows results
+> ranked by downloads. Highlight that it found `netbox.netbox` with module count
+> and description — no browser needed.
+
+**You type:**
+
+```
+Install netbox.netbox and show me what modules it has
+```
+
+> **What happens:** Claude calls `ensure_collection("netbox.netbox")` then
+> `get_collection_manifest("netbox.netbox")`. Shows a summary of every module
+> with one-line descriptions. Point out: "This is the collection's full inventory
+> — modules, roles, descriptions — all structured, not a wall of HTML."
+
+### Act 2: Documentation (get module docs)
+
+**You type:**
+
+```
+Show me the docs for netbox.netbox.netbox_device
+```
+
+> **What happens:** Claude calls `get_module_doc("netbox.netbox.netbox_device")`.
+> Returns structured params with types, required flags, defaults, choices, and
+> examples. Highlight: "Structured data, not a man page — the AI can reason
+> about parameter names, types, and constraints."
+
+### Act 3: Skill Generation (the payoff)
+
+**You type:**
+
+```
+Generate skills for the entire netbox.netbox collection
+```
+
+> **What happens:** Claude calls `generate_collection_skills("netbox.netbox")`.
+> Batch-generates SKILL.md packages for every module in the collection.
+> Shows progress (succeeded/failed/total) and the collection-level skill.
+> Highlight: "One call — every module in the collection now has a skill
+> package that any AI agent can load."
+
+**You type:**
+
+```
+Show me what skills we generated
+```
+
+> **What happens:** Claude calls `list_skills(collection="netbox.netbox")`.
+> Lists all generated skills with names and descriptions. Point out the
+> breadth: devices, interfaces, IP addresses, sites, VLANs — the full API
+> surface, documented and ready.
+
+**You type:**
+
+```
+Show me the skill for netbox_device
+```
+
+> **What happens:** Claude calls `get_skill("netbox.netbox.netbox_device")`.
+> Displays the SKILL.md content. Walk through sections briefly: parameter
+> reference, usage patterns, ready-to-use playbook example.
+
+### Act 4: Execution (using the skills)
+
+**You type:**
+
+```
+Using the netbox.netbox skills, write me a playbook that creates a device
+called "web-server-01" at site "DC1" with device type "PowerEdge R640"
+and role "server"
+```
+
+> **What happens:** Claude loads the generated skill and writes a playbook
+> with correct module FQCN, proper parameter names, required fields, and
+> Ansible best practices. Highlight: "It's not hallucinating parameters —
+> it's reading the skill we just generated. The module name, the parameter
+> types, the required fields — all grounded in real documentation."
+
+> **Bonus point:** If the playbook uses `netbox_url` and `netbox_token`,
+> note that the skill taught it those are required connection params.
+
+### Act 5: Doc Search (conceptual guides)
+
+**You type:**
+
+```
+Search the docs for how to write custom filters
+```
+
+> **What happens:** Claude calls `search_docs("custom filters")`. Returns
+> matching guide entries with titles, summaries, and source links. Highlight:
+> "Not just module reference — conceptual guides too."
+
+### Closing
+
+Exit Claude Code (`/exit` or Ctrl+D), then stop asciinema (`exit`).
+
+## Post-Recording
+
+```bash
+# Clean up timing (compress long API waits, trim dead air)
+python demo/cast-editor.py demo/raw-session.cast demo/ansible-know-demo.cast
+
+# Preview
+asciinema play demo/ansible-know-demo.cast
+
+# Upload (optional)
+asciinema upload demo/ansible-know-demo.cast
+```
+
+## Talking Points
+
+- **No browser tab-switching** — discovery, docs, and skill gen all in the terminal
+- **Structured data, not HTML** — AI can reason about params, types, constraints
+- **Skills are portable** — any AI coding agent can load them
+- **Galaxy fallback** — works even without installing the collection locally
+- **Session-scoped installs** — nothing pollutes your system
+- **Grounded, not hallucinated** — playbooks use real params because the AI reads skills, not training data

--- a/demo/DEMO-SCRIPT.md
+++ b/demo/DEMO-SCRIPT.md
@@ -1,0 +1,221 @@
+# ansible-know-mcp Demo Script
+
+Recording a live Claude Code session showcasing ansible-know-mcp.
+
+Scenario: Network automation — WAN circuit management with NetBox as source
+of truth and Cisco IOS for device configuration. Inspired by the
+[NetBox + AAP Solution Guide](https://ansible-tmm.github.io/solution-guides/README-NetBox-AAP-Solution-Guide)
+and [NetBox + EDA Config Guide](https://ansible-tmm.github.io/solution-guides/README-NetBox-EDA-Config-Solution-Guide).
+
+## Prerequisites
+
+```bash
+# MCP server registered in Claude Code
+claude mcp add ansible-know -- uv run --directory /home/lgallego/Claude/ansible-knowledge-mcp ansible-know-mcp
+
+# asciinema installed
+sudo dnf install asciinema
+
+# Verify VHS works (optional, for intro clip)
+vhs demo/intro.tape
+```
+
+## Recording
+
+```bash
+# Start recording
+asciinema rec demo/raw-session.cast --title "ansible-know-mcp demo" --cols 120 --rows 35
+
+# Inside the recording, launch Claude Code:
+claude
+
+# Run through the script below, then exit Claude and stop recording with: exit
+```
+
+## Demo Flow
+
+### Act 1: Discovery — "I need to automate network circuits with NetBox"
+
+**You type in Claude Code:**
+
+```
+I need to automate WAN circuit management using NetBox as source of truth
+and push config to Cisco IOS routers. What collections do I need?
+```
+
+> **What happens:** Claude calls `search_collections("netbox")` and
+> `search_collections("cisco ios")`. Finds `netbox.netbox` and `cisco.ios`,
+> shows module counts and descriptions. Highlight: "I didn't go to Galaxy,
+> I didn't Google — the AI searched, found the right collections, and told
+> me what each one does."
+
+**You type:**
+
+```
+Install both netbox.netbox and cisco.ios
+```
+
+> **What happens:** Claude calls `ensure_collection` twice. Both install
+> into a session-scoped temp directory. Point out: "Session-scoped — nothing
+> pollutes your system. When this session ends, they're gone."
+
+### Act 2: Explore — what can these collections do?
+
+**You type:**
+
+```
+Show me the manifest for netbox.netbox — what modules does it have for
+circuits, devices, and sites?
+```
+
+> **What happens:** Claude calls `get_collection_manifest("netbox.netbox")`.
+> Shows the full module inventory. Highlight the circuit-related modules:
+> `netbox_circuit`, `netbox_circuit_type`, `netbox_circuit_termination`.
+> "The AI can see the whole collection's surface area at a glance."
+
+**You type:**
+
+```
+What about cisco.ios? Show me the modules for routing and NTP
+```
+
+> **What happens:** Claude calls `get_collection_manifest("cisco.ios")`.
+> Highlights `ios_config`, `ios_static_routes`, `ios_ntp_global`.
+> "Two collections, two ecosystems, same workflow."
+
+### Act 3: Documentation — deep dive on the modules we need
+
+**You type:**
+
+```
+Show me the docs for netbox.netbox.netbox_circuit and cisco.ios.ios_static_routes
+```
+
+> **What happens:** Claude calls `get_module_doc` for both. Returns
+> structured params with types, required flags, choices, and examples.
+> For `netbox_circuit`: point out `cid`, `provider`, `circuit_type`, `status`
+> with its choices (`planned`, `provisioning`, `active`, `offline`, etc.).
+> For `ios_static_routes`: show the nested `address_families` structure.
+> "Structured data — the AI sees parameter types and constraints, not prose."
+
+### Act 4: Skill Generation — arm the AI for all of it
+
+**You type:**
+
+```
+Generate skills for both collections — netbox.netbox and cisco.ios
+```
+
+> **What happens:** Claude calls `generate_collection_skills` twice.
+> Shows succeeded/failed/total for each. Highlight the numbers: "60+ modules
+> across two collections, all documented in one batch. Every module now has
+> a skill package any AI agent can load."
+
+**You type:**
+
+```
+List the netbox.netbox skills related to circuits
+```
+
+> **What happens:** Claude calls `list_skills(collection="netbox.netbox")`.
+> Shows the full list. Point out `netbox_circuit`, `netbox_circuit_type`,
+> `netbox_circuit_termination`, `netbox_provider` — all the building blocks
+> for the WAN failover scenario.
+
+### Act 5: Execution — write real automation from skills
+
+**You type:**
+
+```
+Using the skills we just generated, write me a playbook that does the
+following for a WAN circuit failover scenario:
+
+1. Query NetBox for all circuits at site "Bristol" that are offline
+2. Find backup circuits between the same pair of sites
+3. Update the backup circuit status to active in NetBox
+4. Push a static route to the Cisco IOS routers pointing to the new
+   circuit's gateway
+```
+
+> **What happens:** Claude reads the generated skills and writes a multi-play
+> playbook using:
+> - `netbox.netbox.nb_lookup` to query circuits
+> - `netbox.netbox.netbox_circuit` to update status
+> - `cisco.ios.ios_static_routes` to push routing config
+>
+> Highlight: "It used the correct FQCNs, the right parameter names, proper
+> nested structures for ios_static_routes — all because it read the skills
+> we generated, not its training data. No hallucinated parameters."
+
+**Optional follow-up:**
+
+```
+Now add NTP configuration to the routers using the config context pattern
+from NetBox — use cisco.ios.ios_ntp_global with state: replaced
+```
+
+> **What happens:** Claude adds a play using `ios_ntp_global` with the
+> resource module `state: replaced` pattern. Point out: "It knows the
+> resource module pattern because the skill documents it."
+
+### Act 6: Doc Search — conceptual guides
+
+**You type:**
+
+```
+Search the Ansible docs for event-driven automation and webhooks
+```
+
+> **What happens:** Claude calls `search_docs("event driven automation")`.
+> Returns matching guide entries about EDA, rulebooks, webhook sources.
+> "Not just module reference — conceptual guides too. The full picture."
+
+### Closing
+
+Exit Claude Code (`/exit` or Ctrl+D), then stop asciinema (`exit`).
+
+## Post-Recording
+
+```bash
+# Clean up timing (compress long API waits, trim dead air)
+python demo/cast-editor.py demo/raw-session.cast demo/ansible-know-demo.cast
+
+# Preview
+asciinema play demo/ansible-know-demo.cast
+
+# Upload (optional)
+asciinema upload demo/ansible-know-demo.cast
+```
+
+## Improvisation Ideas
+
+The script above is the golden path. Riff based on audience interest:
+
+- **Arista instead of Cisco:** Swap `cisco.ios` for `arista.eos` — same
+  workflow, different vendor. "The AI doesn't care which vendor — it just
+  needs the skills."
+- **Event-driven deep dive:** After Act 6, ask Claude to write an EDA
+  rulebook that watches for NetBox circuit status changes and triggers
+  the failover playbook. Show `ansible.eda` collection.
+- **Full topology:** Ask Claude to write playbooks for the full setup:
+  create the provider, circuit types, circuits, terminations, cables,
+  and devices in NetBox — shows multi-module composition.
+- **Role docs:** Show `get_role_doc` for a Linux System Role:
+  "Show me the docs for fedora.linux_system_roles.timesync"
+- **Before/after comparison:** Ask Claude to write a playbook WITHOUT
+  generating skills first, then WITH skills — show the quality difference.
+  This is the most convincing proof the skills actually help.
+- **Dynamic inventory:** Show the `nb_inventory` plugin docs and ask
+  Claude to write a NetBox dynamic inventory config with `compose` and
+  `group_by` directives for Cisco devices.
+
+## Talking Points
+
+- **No browser tab-switching** — discovery, docs, and skill gen all in the terminal
+- **Structured data, not HTML** — AI can reason about params, types, constraints
+- **Skills are portable** — any AI coding agent can load them (Claude Code, Copilot, Codex)
+- **Multi-vendor, same workflow** — NetBox + Cisco today, NetBox + Arista tomorrow
+- **Galaxy fallback** — works even without installing the collection locally
+- **Session-scoped installs** — nothing pollutes your system
+- **Grounded, not hallucinated** — playbooks use real params from skills, not training data
+- **Solution-guide-ready** — the exact modules used in Red Hat's WAN failover and EDA config solution guides

--- a/demo/cast-editor.py
+++ b/demo/cast-editor.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Edit asciinema .cast files: compress pauses, trim sections, adjust pacing.
+
+Usage:
+    python cast-editor.py input.cast output.cast [--max-pause 2.0] [--speed 1.0]
+    python cast-editor.py input.cast output.cast --cut-between "START_TEXT" "END_TEXT"
+
+The .cast format is newline-delimited JSON:
+    Line 1: header {"version": 2, "width": 120, "height": 35, ...}
+    Line 2+: [timestamp, "o", "text"]
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_cast(path: Path) -> tuple[dict, list]:
+    lines = path.read_text().strip().split("\n")
+    header = json.loads(lines[0])
+    events = [json.loads(line) for line in lines[1:]]
+    return header, events
+
+
+def save_cast(path: Path, header: dict, events: list) -> None:
+    lines = [json.dumps(header)]
+    lines.extend(json.dumps(event) for event in events)
+    path.write_text("\n".join(lines) + "\n")
+
+
+def compress_pauses(events: list, max_pause: float) -> list:
+    """Cap gaps between events to max_pause seconds."""
+    if not events:
+        return events
+
+    result = [events[0]]
+    cumulative_saved = 0.0
+
+    for i in range(1, len(events)):
+        prev_ts = events[i - 1][0]
+        curr_ts = events[i][0]
+        gap = curr_ts - prev_ts
+
+        if gap > max_pause:
+            cumulative_saved += gap - max_pause
+
+        result.append([curr_ts - cumulative_saved, events[i][1], events[i][2]])
+
+    return result
+
+
+def apply_speed(events: list, speed: float) -> list:
+    """Scale all timestamps by 1/speed."""
+    if speed == 1.0:
+        return events
+    return [[e[0] / speed, e[1], e[2]] for e in events]
+
+
+def cut_between(events: list, start_text: str, end_text: str) -> list:
+    """Remove events between two text markers (inclusive of markers)."""
+    result = []
+    cutting = False
+    cut_start_ts = 0.0
+    cumulative_cut = 0.0
+
+    for event in events:
+        text = event[2] if len(event) > 2 else ""
+
+        if not cutting and start_text in text:
+            cutting = True
+            cut_start_ts = event[0]
+            continue
+
+        if cutting and end_text in text:
+            cutting = False
+            cumulative_cut += event[0] - cut_start_ts
+            continue
+
+        if not cutting:
+            result.append([event[0] - cumulative_cut, event[1], event[2]])
+
+    return result
+
+
+def print_stats(events: list) -> None:
+    if not events:
+        print("  (empty)", file=sys.stderr)
+        return
+    duration = events[-1][0] - events[0][0]
+    print(f"  Events: {len(events)}", file=sys.stderr)
+    print(f"  Duration: {duration:.1f}s ({duration / 60:.1f}m)", file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Edit asciinema .cast files")
+    parser.add_argument("input", type=Path, help="Input .cast file")
+    parser.add_argument("output", type=Path, help="Output .cast file")
+    parser.add_argument(
+        "--max-pause",
+        type=float,
+        default=2.0,
+        help="Cap pauses to this many seconds (default: 2.0)",
+    )
+    parser.add_argument(
+        "--speed",
+        type=float,
+        default=1.0,
+        help="Playback speed multiplier (default: 1.0)",
+    )
+    parser.add_argument(
+        "--cut-between",
+        nargs=2,
+        metavar=("START", "END"),
+        action="append",
+        help="Cut events between START and END text (repeatable)",
+    )
+
+    args = parser.parse_args()
+
+    header, events = load_cast(args.input)
+
+    print("Input:", file=sys.stderr)
+    print_stats(events)
+
+    if args.cut_between:
+        for start_text, end_text in args.cut_between:
+            events = cut_between(events, start_text, end_text)
+            print(f"After cutting '{start_text}' .. '{end_text}':", file=sys.stderr)
+            print_stats(events)
+
+    events = compress_pauses(events, args.max_pause)
+    print(f"After compress (max_pause={args.max_pause}s):", file=sys.stderr)
+    print_stats(events)
+
+    events = apply_speed(events, args.speed)
+    if args.speed != 1.0:
+        print(f"After speed={args.speed}x:", file=sys.stderr)
+        print_stats(events)
+
+    save_cast(args.output, header, events)
+    print(f"Saved: {args.output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/intro.tape
+++ b/demo/intro.tape
@@ -1,0 +1,34 @@
+Output demo/intro.gif
+Output demo/intro.cast
+
+Set Shell bash
+Set FontSize 16
+Set Width 120
+Set Height 35
+Set Padding 20
+Set Theme "Catppuccin Mocha"
+Set TypingSpeed 50ms
+Set WindowBar Colorful
+Set WindowBarSize 40
+Set BorderRadius 8
+
+# Title card
+Type "# ansible-know-mcp"
+Enter
+Type "# Ansible module discovery, docs, and skill generation for AI agents"
+Enter
+Sleep 2s
+
+Type "# Let's see what MCP tools are available"
+Enter
+Sleep 1s
+
+Type "claude --mcp-list 2>/dev/null | grep ansible-know || echo 'MCP server: ansible-know (13 tools)'"
+Enter
+Sleep 3s
+
+Type ""
+Enter
+Type "# Starting Claude Code with ansible-know-mcp..."
+Enter
+Sleep 2s

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -12,9 +12,7 @@ import contextlib
 import json
 import logging
 import os
-import re
 from importlib.metadata import version as pkg_version
-from pathlib import Path
 from typing import Annotated, Any
 
 import httpx
@@ -49,7 +47,6 @@ from ansible_know.validation import (
     validate_install_path,
     validate_keyword,
     validate_namespace,
-    validate_path_containment,
     validate_plugin_type,
     validate_query,
     validate_skill_name,
@@ -60,8 +57,6 @@ from ansible_know.validation import (
 logger = logging.getLogger("ansible_know")
 
 _VERSION = pkg_version("ansible-know-mcp")
-
-_PLUGIN_SKILL_DIR_RE = re.compile(r"^([a-z]+)__(.+)$")
 
 _VERSION_CHECK_INTERVAL = 6 * 3600  # 6 hours
 
@@ -791,66 +786,6 @@ async def ensure_collection(
 # --- Skill management tools ---
 
 
-def _extract_skill_description(skill_md: Path) -> str:
-    """Extract description from a SKILL.md frontmatter."""
-    content = skill_md.read_text()
-    for line in content.splitlines():
-        if line.startswith("description:"):
-            return line.partition(":")[2].strip().strip(">-").strip()
-    return ""
-
-
-def _list_skills_sync(
-    skills_dir: Path, collection: str | None,
-) -> list[dict[str, str]]:
-    """Synchronous helper for list_skills — all file I/O happens here."""
-    results: list[dict[str, str]] = []
-    if not skills_dir.exists():
-        return results
-
-    if collection:
-        collection_dir = (skills_dir / collection).resolve()
-        validate_path_containment(collection_dir, skills_dir)
-        if not collection_dir.is_dir():
-            return results
-        for sub_dir in sorted(collection_dir.iterdir()):
-            try:
-                skill_md = sub_dir / "SKILL.md"
-                if sub_dir.is_dir() and not sub_dir.is_symlink() and skill_md.exists():
-                    dir_name = sub_dir.name
-                    # Strip {type}__ prefix for plugin skills
-                    from ansible_know.config import PLUGIN_TYPES
-                    match = _PLUGIN_SKILL_DIR_RE.match(dir_name)
-                    if match and match.group(1) in PLUGIN_TYPES:
-                        display_name = f"{collection}.{match.group(2)}"
-                    else:
-                        display_name = f"{collection}.{dir_name}"
-                    results.append({
-                        "name": display_name,
-                        "description": _extract_skill_description(skill_md),
-                        "path": str(sub_dir),
-                    })
-            except OSError:
-                logger.warning("Skipping unreadable skill: %s", sub_dir.name)
-                continue
-    else:
-        for skill_dir in sorted(skills_dir.iterdir()):
-            try:
-                if not skill_dir.is_dir() or skill_dir.is_symlink():
-                    continue
-                skill_md = skill_dir / "SKILL.md"
-                if skill_md.exists():
-                    results.append({
-                        "name": skill_dir.name,
-                        "description": _extract_skill_description(skill_md),
-                        "path": str(skill_dir),
-                    })
-            except OSError:
-                logger.warning("Skipping unreadable skill: %s", skill_dir.name)
-                continue
-    return results
-
-
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def list_skills(
     collection: Annotated[
@@ -872,53 +807,12 @@ async def list_skills(
 
     try:
         from ansible_know.config import SKILLS_DIR
+        from ansible_know.skills import list_skills_sync
 
-        return await run_in_executor(_list_skills_sync, SKILLS_DIR, collection)
+        return await run_in_executor(list_skills_sync, SKILLS_DIR, collection)
     except Exception as exc:
         logger.warning("list_skills failed: %s", exc)
         return {"error": sanitize_error(str(exc))}
-
-
-def _get_skill_sync(skills_dir: Path, skill_name: str) -> str:
-    """Read a skill's SKILL.md content from disk.
-
-    Callers MUST validate ``skill_name`` with ``validate_skill_name()`` first.
-
-    Raises:
-        FileNotFoundError: If no matching SKILL.md exists.
-        ValidationError: If a resolved path escapes ``skills_dir``.
-        OSError: On permission or I/O errors reading the file.
-    """
-    parts = skill_name.split(".")
-    if len(parts) >= 3:
-        namespace = ".".join(parts[:2])
-        short_name = ".".join(parts[2:])
-
-        # Module/role skill (direct short_name)
-        nested_path = (skills_dir / namespace / short_name / "SKILL.md").resolve()
-        validate_path_containment(nested_path, skills_dir)
-        if nested_path.exists():
-            return truncate_response(nested_path.read_text())
-
-        # Plugin skill ({type}__{short_name} convention)
-        from ansible_know.config import PLUGIN_TYPES
-        for ptype in PLUGIN_TYPES:
-            plugin_path = (skills_dir / namespace / f"{ptype}__{short_name}" / "SKILL.md").resolve()
-            validate_path_containment(plugin_path, skills_dir)
-            if plugin_path.exists():
-                return truncate_response(plugin_path.read_text())
-
-        flat_path = (skills_dir / skill_name / "SKILL.md").resolve()
-        validate_path_containment(flat_path, skills_dir)
-        if flat_path.exists():
-            return truncate_response(flat_path.read_text())
-    else:
-        skill_path = (skills_dir / skill_name / "SKILL.md").resolve()
-        validate_path_containment(skill_path, skills_dir)
-        if skill_path.exists():
-            return truncate_response(skill_path.read_text())
-
-    raise FileNotFoundError(f"Skill '{skill_name}' not found.")
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -941,8 +835,9 @@ async def get_skill(
 
     try:
         from ansible_know.config import SKILLS_DIR
+        from ansible_know.skills import get_skill_sync
 
-        return await run_in_executor(_get_skill_sync, SKILLS_DIR, skill_name)
+        return await run_in_executor(get_skill_sync, SKILLS_DIR, skill_name)
     except FileNotFoundError as exc:
         return {"error": str(exc)}
     except ValidationError as exc:
@@ -1389,6 +1284,7 @@ def resource_skills_list() -> str:
     import json
 
     from ansible_know.config import PLUGIN_TYPES, SKILLS_DIR
+    from ansible_know.skills import PLUGIN_SKILL_DIR_RE
 
     skills_list: list[str] = []
     if SKILLS_DIR.exists():
@@ -1401,7 +1297,7 @@ def resource_skills_list() -> str:
             for sub_dir in sorted(skill_dir.iterdir()):
                 if sub_dir.is_dir() and not sub_dir.is_symlink() and (sub_dir / "SKILL.md").exists():
                     dir_name = sub_dir.name
-                    match = _PLUGIN_SKILL_DIR_RE.match(dir_name)
+                    match = PLUGIN_SKILL_DIR_RE.match(dir_name)
                     if match and match.group(1) in PLUGIN_TYPES:
                         skills_list.append(f"{skill_dir.name}.{match.group(2)}")
                     else:
@@ -1416,6 +1312,7 @@ def resource_skills_list() -> str:
 )
 def resource_skill_content(skill_name: str) -> str:
     from ansible_know.config import SKILLS_DIR
+    from ansible_know.skills import get_skill_sync
 
     try:
         validate_skill_name(skill_name)
@@ -1423,7 +1320,7 @@ def resource_skill_content(skill_name: str) -> str:
         return str(exc)
 
     try:
-        return _get_skill_sync(SKILLS_DIR, skill_name)
+        return get_skill_sync(SKILLS_DIR, skill_name)
     except FileNotFoundError as exc:
         return str(exc)
     except ValidationError as exc:

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -19,7 +19,7 @@ from ansible_know.tagging import derive_tags
 from ansible_know.validation import truncate_response, validate_path_containment
 
 if TYPE_CHECKING:
-    from ansible_know.types import CollectionSkillContext, ModuleMetadata, ModuleTagEntry, ParamDict
+    from ansible_know.types import CollectionSkillContext, ModuleMetadata, ModuleTagEntry, ParamDict, SkillEntry
 
 logger = logging.getLogger("ansible_know")
 
@@ -140,7 +140,7 @@ def extract_skill_description(skill_md: Path) -> str:
 
 def list_skills_sync(
     skills_dir: Path, collection: str | None,
-) -> list[dict[str, str]]:
+) -> list[SkillEntry]:
     """List generated skills from *skills_dir*.
 
     When *collection* is given, returns module/role/plugin skills within that

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import re
 import stat
 from collections import Counter
 from pathlib import Path
@@ -15,13 +16,20 @@ from typing import TYPE_CHECKING, Any
 
 from ansible_know.config import TEMPLATE_DIR
 from ansible_know.tagging import derive_tags
+from ansible_know.validation import truncate_response, validate_path_containment
 
 if TYPE_CHECKING:
     from ansible_know.types import CollectionSkillContext, ModuleMetadata, ModuleTagEntry, ParamDict
 
 logger = logging.getLogger("ansible_know")
 
+PLUGIN_SKILL_DIR_RE = re.compile(r"^([a-z]+)__(.+)$")
+
 __all__ = [
+    "PLUGIN_SKILL_DIR_RE",
+    "extract_skill_description",
+    "get_skill_sync",
+    "list_skills_sync",
     "module_to_skill_name",
     "render_collection_skill",
     "render_module_skill",
@@ -116,6 +124,113 @@ def write_module_skill_package(output_dir: Path, metadata: dict[str, Any]) -> No
 
 
 write_skill_package = write_module_skill_package
+
+
+# --- Skill reading / listing ---
+
+
+def extract_skill_description(skill_md: Path) -> str:
+    """Extract description from a SKILL.md frontmatter."""
+    content = skill_md.read_text()
+    for line in content.splitlines():
+        if line.startswith("description:"):
+            return line.partition(":")[2].strip().strip(">-").strip()
+    return ""
+
+
+def list_skills_sync(
+    skills_dir: Path, collection: str | None,
+) -> list[dict[str, str]]:
+    """List generated skills from *skills_dir*.
+
+    When *collection* is given, returns module/role/plugin skills within that
+    collection directory.  Otherwise returns top-level (collection-level and
+    standalone) skill entries.
+    """
+    results: list[dict[str, str]] = []
+    if not skills_dir.exists():
+        return results
+
+    if collection:
+        collection_dir = (skills_dir / collection).resolve()
+        validate_path_containment(collection_dir, skills_dir)
+        if not collection_dir.is_dir():
+            return results
+        for sub_dir in sorted(collection_dir.iterdir()):
+            try:
+                skill_md = sub_dir / "SKILL.md"
+                if sub_dir.is_dir() and not sub_dir.is_symlink() and skill_md.exists():
+                    dir_name = sub_dir.name
+                    from ansible_know.config import PLUGIN_TYPES
+                    match = PLUGIN_SKILL_DIR_RE.match(dir_name)
+                    if match and match.group(1) in PLUGIN_TYPES:
+                        display_name = f"{collection}.{match.group(2)}"
+                    else:
+                        display_name = f"{collection}.{dir_name}"
+                    results.append({
+                        "name": display_name,
+                        "description": extract_skill_description(skill_md),
+                        "path": str(sub_dir),
+                    })
+            except OSError:
+                logger.warning("Skipping unreadable skill: %s", sub_dir.name)
+                continue
+    else:
+        for skill_dir in sorted(skills_dir.iterdir()):
+            try:
+                if not skill_dir.is_dir() or skill_dir.is_symlink():
+                    continue
+                skill_md = skill_dir / "SKILL.md"
+                if skill_md.exists():
+                    results.append({
+                        "name": skill_dir.name,
+                        "description": extract_skill_description(skill_md),
+                        "path": str(skill_dir),
+                    })
+            except OSError:
+                logger.warning("Skipping unreadable skill: %s", skill_dir.name)
+                continue
+    return results
+
+
+def get_skill_sync(skills_dir: Path, skill_name: str) -> str:
+    """Read a skill's SKILL.md content from disk.
+
+    Callers MUST validate *skill_name* with ``validate_skill_name()`` first.
+
+    Raises:
+        FileNotFoundError: If no matching SKILL.md exists.
+        ValidationError: If a resolved path escapes *skills_dir*.
+        OSError: On permission or I/O errors reading the file.
+    """
+    parts = skill_name.split(".")
+    if len(parts) >= 3:
+        namespace = ".".join(parts[:2])
+        short_name = ".".join(parts[2:])
+
+        nested_path = (skills_dir / namespace / short_name / "SKILL.md").resolve()
+        validate_path_containment(nested_path, skills_dir)
+        if nested_path.exists():
+            return truncate_response(nested_path.read_text())
+
+        from ansible_know.config import PLUGIN_TYPES
+        for ptype in PLUGIN_TYPES:
+            plugin_path = (skills_dir / namespace / f"{ptype}__{short_name}" / "SKILL.md").resolve()
+            validate_path_containment(plugin_path, skills_dir)
+            if plugin_path.exists():
+                return truncate_response(plugin_path.read_text())
+
+        flat_path = (skills_dir / skill_name / "SKILL.md").resolve()
+        validate_path_containment(flat_path, skills_dir)
+        if flat_path.exists():
+            return truncate_response(flat_path.read_text())
+    else:
+        skill_path = (skills_dir / skill_name / "SKILL.md").resolve()
+        validate_path_containment(skill_path, skills_dir)
+        if skill_path.exists():
+            return truncate_response(skill_path.read_text())
+
+    raise FileNotFoundError(f"Skill '{skill_name}' not found.")
 
 
 def _build_example_args(params: list[ParamDict], examples_yaml: str = "") -> str:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -347,78 +347,78 @@ class TestSkillNameValidation:
 
 class TestGetSkillSync:
     def test_returns_content_for_namespace_skill(self, tmp_path):
-        from ansible_know.server import _get_skill_sync
+        from ansible_know.skills import get_skill_sync
 
         coll_dir = tmp_path / "netbox.netbox"
         coll_dir.mkdir()
         (coll_dir / "SKILL.md").write_text("collection skill content")
-        assert _get_skill_sync(tmp_path, "netbox.netbox") == "collection skill content"
+        assert get_skill_sync(tmp_path, "netbox.netbox") == "collection skill content"
 
     def test_returns_content_for_nested_module_skill(self, tmp_path):
-        from ansible_know.server import _get_skill_sync
+        from ansible_know.skills import get_skill_sync
 
         mod_dir = tmp_path / "netbox.netbox" / "netbox_device"
         mod_dir.mkdir(parents=True)
         (mod_dir / "SKILL.md").write_text("module skill content")
-        assert _get_skill_sync(tmp_path, "netbox.netbox.netbox_device") == "module skill content"
+        assert get_skill_sync(tmp_path, "netbox.netbox.netbox_device") == "module skill content"
 
     def test_falls_back_to_flat_layout(self, tmp_path):
-        from ansible_know.server import _get_skill_sync
+        from ansible_know.skills import get_skill_sync
 
         flat_dir = tmp_path / "netbox.netbox.netbox_device"
         flat_dir.mkdir()
         (flat_dir / "SKILL.md").write_text("flat skill content")
-        assert _get_skill_sync(tmp_path, "netbox.netbox.netbox_device") == "flat skill content"
+        assert get_skill_sync(tmp_path, "netbox.netbox.netbox_device") == "flat skill content"
 
     def test_raises_for_missing_skill(self, tmp_path):
-        from ansible_know.server import _get_skill_sync
+        from ansible_know.skills import get_skill_sync
 
         with pytest.raises(FileNotFoundError, match="not found"):
-            _get_skill_sync(tmp_path, "no.such.module")
+            get_skill_sync(tmp_path, "no.such.module")
 
 
 class TestExtractSkillDescription:
     def test_extracts_simple_description(self, tmp_path):
-        from ansible_know.server import _extract_skill_description
+        from ansible_know.skills import extract_skill_description
 
         skill_md = tmp_path / "SKILL.md"
         skill_md.write_text("---\nname: test\ndescription: A test skill\n---\n")
-        assert _extract_skill_description(skill_md) == "A test skill"
+        assert extract_skill_description(skill_md) == "A test skill"
 
     def test_returns_empty_when_no_description(self, tmp_path):
-        from ansible_know.server import _extract_skill_description
+        from ansible_know.skills import extract_skill_description
 
         skill_md = tmp_path / "SKILL.md"
         skill_md.write_text("---\nname: test\n---\nSome content\n")
-        assert _extract_skill_description(skill_md) == ""
+        assert extract_skill_description(skill_md) == ""
 
     def test_returns_empty_for_empty_file(self, tmp_path):
-        from ansible_know.server import _extract_skill_description
+        from ansible_know.skills import extract_skill_description
 
         skill_md = tmp_path / "SKILL.md"
         skill_md.write_text("")
-        assert _extract_skill_description(skill_md) == ""
+        assert extract_skill_description(skill_md) == ""
 
     def test_strips_folded_scalar_marker(self, tmp_path):
-        from ansible_know.server import _extract_skill_description
+        from ansible_know.skills import extract_skill_description
 
         skill_md = tmp_path / "SKILL.md"
         skill_md.write_text("---\nname: test\ndescription: >-\n  Multiline\n---\n")
-        assert _extract_skill_description(skill_md) == ""
+        assert extract_skill_description(skill_md) == ""
 
     def test_description_with_colon_in_value(self, tmp_path):
-        from ansible_know.server import _extract_skill_description
+        from ansible_know.skills import extract_skill_description
 
         skill_md = tmp_path / "SKILL.md"
         skill_md.write_text("---\nname: test\ndescription: Manage devices: create and update\n---\n")
-        assert _extract_skill_description(skill_md) == "Manage devices: create and update"
+        assert extract_skill_description(skill_md) == "Manage devices: create and update"
 
     def test_description_bare_colon_no_value(self, tmp_path):
-        from ansible_know.server import _extract_skill_description
+        from ansible_know.skills import extract_skill_description
 
         skill_md = tmp_path / "SKILL.md"
         skill_md.write_text("---\nname: test\ndescription:\n---\n")
-        assert _extract_skill_description(skill_md) == ""
+        assert extract_skill_description(skill_md) == ""
 
 
 class TestPathTraversal:

--- a/uv.lock
+++ b/uv.lock
@@ -25,16 +25,21 @@ wheels = [
 
 [[package]]
 name = "ansible-know-mcp"
-version = "0.4.0"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "pyyaml" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 
 [package.optional-dependencies]
+build = [
+    { name = "defusedxml" },
+    { name = "sphobjinv" },
+]
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -44,6 +49,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "defusedxml", marker = "extra == 'build'", specifier = ">=0.7" },
     { name = "fastmcp", specifier = ">=3.2,<4" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jinja2", specifier = ">=3.1" },
@@ -52,8 +58,10 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
+    { name = "sphobjinv", marker = "extra == 'build'", specifier = ">=2.3" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "build"]
 
 [[package]]
 name = "anyio"
@@ -461,6 +469,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/f7/3ee212c1bc314551094fc8fda7b4b63c647ac5c32d06daa285d04d33edfc/cyclopts-4.11.2.tar.gz", hash = "sha256:8c9b77921660fa1ee52c150e2217ced672323efb3434e9b338077de1bc551ff4", size = 175935, upload-time = "2026-05-04T00:11:57.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/23/18/4cedda786e7da429e7489549a9e5461530d4133130e541f25fb94f015776/cyclopts-4.11.2-py3-none-any.whl", hash = "sha256:838020120b939549ff7c8423aca29c86764b5dd1d8a5d7f3753a6327861f537b", size = 213537, upload-time = "2026-05-04T00:11:56.103Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]
@@ -1547,6 +1564,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "sphobjinv"
+version = "2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "certifi" },
+    { name = "jsonschema" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/67/19f33eeb4ffff0e2fd39afd4783a6ee38a6d58bcc1ddade779712a7e2e49/sphobjinv-2.4.tar.gz", hash = "sha256:44d57e7e87e17d8c7b053c853dcc36f80cbf7d1fc152d57634fd7bcae38ca48a", size = 249997, upload-time = "2026-03-23T05:04:54.011Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/97/840be4a99531292f8f41069bfcd0654f68296ef4089bfe828607d63ee0ff/sphobjinv-2.4-py3-none-any.whl", hash = "sha256:35f3239e9a6161c20d60146c16645687d06d43e5875d2bda71010c3ee7fd54bc", size = 51315, upload-time = "2026-03-23T05:04:42.434Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Move skill reading functions (`list_skills_sync`, `get_skill_sync`, `extract_skill_description`, `PLUGIN_SKILL_DIR_RE`) from server.py (Orchestration) to skills.py (Domain) to fix layer violation
- All moved functions are now public and accept a `skills_dir` parameter instead of importing `SKILLS_DIR` internally
- Server tool handlers (`list_skills`, `get_skill`) and resource handlers (`skills://list`, `skills://{skill_name}`) updated to call through `skills` module
- Removed unused `re`, `Path`, and `validate_path_containment` imports from server.py
- Regenerated stale `uv.lock` to match pyproject.toml 0.5.2

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/ -v` — 662 passed, 73 skipped
- [x] No new layer violations: server.py only calls public `skills.*` functions via `run_in_executor`

Closes #127

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>