### PR TITLE
fix: bypass Galaxy CLI cache in ensure_collection

### DIFF
--- a/src/ansible_know/collections.py
+++ b/src/ansible_know/collections.py
@@ -119,7 +119,7 @@ class CollectionManager:
             galaxy = _find_ansible_galaxy()
 
             collection_spec = f"{collection_fqcn}:=={version}" if version else collection_fqcn
-            cmd = [galaxy, "collection", "install", collection_spec, "-p", tmpdir, "--force"]
+            cmd = [galaxy, "collection", "install", collection_spec, "-p", tmpdir, "--force", "--no-cache"]
 
             with self._install_gate:
                 try:

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -113,6 +113,14 @@ class TestEnsureCollectionInstalls:
         assert result["status"] == "already_installed"
         mock_run.assert_not_called()
 
+    def test_passes_no_cache_flag(self, mgr):
+        galaxy_stdout = "Installing 'netbox.netbox:4.1.0' to '<path>'\nnetbox.netbox:4.1.0 was installed successfully"
+        with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
+            with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout)) as mock_run:
+                mgr.ensure_collection("netbox.netbox")
+        args = mock_run.call_args[0][0]
+        assert "--no-cache" in args
+
     def test_reinstalls_different_version(self, mgr):
         galaxy_stdout_1 = "Installing 'netbox.netbox:3.9.0' to '<path>'\nnetbox.netbox:3.9.0 was installed successfully"
         galaxy_stdout_2 = "Installing 'netbox.netbox:4.0.0' to '<path>'\nnetbox.netbox:4.0.0 was installed successfully"


### PR DESCRIPTION
## Summary

- Add `--no-cache` to the `ansible-galaxy collection install` subprocess command
- Works around upstream ansible-core bug ([#85918](https://github.com/ansible/ansible/issues/85918)) where the Galaxy API response cache gets corrupted, causing `Missing expected 'results'` errors
- Since `ensure_collection` installs to a process-scoped temp directory, Galaxy CLI response caching provides zero benefit
- Does NOT affect ansible-know's own `BoundedCache` (PR #142) which caches doc lookups via httpx — these are completely separate cache systems

## Context

The Galaxy CLI cache at `~/.ansible/galaxy_cache/api.json` can get corrupted due to an upstream bug where the in-memory cache is updated before results are available. [PR #85972](https://github.com/ansible/ansible/pull/85972) (merged Oct 2025) improved the error message but did not fix the root cause. [PR #86186](https://github.com/ansible/ansible/pull/86186) addresses the root cause but is still open.

Reproduced in the ansible devcontainer (community-ansible-dev-tools:latest, ansible-core 2.21.1).

## Test plan

- [x] Added `test_passes_no_cache_flag` verifying `--no-cache` is present in subprocess args
- [x] All 19 collection tests pass (18 existing + 1 new)
- [x] Ruff lint clean
- [ ] Integration: run `ensure_collection` with `netbox.netbox` in devcontainer — should succeed without cache errors

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>