### PR TITLE
fix: improve search_docs matching and RTD fallback diversity

### DIFF
--- a/src/ansible_know/config.py
+++ b/src/ansible_know/config.py
@@ -29,6 +29,7 @@ AUDIENCE_MAP: dict[str, str] = {
     "getting_started": "author",
     "getting_started_ee": "author",
     "vault_guide": "author",
+    "plugins": "both",
     "tips_tricks": "author",
     "command_guide": "author",
 }
@@ -47,6 +48,7 @@ GUIDE_TOPIC_PREFIXES: set[str] = {
     "tips_tricks",
     "network",
     "os_guide",
+    "plugins",
     "scenario_guides",
     "user_guide",
     "community",

--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from itertools import zip_longest
 from pathlib import Path
 from typing import Any
 
@@ -222,12 +223,10 @@ async def _search_rtd_api(
                 per_source.append(hits)
             elif isinstance(hits, BaseException):
                 logger.debug("RTD search failed for one project: %s", hits)
-        results: list[SearchDocsEntry] = []
-        max_len = max((len(s) for s in per_source), default=0)
-        for i in range(max_len):
-            for source_hits in per_source:
-                if i < len(source_hits):
-                    results.append(source_hits[i])
+        results: list[SearchDocsEntry] = [
+            hit for group in zip_longest(*per_source)
+            for hit in group if hit is not None
+        ]
     finally:
         if should_close:
             await client.aclose()

--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -216,12 +216,18 @@ async def _search_rtd_api(
             *[_search_one(name, slug) for name, slug in slugs_to_search],
             return_exceptions=True,
         )
-        results: list[SearchDocsEntry] = []
+        per_source: list[list[SearchDocsEntry]] = []
         for hits in all_hits:
             if isinstance(hits, list):
-                results.extend(hits)
+                per_source.append(hits)
             elif isinstance(hits, BaseException):
                 logger.debug("RTD search failed for one project: %s", hits)
+        results: list[SearchDocsEntry] = []
+        max_len = max((len(s) for s in per_source), default=0)
+        for i in range(max_len):
+            for source_hits in per_source:
+                if i < len(source_hits):
+                    results.append(source_hits[i])
     finally:
         if should_close:
             await client.aclose()
@@ -252,6 +258,7 @@ async def search_docs(
     """
     sources = get_doc_sources()
     query_lower = query.lower()
+    query_words = query_lower.split()
     results: list[SearchDocsEntry] = []
     has_filters = bool(topic or audience or core_only)
     manifest_had_entries = False
@@ -289,7 +296,7 @@ async def search_docs(
             topics_str = " ".join(t.lower() for t in entry_topics)
             searchable = f"{title} {summary} {topics_str}"
 
-            if query_lower in searchable:
+            if all(w in searchable for w in query_words):
                 results.append({
                     "title": entry.get("title", ""),
                     "summary": entry.get("summary", ""),

--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -46,11 +46,24 @@ _manifest_cache: BoundedCache[str, list[dict[str, Any]]] = BoundedCache(
 def _postprocess_entries(
     entries: list[dict[str, Any]], source_name: str, base_url: str,
 ) -> list[dict[str, Any]]:
-    """Add _source tag and construct URLs from base_url + path."""
+    """Add _source tag, construct URLs, and precompute lowercase fields."""
     for entry in entries:
         entry["_source"] = source_name
         if "url" not in entry and "path" in entry and base_url:
             entry["url"] = f"{base_url.rstrip('/')}/{entry['path'].lstrip('/')}"
+        topics = entry.get("topics", entry.get("topic", []))
+        if isinstance(topics, str):
+            topics = [topics]
+        entry["_topics"] = topics
+        aud = entry.get("audience", [])
+        if isinstance(aud, str):
+            aud = [aud]
+        entry["_audience"] = aud
+        entry["_searchable"] = "{} {} {}".format(
+            entry.get("title", "").lower(),
+            entry.get("summary", "").lower(),
+            " ".join(t.lower() for t in topics),
+        )
     return entries
 
 
@@ -278,10 +291,10 @@ async def search_docs(
             if core_only and not entry.get("core", False):
                 continue
 
-            entry_topics = entry.get("topics", entry.get("topic", []))
+            entry_topics = entry.get("_topics", entry.get("topics", entry.get("topic", [])))
             if isinstance(entry_topics, str):
                 entry_topics = [entry_topics]
-            entry_audience = entry.get("audience", [])
+            entry_audience = entry.get("_audience", entry.get("audience", []))
             if isinstance(entry_audience, str):
                 entry_audience = [entry_audience]
 
@@ -290,10 +303,13 @@ async def search_docs(
             if audience and audience.lower() not in [a.lower() for a in entry_audience]:
                 continue
 
-            title = entry.get("title", "").lower()
-            summary = entry.get("summary", "").lower()
-            topics_str = " ".join(t.lower() for t in entry_topics)
-            searchable = f"{title} {summary} {topics_str}"
+            searchable = entry.get("_searchable", "")
+            if not searchable:
+                searchable = "{} {} {}".format(
+                    entry.get("title", "").lower(),
+                    entry.get("summary", "").lower(),
+                    " ".join(t.lower() for t in entry_topics),
+                )
 
             if all(w in searchable for w in query_words):
                 results.append({

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,7 +47,7 @@ class TestDocCurationConfig:
     def test_audience_map_has_entries(self):
         from ansible_know.config import AUDIENCE_MAP
         assert isinstance(AUDIENCE_MAP, dict)
-        assert len(AUDIENCE_MAP) == 8
+        assert len(AUDIENCE_MAP) == 9
         assert AUDIENCE_MAP["dev_guide"] == "developer"
         assert AUDIENCE_MAP["playbook_guide"] == "author"
 
@@ -67,6 +67,7 @@ class TestDocCurationConfig:
         from ansible_know.config import GUIDE_TOPIC_PREFIXES
         assert isinstance(GUIDE_TOPIC_PREFIXES, set)
         assert "playbook_guide" in GUIDE_TOPIC_PREFIXES
+        assert "plugins" in GUIDE_TOPIC_PREFIXES
         assert "collections" not in GUIDE_TOPIC_PREFIXES
 
     def test_project_base_urls(self):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -452,6 +452,31 @@ class TestTokenizedSearch:
         assert results[0]["title"] == "no-handler"
 
     @pytest.mark.asyncio
+    async def test_source_key_not_searchable(self, tmp_path):
+        """Source dict key name (e.g. 'lint') must not be part of searchable text."""
+        manifest = {
+            "version": "2.0",
+            "base_url": "https://docs.example.com",
+            "files": [
+                {
+                    "path": "rules/no-handler.html",
+                    "topic": "rules",
+                    "title": "no-handler",
+                    "summary": "Use handlers instead of when: result.changed",
+                    "audience": "author",
+                    "lines": 50,
+                },
+            ],
+        }
+        p_file = tmp_path / "tok_manifest.json"
+        p_file.write_text(json.dumps(manifest))
+        sources = {"lint": {"file": str(p_file), "description": "Lint"}}
+        with patch("ansible_know.docs.get_doc_sources", return_value=sources), \
+             patch("ansible_know.docs._search_rtd_api", new_callable=AsyncMock, return_value=[]):
+            results = await search_docs("lint rules")
+        assert results == []
+
+    @pytest.mark.asyncio
     async def test_single_word_still_works(self, file_sources):
         results = await search_docs("playbook")
         assert len(results) == 1

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -419,6 +419,92 @@ class TestSearchRtdApi:
         assert len(results) <= 5
 
 
+class TestTokenizedSearch:
+    @pytest.mark.asyncio
+    async def test_multi_word_matches_across_fields(self, file_sources):
+        """Words from different fields (title + summary) should match."""
+        results = await search_docs("precedence rules")
+        assert len(results) == 1
+        assert results[0]["title"] == "Variable Precedence"
+
+    @pytest.mark.asyncio
+    async def test_multi_word_matches_title_and_topic(self, tmp_path):
+        manifest = {
+            "version": "2.0",
+            "base_url": "https://docs.example.com",
+            "files": [
+                {
+                    "path": "rules/no-handler.html",
+                    "topic": "rules",
+                    "title": "no-handler",
+                    "summary": "Use handlers instead of when: result.changed",
+                    "audience": "author",
+                    "lines": 50,
+                },
+            ],
+        }
+        p_file = tmp_path / "tok_manifest.json"
+        p_file.write_text(json.dumps(manifest))
+        sources = {"lint": {"file": str(p_file), "description": "Lint"}}
+        with patch("ansible_know.docs.get_doc_sources", return_value=sources):
+            results = await search_docs("handler rules")
+        assert len(results) == 1
+        assert results[0]["title"] == "no-handler"
+
+    @pytest.mark.asyncio
+    async def test_single_word_still_works(self, file_sources):
+        results = await search_docs("playbook")
+        assert len(results) == 1
+        assert results[0]["title"] == "Introduction Guide"
+
+    @pytest.mark.asyncio
+    async def test_word_order_does_not_matter(self, file_sources):
+        r1 = await search_docs("precedence variable")
+        r2 = await search_docs("variable precedence")
+        assert len(r1) == len(r2) == 1
+        assert r1[0]["title"] == r2[0]["title"]
+
+
+class TestRtdInterleave:
+    @pytest.mark.asyncio
+    async def test_interleaves_across_sources(self):
+        """Results from multiple sources should be interleaved, not concatenated."""
+        source_a_hits = [
+            {"title": f"A{i}", "path": f"/a{i}.html", "domain": "https://docs.ansible.com", "blocks": []}
+            for i in range(5)
+        ]
+        source_b_hits = [
+            {"title": f"B{i}", "path": f"/b{i}.html", "domain": "https://docs.ansible.com", "blocks": []}
+            for i in range(5)
+        ]
+
+        call_count = 0
+
+        async def mock_get(*args, **kwargs):
+            nonlocal call_count
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.raise_for_status = MagicMock()
+            if call_count == 0:
+                mock_resp.json.return_value = {"results": source_a_hits}
+            else:
+                mock_resp.json.return_value = {"results": source_b_hits}
+            call_count += 1
+            return mock_resp
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        slugs = {"source-a": "slug-a", "source-b": "slug-b"}
+        with patch("ansible_know.docs.RTD_PROJECT_SLUGS", slugs):
+            results = await _search_rtd_api("test", limit=10, http_client=mock_client)
+
+        sources = [r["source"] for r in results]
+        assert "rtd-search:source-a" in sources
+        assert "rtd-search:source-b" in sources
+        assert results[0]["source"] != results[1]["source"]
+
+
 class TestSearchDocsFallback:
     @pytest.mark.asyncio
     async def test_falls_back_to_rtd_when_manifest_empty(self):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -419,6 +419,32 @@ class TestSearchRtdApi:
         assert len(results) <= 5
 
 
+LINT_MANIFEST = {
+    "version": "2.0",
+    "base_url": "https://docs.example.com",
+    "files": [
+        {
+            "path": "rules/no-handler.html",
+            "topic": "rules",
+            "title": "no-handler",
+            "summary": "Use handlers instead of when: result.changed",
+            "audience": "author",
+            "lines": 50,
+        },
+    ],
+}
+
+
+@pytest.fixture
+def lint_sources(tmp_path):
+    """Patch get_doc_sources to return a lint-like single-entry manifest."""
+    p_file = tmp_path / "lint_manifest.json"
+    p_file.write_text(json.dumps(LINT_MANIFEST))
+    sources = {"lint": {"file": str(p_file), "description": "Lint"}}
+    with patch("ansible_know.docs.get_doc_sources", return_value=sources):
+        yield
+
+
 class TestTokenizedSearch:
     @pytest.mark.asyncio
     async def test_multi_word_matches_across_fields(self, file_sources):
@@ -428,51 +454,15 @@ class TestTokenizedSearch:
         assert results[0]["title"] == "Variable Precedence"
 
     @pytest.mark.asyncio
-    async def test_multi_word_matches_title_and_topic(self, tmp_path):
-        manifest = {
-            "version": "2.0",
-            "base_url": "https://docs.example.com",
-            "files": [
-                {
-                    "path": "rules/no-handler.html",
-                    "topic": "rules",
-                    "title": "no-handler",
-                    "summary": "Use handlers instead of when: result.changed",
-                    "audience": "author",
-                    "lines": 50,
-                },
-            ],
-        }
-        p_file = tmp_path / "tok_manifest.json"
-        p_file.write_text(json.dumps(manifest))
-        sources = {"lint": {"file": str(p_file), "description": "Lint"}}
-        with patch("ansible_know.docs.get_doc_sources", return_value=sources):
-            results = await search_docs("handler rules")
+    async def test_multi_word_matches_title_and_topic(self, lint_sources):
+        results = await search_docs("handler rules")
         assert len(results) == 1
         assert results[0]["title"] == "no-handler"
 
     @pytest.mark.asyncio
-    async def test_source_key_not_searchable(self, tmp_path):
+    async def test_source_key_not_searchable(self, lint_sources):
         """Source dict key name (e.g. 'lint') must not be part of searchable text."""
-        manifest = {
-            "version": "2.0",
-            "base_url": "https://docs.example.com",
-            "files": [
-                {
-                    "path": "rules/no-handler.html",
-                    "topic": "rules",
-                    "title": "no-handler",
-                    "summary": "Use handlers instead of when: result.changed",
-                    "audience": "author",
-                    "lines": 50,
-                },
-            ],
-        }
-        p_file = tmp_path / "tok_manifest.json"
-        p_file.write_text(json.dumps(manifest))
-        sources = {"lint": {"file": str(p_file), "description": "Lint"}}
-        with patch("ansible_know.docs.get_doc_sources", return_value=sources), \
-             patch("ansible_know.docs._search_rtd_api", new_callable=AsyncMock, return_value=[]):
+        with patch("ansible_know.docs._search_rtd_api", new_callable=AsyncMock, return_value=[]):
             results = await search_docs("lint rules")
         assert results == []
 


### PR DESCRIPTION
## Summary

- Switch manifest search from substring to tokenized AND matching so multi-word queries like "playbook variables" or "lint rules" match entries where words appear across different fields (title, summary, topic).
- Interleave RTD fallback results round-robin across sources instead of concatenating in insertion order, so ansible-core no longer crowds out other sources within the result limit.
- Add "plugins" to `GUIDE_TOPIC_PREFIXES` and `AUDIENCE_MAP` so plugin reference pages (inventory, vars, cache, etc.) are indexed in the ansible-core manifest on next rebuild.

Fixes #138, fixes #139.

## Test plan

- [ ] Verify `search_docs("playbook variables")` returns manifest hits (not RTD fallback)
- [ ] Verify `search_docs("ansible-lint rules")` returns lint manifest hits
- [ ] Verify `search_docs("handlers")` still works (single-word, no regression)
- [ ] Verify RTD fallback interleaves sources when manifest misses
- [ ] Rebuild manifests and verify plugins/ pages are included
- [ ] All 667 unit tests pass, ruff clean

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>