### PR TITLE
release: v0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ansible-know-mcp"
-version = "0.5.2"
+version = "0.6.0"
 description = "Ansible Knowledge MCP Server — module and role discovery, documentation, and skill generation for AI agents"
 requires-python = ">=3.10"
 license = "GPL-3.0-or-later"

--- a/src/ansible_know/cli.py
+++ b/src/ansible_know/cli.py
@@ -14,7 +14,7 @@ from typing import Literal
 __all__ = ["ServerConfig", "parse_args"]
 
 _VALID_TRANSPORTS = ("stdio", "http")
-_DEFAULT_HOST = "0.0.0.0"
+_DEFAULT_HOST = "127.0.0.1"
 _DEFAULT_PORT = 8080
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,7 @@ class TestParseArgsDefaults:
     def test_defaults(self):
         config = parse_args([])
         assert config.transport == "stdio"
-        assert config.host == "0.0.0.0"
+        assert config.host == "127.0.0.1"
         assert config.port == 8080
 
     def test_transport_http(self):


### PR DESCRIPTION
## Release v0.6.0

### Changes since v0.5.2
- **feat:** Add plugin discovery, documentation, and skill generation (#122)
- **feat:** Replace ai-docs fork with RTD-native doc discovery (#116)
- **refactor:** Align resolve_module_doc return type with role/plugin pattern (#129)
- **fix:** Tighten plugins_metadata and roles_metadata parameter typing (#128)
- **fix:** Move skill reading functions from server.py to skills.py (#130)
- **fix:** Remove AnsibleClaw references from templates and source (#115)
- **fix:** Mention resources in MCP server instructions (#114)
- **security:** Default HTTP bind address changed from 0.0.0.0 to 127.0.0.1

### Pre-release review
- 662 tests pass, 73 skipped (integration)
- Lint clean (ruff)
- Code review: no critical or high-severity findings
- Security review: no critical or high-severity findings
- Remaining low-priority defense-in-depth items tracked in #133

### Test plan
- [x] Full test suite passes (662 passed)
- [x] Ruff lint clean
- [x] Code review completed
- [x] Security review completed
- [ ] CI passes on this PR
- [ ] Tag v0.6.0 after merge triggers publish workflow

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>