### PR TITLE
feat: batch docs-blob fetch for collection documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ src/ansible_know/
 | `fetch_doc` | read-only | Fetch a docs.ansible.com page as clean Markdown |
 | `search_collections` | read-only | Search Galaxy for collections by keyword |
 | `get_collection_manifest` | read-only | Get collection-level module and role summary |
+| `get_collection_docs` | read-only | Get all module docs for a collection from Galaxy |
 | `ensure_collection` | idempotent write | Install a collection for this session |
 | `list_skills` | read-only | List generated skills |
 | `get_skill` | read-only | Read a skill's content |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ packages = ["src/ansible_know"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+pythonpath = ["src"]
 markers = [
     "integration: opt-in tests that hit real ansible-doc or Galaxy API (deselect with '-m not integration')",
 ]

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -18,7 +18,7 @@ from ansible_know.errors import GalaxyError
 
 if TYPE_CHECKING:
     from ansible_know.galaxy_config import GalaxyServerConfig
-    from ansible_know.types import DocProvenance
+    from ansible_know.types import DocProvenance, ModuleMetadata
 
 logger = logging.getLogger("ansible_know")
 
@@ -489,6 +489,72 @@ class GalaxyClient:
         if self.server_name:
             meta["doc_source_server"] = self.server_name
         return doc, meta
+
+    async def fetch_collection_docs(
+        self, collection_namespace: str, version: str | None = None,
+    ) -> tuple[dict[str, ModuleMetadata], DocProvenance]:
+        """Fetch all module docs from a collection in one docs-blob call.
+
+        Extracts every module entry from the blob and transforms each into
+        the same ``ModuleMetadata`` shape that ``extract_module_metadata``
+        produces from ansible-doc output.
+
+        Contract:
+            Preconditions:
+                - ``collection_namespace`` must be 'namespace.name' format
+                  (two dot-separated segments). Raises ``GalaxyError`` if not.
+
+            Raises:
+                GalaxyError: If the namespace is malformed, the collection is
+                    not found on Galaxy, or the API request fails.
+
+            Silences:
+                - Individual modules whose ``transform_galaxy_to_ansible_doc_format``
+                  or ``extract_module_metadata`` raises are logged and skipped.
+                  The caller receives docs for the remaining modules with no
+                  indication of partial failure (check logs).
+        """
+        from ansible_know.parser import (
+            extract_module_metadata,
+            transform_galaxy_to_ansible_doc_format,
+        )
+
+        parts = collection_namespace.split(".")
+        if len(parts) != 2:
+            raise GalaxyError(
+                f"'{collection_namespace}' is not a valid collection FQCN "
+                f"(expected namespace.name)."
+            )
+        namespace, name = parts
+        resolved_version = version or await self.latest_version(namespace, name)
+        is_latest = version is None
+
+        blob = await self._fetch_docs_blob(namespace, name, resolved_version)
+        result: dict[str, ModuleMetadata] = {}
+        for item in blob.get("contents", []):
+            if item.get("content_type") != "module":
+                continue
+            short_name = item.get("content_name", "")
+            fqcn = f"{collection_namespace}.{short_name}"
+            try:
+                raw_doc = transform_galaxy_to_ansible_doc_format(fqcn, item)
+                result[fqcn] = extract_module_metadata(raw_doc)
+            except Exception:
+                logger.warning("Skipping module %s: metadata extraction failed", fqcn)
+
+        meta: DocProvenance = {
+            "doc_source": "galaxy",
+            "doc_version": resolved_version,
+        }
+        if is_latest:
+            meta["doc_warning"] = (
+                f"Documentation sourced from Galaxy "
+                f"({namespace}.{name} {resolved_version}). "
+                f"Your installed version may differ."
+            )
+        if self.server_name:
+            meta["doc_source_server"] = self.server_name
+        return result, meta
 
     async def list_collection_modules(
         self, collection_fqcn: str, version: str | None = None,

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -540,7 +540,7 @@ class GalaxyClient:
                 raw_doc = transform_galaxy_to_ansible_doc_format(fqcn, item)
                 result[fqcn] = extract_module_metadata(raw_doc)
             except Exception:
-                logger.warning("Skipping module %s: metadata extraction failed", fqcn)
+                logger.warning("Skipping module %s: metadata extraction failed", fqcn, exc_info=True)
 
         meta: DocProvenance = {
             "doc_source": "galaxy",

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -495,7 +495,8 @@ class GalaxyClient:
     ) -> tuple[dict[str, ModuleMetadata], DocProvenance]:
         """Fetch all module docs from a collection in one docs-blob call.
 
-        Extracts every module entry from the blob and transforms each into
+        Extracts every module entry from the blob, returning a dict keyed
+        by module FQCN. Transforms each into
         the same ``ModuleMetadata`` shape that ``extract_module_metadata``
         produces from ansible-doc output.
 

--- a/src/ansible_know/resolution.py
+++ b/src/ansible_know/resolution.py
@@ -362,7 +362,6 @@ async def resolve_collection_module_docs(
     http_client: httpx.AsyncClient | None = None,
     galaxy_servers: list[GalaxyServerConfig] | None = None,
     client_factory: GalaxyClientFactory | None = None,
-    missing_collections: set[str] | None = None,
 ) -> CollectionDocsResult | ErrorResponse:
     """Batch-fetch all module docs for a collection from Galaxy.
 

--- a/src/ansible_know/resolution.py
+++ b/src/ansible_know/resolution.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
     from ansible_know.galaxy_config import GalaxyServerConfig
     from ansible_know.types import (
+        CollectionDocsResult,
         ErrorResponse,
         GalaxyClientFactory,
         GetModuleDocResult,
@@ -32,6 +33,7 @@ logger = logging.getLogger("ansible_know")
 
 __all__ = [
     "discover_collection_plugins",
+    "resolve_collection_module_docs",
     "resolve_module_doc",
     "resolve_plugin_doc",
     "resolve_role_doc",
@@ -352,6 +354,65 @@ async def resolve_role_doc(
             "error": sanitize_error(str(galaxy_exc)),
             "entry_points": {},
         }
+
+
+async def resolve_collection_module_docs(
+    collection_namespace: str,
+    version: str | None = None,
+    http_client: httpx.AsyncClient | None = None,
+    galaxy_servers: list[GalaxyServerConfig] | None = None,
+    client_factory: GalaxyClientFactory | None = None,
+    missing_collections: set[str] | None = None,
+) -> CollectionDocsResult | ErrorResponse:
+    """Batch-fetch all module docs for a collection from Galaxy.
+
+    Delegates to ``GalaxyClient.fetch_collection_docs`` via the
+    multi-server fallback chain. Does NOT try local ansible-doc —
+    the caller decides whether to use this (Galaxy-only) path or
+    the existing per-module local path.
+
+    Contract:
+        Preconditions:
+            - ``client_factory`` must be provided. If ``None``, returns
+              an ``ErrorResponse`` immediately (no exception raised).
+
+        Raises:
+            Nothing — errors are returned as ``ErrorResponse`` dicts.
+
+        Silences:
+            - ``GalaxyError`` from all servers: caught and returned as
+              ``{"error": str}`` after sanitization. Individual server
+              failures are logged at INFO level by ``_try_galaxy_servers``.
+    """
+    from ansible_know.errors import GalaxyError
+
+    if client_factory is None:
+        return {"error": "No Galaxy client configured for collection docs"}
+
+    servers = _get_servers(galaxy_servers)
+
+    async def _fetch(client):
+        return await client.fetch_collection_docs(
+            collection_namespace, version=version,
+        )
+
+    try:
+        modules, galaxy_meta = await _try_galaxy_servers(
+            servers, _fetch, client_factory, http_client,
+        )
+        result: CollectionDocsResult = {
+            "modules": modules,
+            "doc_source": "galaxy",
+        }
+        if "doc_version" in galaxy_meta:
+            result["doc_version"] = galaxy_meta["doc_version"]
+        if "doc_warning" in galaxy_meta:
+            result["doc_warning"] = galaxy_meta["doc_warning"]
+        if "doc_source_server" in galaxy_meta:
+            result["doc_source_server"] = galaxy_meta["doc_source_server"]
+        return result
+    except GalaxyError as exc:
+        return {"error": sanitize_error(str(exc))}
 
 
 async def search_galaxy_collections(

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -761,7 +761,6 @@ async def get_collection_docs(
             http_client=http_client,
             galaxy_servers=state.galaxy_servers,
             client_factory=_galaxy_factory(ctx),
-            missing_collections=state.missing_collections,
         )
     except Exception as exc:
         logger.warning("get_collection_docs failed: %s", exc)
@@ -1118,7 +1117,6 @@ async def generate_collection_skills(
                 http_client=_get_http_client(ctx),
                 galaxy_servers=state.galaxy_servers,
                 client_factory=_galaxy_factory(ctx),
-                missing_collections=state.missing_collections,
             )
             if "modules" in batch_result:
                 galaxy_batch_modules = batch_result["modules"]

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -25,6 +25,7 @@ from ansible_know.errors import AnsibleDocError, AnsibleKnowError, ValidationErr
 from ansible_know.state import LifespanContext, ServerState, SessionManager, SharedState
 from ansible_know.types import (
     ClearCacheResult,
+    CollectionDocsResult,
     CollectionSearchResult,
     EnsureCollectionResult,
     ErrorResponse,
@@ -726,6 +727,44 @@ async def get_collection_manifest(
         raise
     except Exception as exc:
         logger.warning("get_collection_manifest failed: %s", exc)
+        return {"error": maybe_add_hint(sanitize_error(str(exc)), collection_namespace)}
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def get_collection_docs(
+    collection_namespace: Annotated[str, "Collection namespace (e.g. 'netbox.netbox')"],
+    version: Annotated[str | None, "Optional version (e.g. '3.23.0'). If omitted, uses latest."] = None,
+    ctx: Context | None = None,
+) -> CollectionDocsResult | ErrorResponse:
+    """Get full module documentation for all modules in a collection from Galaxy.
+
+    Returns all module docs in a single API call without installing the collection.
+    Result shape: {"modules": {fqcn: {module_name, short_description, params, examples, is_api_module}, ...},
+    "doc_source": "galaxy", "doc_version": str}.
+    On failure returns {"error": str}.
+    """
+    logger.info("get_collection_docs namespace=%r version=%r", collection_namespace, version)
+    await _maybe_warn_upgrade(ctx)
+    try:
+        validate_namespace(collection_namespace)
+    except ValidationError as exc:
+        return {"error": str(exc)}
+
+    try:
+        from ansible_know import resolution
+
+        state = await _get_state(ctx)
+        http_client = _get_http_client(ctx)
+        return await resolution.resolve_collection_module_docs(
+            collection_namespace,
+            version=version,
+            http_client=http_client,
+            galaxy_servers=state.galaxy_servers,
+            client_factory=_galaxy_factory(ctx),
+            missing_collections=state.missing_collections,
+        )
+    except Exception as exc:
+        logger.warning("get_collection_docs failed: %s", exc)
         return {"error": maybe_add_hint(sanitize_error(str(exc)), collection_namespace)}
 
 

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1110,6 +1110,19 @@ async def generate_collection_skills(
             collections_path=cpath,
         )
 
+        # Galaxy batch fallback for modules when collection not installed locally
+        galaxy_batch_modules: dict[str, Any] = {}
+        if not modules:
+            batch_result = await resolution.resolve_collection_module_docs(
+                collection_namespace,
+                http_client=_get_http_client(ctx),
+                galaxy_servers=state.galaxy_servers,
+                client_factory=_galaxy_factory(ctx),
+                missing_collections=state.missing_collections,
+            )
+            if "modules" in batch_result:
+                galaxy_batch_modules = batch_result["modules"]
+
         # Discover roles
         roles_raw = {}
         try:
@@ -1126,14 +1139,14 @@ async def generate_collection_skills(
 
         # Combined guard — reject only if ALL content types are empty
         has_plugins = any(plugins for _, plugins in plugin_list_results)
-        if not modules and not roles_raw and not has_plugins:
+        if not modules and not galaxy_batch_modules and not roles_raw and not has_plugins:
             return {"error": (
                 f"No modules, roles, or plugins found in collection '{collection_namespace}'."
                 + collection_hint(collection_namespace)
             )}
 
         plugin_count = sum(len(plugins) for _, plugins in plugin_list_results)
-        total = len(modules) + len(roles_raw) + plugin_count
+        total = len(modules) + len(galaxy_batch_modules) + len(roles_raw) + plugin_count
         succeeded = 0
         failed = 0
         current = 0
@@ -1161,6 +1174,21 @@ async def generate_collection_skills(
                 succeeded += 1
             except Exception as exc:
                 logger.warning("Module skill generation failed for %s: %s", module_name, exc)
+                failed += 1
+
+        # Generate module skills from Galaxy batch (when not installed locally)
+        for module_fqcn, module_meta in sorted(galaxy_batch_modules.items()):
+            if ctx:
+                await ctx.report_progress(progress=current, total=total)
+            current += 1
+            try:
+                metadata_list.append(module_meta)
+                short_name = module_fqcn.rsplit(".", 1)[-1]
+                output_dir = base_dir / collection_namespace / short_name
+                await run_in_executor(skills.write_module_skill_package, output_dir, module_meta)
+                succeeded += 1
+            except Exception as exc:
+                logger.warning("Module skill generation failed for %s: %s", module_fqcn, exc)
                 failed += 1
 
         # Generate role skills

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -331,6 +331,25 @@ class ClearCacheResult(TypedDict):
     cleared: list[str]
 
 
+class _CollectionDocsResultBase(TypedDict):
+    """Required fields for batch collection docs result."""
+
+    modules: dict[str, ModuleMetadata]
+    doc_source: str
+
+
+class CollectionDocsResult(_CollectionDocsResultBase, total=False):
+    """Result of resolve_collection_module_docs / get_collection_docs.
+
+    When doc_source is 'galaxy', includes doc_version and optionally
+    doc_warning/doc_source_server.
+    """
+
+    doc_version: str
+    doc_warning: str
+    doc_source_server: str
+
+
 class GalaxyDocClient(Protocol):
     """Structural interface for Galaxy documentation clients.
 
@@ -350,6 +369,10 @@ class GalaxyDocClient(Protocol):
     async def fetch_plugin_doc(
         self, plugin_name: str, plugin_type: str,
     ) -> tuple[dict[str, Any], DocProvenance]: ...
+
+    async def fetch_collection_docs(
+        self, collection_namespace: str, version: str | None = None,
+    ) -> tuple[dict[str, ModuleMetadata], DocProvenance]: ...
 
     async def search_collections(
         self, query: str, tags: str | None = None,

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -611,6 +611,56 @@ class TestFetchCollectionDocs:
         with pytest.raises(GalaxyError, match="not a valid collection FQCN"):
             await client.fetch_collection_docs("just_one_part")
 
+    @pytest.mark.asyncio
+    async def test_silences_individual_module_failures(self, caplog):
+        """Individual module extraction failures are logged and skipped."""
+        blob_with_bad_module = {
+            "docs_blob": {
+                "contents": [
+                    {
+                        "content_type": "module",
+                        "content_name": "good_module",
+                        "doc_strings": {
+                            "doc": {
+                                "short_description": "A good module",
+                                "description": [],
+                                "options": [],
+                                "author": [],
+                                "notes": [],
+                                "version_added": "0.1.0",
+                            },
+                            "examples": "",
+                            "return": [],
+                            "metadata": {},
+                        },
+                    },
+                    {
+                        "content_type": "module",
+                        "content_name": "bad_module",
+                        "doc_strings": None,  # Will cause extraction to fail
+                    },
+                ],
+            },
+        }
+
+        async def mock_api_get(self_client, path, params=None, timeout=None):
+            if "versions/" in path and "docs-blob" not in path:
+                return SAMPLE_VERSIONS_RESPONSE
+            if "docs-blob" in path:
+                return blob_with_bad_module
+            return {}
+
+        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+            client = GalaxyClient()
+            import logging
+            with caplog.at_level(logging.WARNING, logger="ansible_know"):
+                docs, meta = await client.fetch_collection_docs("netbox.netbox")
+
+        assert "netbox.netbox.good_module" in docs
+        assert "netbox.netbox.bad_module" not in docs
+        assert len(docs) == 1
+        assert any("bad_module" in r.message and "metadata extraction failed" in r.message for r in caplog.records)
+
 
 class TestListCollectionModules:
     @pytest.mark.asyncio

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -541,6 +541,77 @@ class TestFetchModuleDoc:
         assert "param1" in options
 
 
+class TestFetchCollectionDocs:
+    @pytest.mark.asyncio
+    async def test_returns_all_module_docs(self):
+        """Batch extracts docs for every module in the blob."""
+        async def mock_api_get(self_client, path, params=None, timeout=None):
+            if "versions/" in path and "docs-blob" not in path:
+                return SAMPLE_VERSIONS_RESPONSE
+            if "docs-blob" in path:
+                return SAMPLE_DOCS_BLOB
+            return {}
+
+        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+            client = GalaxyClient()
+            docs, meta = await client.fetch_collection_docs("netbox.netbox")
+
+        assert "netbox.netbox.netbox_device" in docs
+        assert "netbox.netbox.netbox_site" in docs
+        assert len(docs) == 2  # only modules, not inventory plugin
+        assert docs["netbox.netbox.netbox_device"]["module_name"] == "netbox.netbox.netbox_device"
+        assert docs["netbox.netbox.netbox_device"]["short_description"] == "Create, update or delete devices"
+        assert meta["doc_source"] == "galaxy"
+        assert meta["doc_version"] == "3.23.0"
+
+    @pytest.mark.asyncio
+    async def test_with_explicit_version(self):
+        """Explicit version skips latest_version lookup and omits warning."""
+        async def mock_api_get(self_client, path, params=None, timeout=None):
+            if "docs-blob" in path:
+                assert "3.20.0" in path
+                return SAMPLE_DOCS_BLOB
+            return {}
+
+        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+            client = GalaxyClient()
+            docs, meta = await client.fetch_collection_docs(
+                "netbox.netbox", version="3.20.0",
+            )
+
+        assert meta["doc_version"] == "3.20.0"
+        assert "doc_warning" not in meta
+
+    @pytest.mark.asyncio
+    async def test_empty_collection_returns_empty_dict(self):
+        """Collection with no modules returns empty dict, not error."""
+        empty_blob = {"docs_blob": {"contents": [
+            {"content_type": "inventory", "content_name": "nb_inventory",
+             "doc_strings": {"doc": {"short_description": "Inv plugin"}, "examples": "", "return": [], "metadata": {}}},
+        ]}}
+
+        async def mock_api_get(self_client, path, params=None, timeout=None):
+            if "versions/" in path and "docs-blob" not in path:
+                return SAMPLE_VERSIONS_RESPONSE
+            if "docs-blob" in path:
+                return empty_blob
+            return {}
+
+        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+            client = GalaxyClient()
+            docs, meta = await client.fetch_collection_docs("netbox.netbox")
+
+        assert docs == {}
+        assert meta["doc_source"] == "galaxy"
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_namespace(self):
+        """Namespace must be namespace.name format."""
+        client = GalaxyClient()
+        with pytest.raises(GalaxyError, match="not a valid collection FQCN"):
+            await client.fetch_collection_docs("just_one_part")
+
+
 class TestListCollectionModules:
     @pytest.mark.asyncio
     async def test_lists_modules_only(self):

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from ansible_know.errors import CollectionNotFoundError
+from ansible_know.errors import CollectionNotFoundError, GalaxyError
 from ansible_know.galaxy import GalaxyClient
 from ansible_know.resolution import discover_collection_plugins, resolve_plugin_doc
 from tests.conftest import SAMPLE_MODULE_DOC, SAMPLE_ROLE_DOC
@@ -477,3 +477,90 @@ class TestResolvePluginDoc:
         assert result["content_type"] == "plugin"
         assert result["plugin_type"] == "lookup"
         assert "params" in result
+
+
+class TestResolveCollectionModuleDocs:
+    """Tests for resolve_collection_module_docs batch resolution."""
+
+    @pytest.mark.asyncio
+    async def test_returns_galaxy_docs(self, missing):
+        """Batch fetch via Galaxy returns all module docs."""
+        from ansible_know.resolution import resolve_collection_module_docs
+
+        sample_modules = {
+            "netbox.netbox.netbox_device": {
+                "module_name": "netbox.netbox.netbox_device",
+                "short_description": "Create, update or delete devices",
+                "params": [],
+                "examples": "",
+                "is_api_module": True,
+            },
+        }
+        galaxy_meta = {"doc_source": "galaxy", "doc_version": "3.23.0"}
+
+        with patch(
+            "ansible_know.galaxy.GalaxyClient.fetch_collection_docs",
+            new_callable=AsyncMock,
+            return_value=(sample_modules, galaxy_meta),
+        ):
+            result = await resolve_collection_module_docs(
+                "netbox.netbox",
+                galaxy_servers=[],
+                client_factory=FACTORY,
+                missing_collections=missing,
+            )
+
+        assert result["doc_source"] == "galaxy"
+        assert "netbox.netbox.netbox_device" in result["modules"]
+        assert result["doc_version"] == "3.23.0"
+
+    @pytest.mark.asyncio
+    async def test_galaxy_failure_returns_error(self, missing):
+        """When Galaxy fails, returns error response."""
+        from ansible_know.resolution import resolve_collection_module_docs
+
+        with patch(
+            "ansible_know.galaxy.GalaxyClient.fetch_collection_docs",
+            new_callable=AsyncMock,
+            side_effect=GalaxyError("Connection failed"),
+        ):
+            result = await resolve_collection_module_docs(
+                "netbox.netbox",
+                galaxy_servers=[],
+                client_factory=FACTORY,
+                missing_collections=missing,
+            )
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_no_factory_returns_error(self, missing):
+        """Without client_factory, returns error immediately."""
+        from ansible_know.resolution import resolve_collection_module_docs
+
+        result = await resolve_collection_module_docs(
+            "netbox.netbox",
+            missing_collections=missing,
+        )
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_passes_version_through(self, missing):
+        """Explicit version is forwarded to Galaxy client."""
+        from ansible_know.resolution import resolve_collection_module_docs
+
+        with patch(
+            "ansible_know.galaxy.GalaxyClient.fetch_collection_docs",
+            new_callable=AsyncMock,
+            return_value=({}, {"doc_source": "galaxy", "doc_version": "3.20.0"}),
+        ) as mock_fetch:
+            await resolve_collection_module_docs(
+                "netbox.netbox",
+                version="3.20.0",
+                galaxy_servers=[],
+                client_factory=FACTORY,
+                missing_collections=missing,
+            )
+
+        mock_fetch.assert_called_once_with("netbox.netbox", version="3.20.0")

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -507,7 +507,6 @@ class TestResolveCollectionModuleDocs:
                 "netbox.netbox",
                 galaxy_servers=[],
                 client_factory=FACTORY,
-                missing_collections=missing,
             )
 
         assert result["doc_source"] == "galaxy"
@@ -528,7 +527,6 @@ class TestResolveCollectionModuleDocs:
                 "netbox.netbox",
                 galaxy_servers=[],
                 client_factory=FACTORY,
-                missing_collections=missing,
             )
 
         assert "error" in result
@@ -540,7 +538,6 @@ class TestResolveCollectionModuleDocs:
 
         result = await resolve_collection_module_docs(
             "netbox.netbox",
-            missing_collections=missing,
         )
 
         assert "error" in result
@@ -560,7 +557,6 @@ class TestResolveCollectionModuleDocs:
                 version="3.20.0",
                 galaxy_servers=[],
                 client_factory=FACTORY,
-                missing_collections=missing,
             )
 
         mock_fetch.assert_called_once_with("netbox.netbox", version="3.20.0")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -235,6 +235,51 @@ class TestGenerateCollectionSkillsTool:
         assert result["collection_skill"] == "ansible.builtin"
         assert (tmp_path / "ansible.builtin" / "SKILL.md").exists()
 
+    @pytest.mark.asyncio
+    async def test_galaxy_batch_fallback(self, tmp_path, mock_ansible_doc, monkeypatch):
+        """When search_modules returns empty, falls back to Galaxy batch fetch."""
+        # search_modules returns empty (collection not installed)
+        # list_roles returns empty
+        # 14 plugin types return empty
+        responses = [
+            json.dumps({}),  # search_modules — empty
+            json.dumps({}),  # list_roles — empty
+        ]
+        responses.extend([json.dumps({})] * 14)  # 14 plugin types
+
+        mock_ansible_doc.side_effect = responses
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+
+        sample_batch = {
+            "netbox.netbox.netbox_device": {
+                "module_name": "netbox.netbox.netbox_device",
+                "short_description": "Create, update or delete devices",
+                "params": [{"name": "data", "type": "dict", "required": True,
+                            "default": None, "choices": None,
+                            "description": "Device data", "aliases": []}],
+                "examples": "- name: Create\n  netbox.netbox.netbox_device:\n    data: {}\n",
+                "is_api_module": True,
+            },
+        }
+
+        with patch(
+            "ansible_know.resolution.resolve_collection_module_docs",
+            new_callable=AsyncMock,
+            return_value={
+                "modules": sample_batch,
+                "doc_source": "galaxy",
+                "doc_version": "3.23.0",
+            },
+        ):
+            from ansible_know.server import generate_collection_skills
+            result = await generate_collection_skills(
+                "netbox.netbox", install_to=str(tmp_path),
+            )
+
+        assert result["total"] == 1
+        assert result["succeeded"] == 1
+        assert (tmp_path / "netbox.netbox" / "netbox_device" / "SKILL.md").exists()
+
 
 class TestFQCNValidation:
     @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1888,3 +1888,48 @@ class TestResourceSkillsListPlugins:
             result = json.loads(resource_skills_list())
         assert "netbox.netbox.nb_lookup" in result
         assert "netbox.netbox.lookup__nb_lookup" not in result
+
+
+class TestGetCollectionDocsTool:
+    @pytest.mark.asyncio
+    async def test_returns_batch_docs(self, mock_ansible_doc):
+        from ansible_know.server import get_collection_docs
+
+        sample_result = {
+            "modules": {
+                "netbox.netbox.netbox_device": {
+                    "module_name": "netbox.netbox.netbox_device",
+                    "short_description": "Create, update or delete devices",
+                    "params": [],
+                    "examples": "",
+                    "is_api_module": True,
+                },
+            },
+            "doc_source": "galaxy",
+            "doc_version": "3.23.0",
+        }
+
+        with patch(
+            "ansible_know.resolution.resolve_collection_module_docs",
+            new_callable=AsyncMock,
+            return_value=sample_result,
+        ):
+            result = await get_collection_docs("netbox.netbox")
+
+        assert "modules" in result
+        assert "netbox.netbox.netbox_device" in result["modules"]
+        assert result["doc_source"] == "galaxy"
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_namespace(self):
+        from ansible_know.server import get_collection_docs
+
+        result = await get_collection_docs("invalid")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_rejects_fqcn_with_three_parts(self):
+        from ansible_know.server import get_collection_docs
+
+        result = await get_collection_docs("a.b.c")
+        assert "error" in result


### PR DESCRIPTION
## Summary

- Add `GalaxyClient.fetch_collection_docs()` — fetches docs-blob once and extracts all module docs in a single pass, returning `dict[str, ModuleMetadata]` keyed by FQCN
- Add `resolve_collection_module_docs()` in resolution.py — wraps the Galaxy call with multi-server fallback
- Add `get_collection_docs` MCP tool — returns all module documentation for a collection from Galaxy without installing it
- Integrate batch path into `generate_collection_skills` — when a collection is not installed locally, falls back to batch Galaxy fetch instead of failing

## Motivation

`generate_collection_skills` for a 200-module collection made 200 separate `fetch_module_doc` calls. Even with blob caching, this re-looked up the same cached blob 199 times. The batch method fetches once and extracts all modules in one pass.

## Test plan

- [x] Unit tests for `fetch_collection_docs` (4 tests: batch extraction, explicit version, empty collection, invalid namespace)
- [x] Unit test for silent failure path with `exc_info` logging
- [x] Unit tests for `resolve_collection_module_docs` (4 tests: success, Galaxy failure, no factory, version passthrough)
- [x] Unit tests for `get_collection_docs` tool (3 tests: batch docs, invalid namespace, FQCN rejection)
- [x] Unit test for Galaxy batch fallback in `generate_collection_skills`
- [x] All 675 existing tests pass, 0 regressions
- [x] `ruff check src/ tests/` clean

Closes #85

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>