### PR TITLE
feat: agentskills.io spec compliance for generated skills

### DIFF
--- a/src/ansible_know/collection_manifest.py
+++ b/src/ansible_know/collection_manifest.py
@@ -47,18 +47,24 @@ def generate_manifest(
     Returns:
         The manifest dict.
     """
+    from ansible_know.skills import (  # noqa: I001
+        collection_skill_name,
+        fqcn_to_skill_name,
+        plugin_skill_name as _plugin_skill_name,
+        role_skill_name as _role_skill_name,
+    )
+
     if skills_dir is None:
         skills_dir = SKILLS_DIR
 
-    collection_dir = skills_dir / collection_namespace
+    collection_dir = skills_dir / collection_skill_name(collection_namespace)
 
     modules_list = []
     for meta in modules_metadata:
         fqcn = meta["module_name"]
         params = meta["params"]
         required_params = [p["name"] for p in params if p.get("required")]
-        short_name = fqcn.rsplit(".", 1)[-1]
-        has_skill = (collection_dir / short_name / "SKILL.md").exists()
+        has_skill = (collection_dir / fqcn_to_skill_name(fqcn) / "SKILL.md").exists()
 
         modules_list.append({
             "fqcn": fqcn,
@@ -73,8 +79,7 @@ def generate_manifest(
     roles_list = []
     for role_meta in (roles_metadata or []):
         fqcn = role_meta["fqcn"]
-        short_name = fqcn.rsplit(".", 1)[-1]
-        has_skill = (collection_dir / short_name / "SKILL.md").exists()
+        has_skill = (collection_dir / _role_skill_name(fqcn) / "SKILL.md").exists()
 
         roles_list.append({
             "fqcn": fqcn,
@@ -88,8 +93,7 @@ def generate_manifest(
     for plugin_meta in (plugins_metadata or []):
         fqcn = plugin_meta["fqcn"]
         ptype = plugin_meta["plugin_type"]
-        short_name = fqcn.rsplit(".", 1)[-1]
-        skill_path = (collection_dir / f"{ptype}__{short_name}" / "SKILL.md").resolve()
+        skill_path = (collection_dir / _plugin_skill_name(fqcn, ptype) / "SKILL.md").resolve()
         try:
             validate_path_containment(skill_path, skills_dir)
             has_skill = skill_path.exists()
@@ -136,10 +140,12 @@ def write_manifest(
         ValidationError: If the resolved path escapes ``skills_dir``.
         OSError: On permission or I/O errors.
     """
+    from ansible_know.skills import collection_skill_name
+
     if skills_dir is None:
         skills_dir = SKILLS_DIR
 
-    collection_dir = (skills_dir / collection_namespace).resolve()
+    collection_dir = (skills_dir / collection_skill_name(collection_namespace)).resolve()
     validate_path_containment(collection_dir, skills_dir)
     collection_dir.mkdir(parents=True, exist_ok=True)
     manifest_path = collection_dir / "MANIFEST.json"
@@ -159,10 +165,12 @@ def load_cached_manifest(
     Backfills plugin_count and plugins fields for cached manifests
     created before plugin support was added.
     """
+    from ansible_know.skills import collection_skill_name
+
     if skills_dir is None:
         skills_dir = SKILLS_DIR
 
-    manifest_path = skills_dir / collection_namespace / "MANIFEST.json"
+    manifest_path = skills_dir / collection_skill_name(collection_namespace) / "MANIFEST.json"
     if not manifest_path.exists():
         return None
 

--- a/src/ansible_know/collection_manifest.py
+++ b/src/ansible_know/collection_manifest.py
@@ -50,8 +50,8 @@ def generate_manifest(
     from ansible_know.skills import (  # noqa: I001
         collection_skill_name,
         fqcn_to_skill_name,
-        plugin_skill_name as _plugin_skill_name,
-        role_skill_name as _role_skill_name,
+        plugin_skill_name,
+        role_skill_name,
     )
 
     if skills_dir is None:
@@ -79,7 +79,7 @@ def generate_manifest(
     roles_list = []
     for role_meta in (roles_metadata or []):
         fqcn = role_meta["fqcn"]
-        has_skill = (collection_dir / _role_skill_name(fqcn) / "SKILL.md").exists()
+        has_skill = (collection_dir / role_skill_name(fqcn) / "SKILL.md").exists()
 
         roles_list.append({
             "fqcn": fqcn,
@@ -93,7 +93,7 @@ def generate_manifest(
     for plugin_meta in (plugins_metadata or []):
         fqcn = plugin_meta["fqcn"]
         ptype = plugin_meta["plugin_type"]
-        skill_path = (collection_dir / _plugin_skill_name(fqcn, ptype) / "SKILL.md").resolve()
+        skill_path = (collection_dir / plugin_skill_name(fqcn, ptype) / "SKILL.md").resolve()
         try:
             validate_path_containment(skill_path, skills_dir)
             has_skill = skill_path.exists()

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1334,19 +1334,30 @@ async def clear_cache(
 def resource_skills_list() -> str:
     import json
 
-    from ansible_know.config import SKILLS_DIR
+    from ansible_know.config import PLUGIN_TYPES, SKILLS_DIR
+    from ansible_know.skills import (
+        PLUGIN_SKILL_DIR_RE,
+        skill_dir_to_collection_fqcn,
+        skill_dir_to_short_fqcn,
+    )
 
     skills_list: list[str] = []
     if SKILLS_DIR.exists():
         for skill_dir in sorted(SKILLS_DIR.iterdir()):
             if not skill_dir.is_dir() or skill_dir.is_symlink():
                 continue
+            collection_fqcn = skill_dir_to_collection_fqcn(skill_dir.name)
             skill_md = skill_dir / "SKILL.md"
             if skill_md.exists():
-                skills_list.append(skill_dir.name)
+                skills_list.append(collection_fqcn)
             for sub_dir in sorted(skill_dir.iterdir()):
                 if sub_dir.is_dir() and not sub_dir.is_symlink() and (sub_dir / "SKILL.md").exists():
-                    skills_list.append(sub_dir.name)
+                    dir_name = sub_dir.name
+                    match = PLUGIN_SKILL_DIR_RE.match(dir_name)
+                    if match and match.group(1) in PLUGIN_TYPES:
+                        skills_list.append(f"{collection_fqcn}.{skill_dir_to_short_fqcn(match.group(2))}")
+                    else:
+                        skills_list.append(f"{collection_fqcn}.{skill_dir_to_short_fqcn(dir_name)}")
     return json.dumps(skills_list, indent=2)
 
 

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -923,10 +923,9 @@ async def generate_skill(
             await ctx.report_progress(progress=50, total=100)
 
         fqcn = metadata["module_name"]
-        namespace = extract_namespace(fqcn)
-        short_name = fqcn.rsplit(".", 1)[-1]
         base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
-        output_dir = base_dir / namespace / short_name
+        collection_dir = skills.collection_skill_name(extract_namespace(fqcn))
+        output_dir = base_dir / collection_dir / skills.fqcn_to_skill_name(fqcn)
 
         await run_in_executor(skills.write_module_skill_package, output_dir, metadata)
         logger.info("generate_skill wrote to %s", output_dir)
@@ -985,10 +984,9 @@ async def generate_role_skill(
         if ctx:
             await ctx.report_progress(progress=50, total=100)
 
-        namespace = extract_namespace(role_name)
-        short_name = role_name.rsplit(".", 1)[-1]
         base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
-        output_dir = base_dir / namespace / short_name
+        collection_dir = skills.collection_skill_name(extract_namespace(role_name))
+        output_dir = base_dir / collection_dir / skills.role_skill_name(role_name)
 
         await run_in_executor(skills.write_role_skill_package, output_dir, metadata)
         logger.info("generate_role_skill wrote to %s", output_dir)
@@ -1055,10 +1053,9 @@ async def generate_plugin_skill(
         if ctx:
             await ctx.report_progress(progress=50, total=100)
 
-        namespace = extract_namespace(plugin_name)
-        short_name = plugin_name.rsplit(".", 1)[-1]
         base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
-        output_dir = base_dir / namespace / f"{plugin_type}__{short_name}"
+        collection_dir = skills.collection_skill_name(extract_namespace(plugin_name))
+        output_dir = base_dir / collection_dir / skills.plugin_skill_name(plugin_name, plugin_type)
 
         await run_in_executor(skills.write_plugin_skill_package, output_dir, metadata)
         logger.info("generate_plugin_skill wrote to %s", output_dir)
@@ -1151,6 +1148,7 @@ async def generate_collection_skills(
         metadata_list = []
 
         base_dir = validate_install_path(install_to) if install_to else SKILLS_DIR
+        collection_dir_name = skills.collection_skill_name(collection_namespace)
 
         installed_version = state.collection_manager.list_installed().get(collection_namespace)
 
@@ -1166,8 +1164,7 @@ async def generate_collection_skills(
                 metadata = parser.extract_module_metadata(raw_doc)
                 metadata_list.append(metadata)
 
-                short_name = metadata["module_name"].rsplit(".", 1)[-1]
-                output_dir = base_dir / collection_namespace / short_name
+                output_dir = base_dir / collection_dir_name / skills.fqcn_to_skill_name(module_name)
                 await run_in_executor(skills.write_module_skill_package, output_dir, metadata)
                 succeeded += 1
             except Exception as exc:
@@ -1181,8 +1178,7 @@ async def generate_collection_skills(
             current += 1
             try:
                 metadata_list.append(module_meta)
-                short_name = module_fqcn.rsplit(".", 1)[-1]
-                output_dir = base_dir / collection_namespace / short_name
+                output_dir = base_dir / collection_dir_name / skills.fqcn_to_skill_name(module_fqcn)
                 await run_in_executor(skills.write_module_skill_package, output_dir, module_meta)
                 succeeded += 1
             except Exception as exc:
@@ -1221,8 +1217,7 @@ async def generate_collection_skills(
                     "entry_points": entry_points,
                 })
 
-                short_name = role_fqcn.rsplit(".", 1)[-1]
-                output_dir = base_dir / collection_namespace / short_name
+                output_dir = base_dir / collection_dir_name / skills.role_skill_name(role_fqcn)
                 await run_in_executor(
                     skills.write_role_skill_package, output_dir, role_meta,
                 )
@@ -1251,8 +1246,7 @@ async def generate_collection_skills(
                         "param_count": len(meta["params"]),
                     })
 
-                    short_name = pfqcn.rsplit(".", 1)[-1]
-                    output_dir = base_dir / collection_namespace / f"{ptype}__{short_name}"
+                    output_dir = base_dir / collection_dir_name / skills.plugin_skill_name(pfqcn, ptype)
                     await run_in_executor(
                         skills.write_plugin_skill_package, output_dir, meta,
                     )
@@ -1276,7 +1270,7 @@ async def generate_collection_skills(
 
         await run_in_executor(
             skills.write_collection_skill_package,
-            base_dir / collection_namespace, collection_namespace,
+            base_dir / collection_dir_name, collection_namespace,
             metadata_list, installed_version, plugins_metadata,
         )
 
@@ -1340,8 +1334,7 @@ async def clear_cache(
 def resource_skills_list() -> str:
     import json
 
-    from ansible_know.config import PLUGIN_TYPES, SKILLS_DIR
-    from ansible_know.skills import PLUGIN_SKILL_DIR_RE
+    from ansible_know.config import SKILLS_DIR
 
     skills_list: list[str] = []
     if SKILLS_DIR.exists():
@@ -1353,12 +1346,7 @@ def resource_skills_list() -> str:
                 skills_list.append(skill_dir.name)
             for sub_dir in sorted(skill_dir.iterdir()):
                 if sub_dir.is_dir() and not sub_dir.is_symlink() and (sub_dir / "SKILL.md").exists():
-                    dir_name = sub_dir.name
-                    match = PLUGIN_SKILL_DIR_RE.match(dir_name)
-                    if match and match.group(1) in PLUGIN_TYPES:
-                        skills_list.append(f"{skill_dir.name}.{match.group(2)}")
-                    else:
-                        skills_list.append(f"{skill_dir.name}.{dir_name}")
+                    skills_list.append(sub_dir.name)
     return json.dumps(skills_list, indent=2)
 
 

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -16,7 +16,11 @@ from typing import TYPE_CHECKING, Any
 
 from ansible_know.config import TEMPLATE_DIR
 from ansible_know.tagging import derive_tags
-from ansible_know.validation import truncate_response, validate_path_containment
+from ansible_know.validation import (
+    extract_namespace,
+    truncate_response,
+    validate_path_containment,
+)
 
 if TYPE_CHECKING:
     from ansible_know.types import (
@@ -41,6 +45,8 @@ __all__ = [
     "list_skills_sync",
     "module_to_skill_name",
     "plugin_skill_name",
+    "skill_dir_to_collection_fqcn",
+    "skill_dir_to_short_fqcn",
     "render_collection_skill",
     "render_module_skill",
     "render_plugin_skill",
@@ -98,15 +104,32 @@ def collection_skill_name(namespace: str) -> str:
     return _to_kebab(namespace)
 
 
+def skill_dir_to_collection_fqcn(kebab_dir: str) -> str:
+    """Reverse a kebab collection directory name to a collection FQCN.
+
+    Splits on the first hyphen: namespace becomes the dot separator,
+    remaining hyphens revert to underscores.
+    ``netbox-netbox`` → ``netbox.netbox``
+    ``fedora-linux-system-roles`` → ``fedora.linux_system_roles``
+    """
+    parts = kebab_dir.split("-", 1)
+    if len(parts) == 2:
+        return parts[0] + "." + parts[1].replace("-", "_")
+    return parts[0]
+
+
+def skill_dir_to_short_fqcn(kebab_dir: str) -> str:
+    """Reverse a kebab skill directory name to the original short name.
+
+    ``netbox-device`` → ``netbox_device``
+    """
+    return kebab_dir.replace("-", "_")
+
+
 def module_to_skill_name(module_name: str) -> str:
     """Convert a module FQCN to a skill directory name."""
     return fqcn_to_skill_name(module_name)
 
-
-def _extract_namespace(fqcn: str) -> str:
-    """Extract namespace (first two parts) from a FQCN."""
-    parts = fqcn.split(".")
-    return ".".join(parts[:2]) if len(parts) >= 3 else fqcn
 
 
 def _module_template_context(metadata: dict[str, Any]) -> dict[str, Any]:
@@ -114,7 +137,7 @@ def _module_template_context(metadata: dict[str, Any]) -> dict[str, Any]:
     fqcn = metadata["module_name"]
     params = metadata["params"]
     example_args = _build_example_args(params, metadata.get("examples", ""))
-    namespace = _extract_namespace(fqcn)
+    namespace = extract_namespace(fqcn) or fqcn
     return {
         "module_name": fqcn,
         "spec_name": fqcn_to_skill_name(fqcn),
@@ -219,9 +242,9 @@ def list_skills_sync(
                     from ansible_know.config import PLUGIN_TYPES
                     match = PLUGIN_SKILL_DIR_RE.match(dir_name)
                     if match and match.group(1) in PLUGIN_TYPES:
-                        display_name = f"{collection}.{match.group(2).replace('-', '_')}"
+                        display_name = f"{collection}.{skill_dir_to_short_fqcn(match.group(2))}"
                     else:
-                        display_name = f"{collection}.{dir_name.replace('-', '_')}"
+                        display_name = f"{collection}.{skill_dir_to_short_fqcn(dir_name)}"
                     results.append({
                         "name": display_name,
                         "description": extract_skill_description(skill_md),
@@ -341,7 +364,7 @@ def _extract_example_values(examples_yaml: str) -> dict[str, str]:
 def _role_template_context(metadata: dict[str, Any]) -> dict[str, Any]:
     """Build template context from role metadata."""
     fqcn = metadata["role_name"]
-    namespace = _extract_namespace(fqcn)
+    namespace = extract_namespace(fqcn) or fqcn
     return {
         "role_name": fqcn,
         "spec_name": role_skill_name(fqcn),
@@ -391,7 +414,7 @@ def _plugin_template_context(metadata: dict[str, Any]) -> dict[str, Any]:
     """Build template context from plugin metadata."""
     fqcn = metadata["plugin_name"]
     ptype = metadata["plugin_type"]
-    namespace = _extract_namespace(fqcn)
+    namespace = extract_namespace(fqcn) or fqcn
     return {
         "plugin_name": fqcn,
         "plugin_type": ptype,
@@ -474,6 +497,7 @@ def _collection_template_context(
 
     return {
         "collection_namespace": namespace,
+        "fqcn": namespace,
         "spec_name": collection_skill_name(namespace),
         "collection_version": collection_version,
         "modules_by_tag": modules_by_tag,

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -30,19 +30,23 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("ansible_know")
 
-PLUGIN_SKILL_DIR_RE = re.compile(r"^([a-z]+)__(.+)$")
+PLUGIN_SKILL_DIR_RE = re.compile(r"^([a-z]+)-(.+)$")
 
 __all__ = [
     "PLUGIN_SKILL_DIR_RE",
+    "collection_skill_name",
     "extract_skill_description",
+    "fqcn_to_skill_name",
     "get_skill_sync",
     "list_skills_sync",
     "module_to_skill_name",
+    "plugin_skill_name",
     "render_collection_skill",
     "render_module_skill",
     "render_plugin_skill",
     "render_role_skill",
     "render_skill",
+    "role_skill_name",
     "write_collection_skill_package",
     "write_module_skill_package",
     "write_plugin_skill_package",
@@ -64,24 +68,67 @@ def _get_template_env():
     )
 
 
+def _to_kebab(name: str) -> str:
+    """Convert underscores and dots to hyphens for spec-compliant naming."""
+    return name.replace("_", "-").replace(".", "-")
+
+
+def fqcn_to_skill_name(fqcn: str) -> str:
+    """Convert a module/role FQCN to a spec-compliant kebab-case skill name.
+
+    Takes the short name (after last dot) and converts underscores to hyphens.
+    """
+    short = fqcn.rsplit(".", 1)[-1]
+    return _to_kebab(short)
+
+
+def plugin_skill_name(fqcn: str, plugin_type: str) -> str:
+    """Convert a plugin FQCN to a spec-compliant skill name with type prefix."""
+    short = fqcn.rsplit(".", 1)[-1]
+    return f"{plugin_type}-{_to_kebab(short)}"
+
+
+def role_skill_name(fqcn: str) -> str:
+    """Convert a role FQCN to a spec-compliant kebab-case skill name."""
+    return fqcn_to_skill_name(fqcn)
+
+
+def collection_skill_name(namespace: str) -> str:
+    """Convert a collection namespace to a spec-compliant kebab-case skill name."""
+    return _to_kebab(namespace)
+
+
 def module_to_skill_name(module_name: str) -> str:
     """Convert a module FQCN to a skill directory name."""
-    return module_name
+    return fqcn_to_skill_name(module_name)
+
+
+def _extract_namespace(fqcn: str) -> str:
+    """Extract namespace (first two parts) from a FQCN."""
+    parts = fqcn.split(".")
+    return ".".join(parts[:2]) if len(parts) >= 3 else fqcn
 
 
 def _module_template_context(metadata: dict[str, Any]) -> dict[str, Any]:
     """Build the shared template context from module metadata."""
+    fqcn = metadata["module_name"]
     params = metadata["params"]
     example_args = _build_example_args(params, metadata.get("examples", ""))
+    namespace = _extract_namespace(fqcn)
     return {
-        "module_name": metadata["module_name"],
-        "skill_name": metadata["module_name"].rsplit(".", 1)[-1],
+        "module_name": fqcn,
+        "spec_name": fqcn_to_skill_name(fqcn),
+        "skill_name": fqcn.rsplit(".", 1)[-1],
         "short_description": metadata["short_description"],
         "params": params,
         "examples": metadata["examples"].strip() if metadata["examples"] else "",
         "example_args": example_args,
         "is_api_module": metadata.get("is_api_module", False),
         "examples_contain_play": _examples_contain_play(metadata.get("examples", "")),
+        "fqcn": fqcn,
+        "collection": namespace,
+        "plugin_type": "module",
+        "doc_version": metadata.get("doc_version"),
     }
 
 
@@ -159,7 +206,8 @@ def list_skills_sync(
         return results
 
     if collection:
-        collection_dir = (skills_dir / collection).resolve()
+        collection_dir_name = collection_skill_name(collection)
+        collection_dir = (skills_dir / collection_dir_name).resolve()
         validate_path_containment(collection_dir, skills_dir)
         if not collection_dir.is_dir():
             return results
@@ -171,9 +219,9 @@ def list_skills_sync(
                     from ansible_know.config import PLUGIN_TYPES
                     match = PLUGIN_SKILL_DIR_RE.match(dir_name)
                     if match and match.group(1) in PLUGIN_TYPES:
-                        display_name = f"{collection}.{match.group(2)}"
+                        display_name = f"{collection}.{match.group(2).replace('-', '_')}"
                     else:
-                        display_name = f"{collection}.{dir_name}"
+                        display_name = f"{collection}.{dir_name.replace('-', '_')}"
                     results.append({
                         "name": display_name,
                         "description": extract_skill_description(skill_md),
@@ -214,15 +262,17 @@ def get_skill_sync(skills_dir: Path, skill_name: str) -> str:
     if len(parts) >= 3:
         namespace = ".".join(parts[:2])
         short_name = ".".join(parts[2:])
+        collection_dir_name = collection_skill_name(namespace)
+        kebab_short = _to_kebab(short_name)
 
-        nested_path = (skills_dir / namespace / short_name / "SKILL.md").resolve()
+        nested_path = (skills_dir / collection_dir_name / kebab_short / "SKILL.md").resolve()
         validate_path_containment(nested_path, skills_dir)
         if nested_path.exists():
             return truncate_response(nested_path.read_text())
 
         from ansible_know.config import PLUGIN_TYPES
         for ptype in PLUGIN_TYPES:
-            plugin_path = (skills_dir / namespace / f"{ptype}__{short_name}" / "SKILL.md").resolve()
+            plugin_path = (skills_dir / collection_dir_name / f"{ptype}-{kebab_short}" / "SKILL.md").resolve()
             validate_path_containment(plugin_path, skills_dir)
             if plugin_path.exists():
                 return truncate_response(plugin_path.read_text())
@@ -290,15 +340,21 @@ def _extract_example_values(examples_yaml: str) -> dict[str, str]:
 
 def _role_template_context(metadata: dict[str, Any]) -> dict[str, Any]:
     """Build template context from role metadata."""
-    role_name = metadata["role_name"]
+    fqcn = metadata["role_name"]
+    namespace = _extract_namespace(fqcn)
     return {
-        "role_name": role_name,
-        "skill_name": role_name.rsplit(".", 1)[-1],
+        "role_name": fqcn,
+        "spec_name": role_skill_name(fqcn),
+        "skill_name": fqcn.rsplit(".", 1)[-1],
         "short_description": metadata.get("short_description", ""),
         "entry_points": metadata.get("entry_points", {}),
         "dependencies": metadata.get("dependencies", []),
         "examples": metadata.get("examples", "").strip(),
         "doc_source": metadata.get("doc_source", ""),
+        "fqcn": fqcn,
+        "collection": namespace,
+        "plugin_type": "role",
+        "doc_version": metadata.get("doc_version"),
     }
 
 
@@ -333,14 +389,20 @@ def write_role_skill_package(output_dir: Path, metadata: dict[str, Any]) -> None
 
 def _plugin_template_context(metadata: dict[str, Any]) -> dict[str, Any]:
     """Build template context from plugin metadata."""
-    plugin_name = metadata["plugin_name"]
+    fqcn = metadata["plugin_name"]
+    ptype = metadata["plugin_type"]
+    namespace = _extract_namespace(fqcn)
     return {
-        "plugin_name": plugin_name,
-        "plugin_type": metadata["plugin_type"],
-        "skill_name": plugin_name.rsplit(".", 1)[-1],
+        "plugin_name": fqcn,
+        "plugin_type": ptype,
+        "spec_name": plugin_skill_name(fqcn, ptype),
+        "skill_name": fqcn.rsplit(".", 1)[-1],
         "short_description": metadata.get("short_description", ""),
         "params": metadata.get("params", []),
         "examples": metadata.get("examples", "").strip(),
+        "fqcn": fqcn,
+        "collection": namespace,
+        "doc_version": metadata.get("doc_version"),
     }
 
 
@@ -412,12 +474,15 @@ def _collection_template_context(
 
     return {
         "collection_namespace": namespace,
+        "spec_name": collection_skill_name(namespace),
         "collection_version": collection_version,
         "modules_by_tag": modules_by_tag,
         "all_api": all_api,
         "common_params": common_params,
         "module_count": len(metadata_list),
         "plugins_by_type": plugins_by_type,
+        "collection": namespace,
+        "plugin_type": "collection",
     }
 
 

--- a/src/ansible_know/templates/COLLECTION_SKILL.md.j2
+++ b/src/ansible_know/templates/COLLECTION_SKILL.md.j2
@@ -1,8 +1,15 @@
 ---
-name: {{ collection_namespace }}
+name: {{ spec_name }}
 description: >-
   Guided playbook development for the {{ collection_namespace }} collection.
   Covers {{ module_count }} module{{ "s" if module_count != 1 else "" }}{% if collection_version %} (v{{ collection_version }}){% endif %}.
+compatibility: Requires ansible-core and the {{ collection }} collection
+metadata:
+  collection: {{ collection }}
+  plugin-type: {{ plugin_type }}
+{% if collection_version %}
+  version: "{{ collection_version }}"
+{% endif %}
 ---
 
 # {{ collection_namespace }} Playbook Guide

--- a/src/ansible_know/templates/COLLECTION_SKILL.md.j2
+++ b/src/ansible_know/templates/COLLECTION_SKILL.md.j2
@@ -5,6 +5,7 @@ description: >-
   Covers {{ module_count }} module{{ "s" if module_count != 1 else "" }}{% if collection_version %} (v{{ collection_version }}){% endif %}.
 compatibility: Requires ansible-core and the {{ collection }} collection
 metadata:
+  fqcn: {{ fqcn }}
   collection: {{ collection }}
   plugin-type: {{ plugin_type }}
 {% if collection_version %}

--- a/src/ansible_know/templates/PLUGIN_SKILL.md.j2
+++ b/src/ansible_know/templates/PLUGIN_SKILL.md.j2
@@ -1,9 +1,17 @@
 {# src/ansible_know/templates/PLUGIN_SKILL.md.j2 #}
 ---
-name: {{ plugin_name }}
+name: {{ spec_name }}
 description: >-
   {{ short_description }}
   Use when you need the {{ skill_name | replace('_', ' ') }} {{ plugin_type }} plugin in Ansible.
+compatibility: Requires ansible-core and the {{ collection }} collection
+metadata:
+  fqcn: {{ fqcn }}
+  collection: {{ collection }}
+  plugin-type: {{ plugin_type }}
+{% if doc_version %}
+  version: "{{ doc_version }}"
+{% endif %}
 ---
 
 # {{ plugin_name }} ({{ plugin_type }} plugin)

--- a/src/ansible_know/templates/ROLE_SKILL.md.j2
+++ b/src/ansible_know/templates/ROLE_SKILL.md.j2
@@ -1,8 +1,16 @@
 ---
-name: {{ role_name }}
+name: {{ spec_name }}
 description: >-
   {{ short_description }}
   Use when configuring {{ skill_name | replace('_', ' ') }} via Ansible role.
+compatibility: Requires ansible-core and the {{ collection }} collection
+metadata:
+  fqcn: {{ fqcn }}
+  collection: {{ collection }}
+  plugin-type: {{ plugin_type }}
+{% if doc_version %}
+  version: "{{ doc_version }}"
+{% endif %}
 ---
 
 # {{ role_name }}

--- a/src/ansible_know/templates/SKILL.md.j2
+++ b/src/ansible_know/templates/SKILL.md.j2
@@ -1,11 +1,19 @@
 ---
-name: {{ module_name }}
+name: {{ spec_name }}
 description: >-
   {{ short_description }}
 {% if is_api_module %}
   Use when managing {{ skill_name | replace('_', ' ') }} resources via API with Ansible.
 {% else %}
   Use when managing {{ skill_name | replace('_', ' ') }} resources on remote hosts via Ansible.
+{% endif %}
+compatibility: Requires ansible-core and the {{ collection }} collection
+metadata:
+  fqcn: {{ fqcn }}
+  collection: {{ collection }}
+  plugin-type: {{ plugin_type }}
+{% if doc_version %}
+  version: "{{ doc_version }}"
 {% endif %}
 ---
 

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -154,12 +154,16 @@ class CollectionSkillContext(TypedDict):
     """Template context for collection-level skill rendering."""
 
     collection_namespace: str
+    fqcn: str
+    spec_name: str
     collection_version: str | None
     modules_by_tag: dict[str, list[ModuleTagEntry]]
     all_api: bool
     common_params: list[ParamDict]
     module_count: int
     plugins_by_type: dict[str, list[dict[str, str]]]
+    collection: str
+    plugin_type: str
 
 
 class ManifestModuleEntry(TypedDict):

--- a/tests/test_collection_manifest.py
+++ b/tests/test_collection_manifest.py
@@ -62,14 +62,14 @@ class TestGenerateManifest:
         manifest = generate_manifest("ansible.builtin", [metadata], skills_dir=tmp_path)
         write_manifest(manifest, "ansible.builtin", skills_dir=tmp_path)
 
-        manifest_path = tmp_path / "ansible.builtin" / "MANIFEST.json"
+        manifest_path = tmp_path / "ansible-builtin" / "MANIFEST.json"
         assert manifest_path.exists()
 
         loaded = json.loads(manifest_path.read_text())
         assert loaded["collection"] == "ansible.builtin"
 
     def test_detects_existing_skills(self, tmp_path, sample_module_doc):
-        skill_dir = tmp_path / "ansible.builtin" / "package"
+        skill_dir = tmp_path / "ansible-builtin" / "package"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("test")
 
@@ -91,7 +91,7 @@ class TestGenerateManifest:
         assert manifest["has_collection_skill"] is False
 
     def test_has_collection_skill_true_when_exists(self, tmp_path, sample_module_doc):
-        skill_dir = tmp_path / "ansible.builtin"
+        skill_dir = tmp_path / "ansible-builtin"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("collection skill content")
 
@@ -149,7 +149,7 @@ class TestGenerateManifestWithRoles:
         assert manifest["roles"] == []
 
     def test_role_has_skill_detection(self, tmp_path):
-        skill_dir = tmp_path / "ansible.builtin" / "test_role"
+        skill_dir = tmp_path / "ansible-builtin" / "test-role"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("test")
 
@@ -217,7 +217,7 @@ class TestManifestPluginEntries:
         assert manifest["plugins"] == []
 
     def test_plugin_skill_detection(self, tmp_path):
-        skill_dir = tmp_path / "netbox.netbox" / "lookup__nb_lookup"
+        skill_dir = tmp_path / "netbox-netbox" / "lookup-nb-lookup"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("---\nname: test\n---\n")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -138,7 +138,7 @@ class TestListSkillsTool:
     @pytest.mark.asyncio
     async def test_returns_collection_skills_with_filter(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
-        mod_dir = tmp_path / "netbox.netbox" / "netbox_device"
+        mod_dir = tmp_path / "netbox-netbox" / "netbox-device"
         mod_dir.mkdir(parents=True)
         (mod_dir / "SKILL.md").write_text("---\nname: netbox.netbox.netbox_device\ndescription: Device\n---\n")
         from ansible_know.server import list_skills
@@ -174,7 +174,7 @@ class TestGetSkillTool:
     @pytest.mark.asyncio
     async def test_reads_nested_skill(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
-        nested = tmp_path / "netbox.netbox" / "netbox_device"
+        nested = tmp_path / "netbox-netbox" / "netbox-device"
         nested.mkdir(parents=True)
         (nested / "SKILL.md").write_text("nested skill content")
         from ansible_know.server import get_skill
@@ -210,7 +210,7 @@ class TestGenerateSkillTool:
         from ansible_know.server import generate_skill
         result = await generate_skill("ansible.builtin.package")
         assert "ansible.builtin.package" in result
-        assert (tmp_path / "ansible.builtin" / "package" / "SKILL.md").exists()
+        assert (tmp_path / "ansible-builtin" / "package" / "SKILL.md").exists()
 
 
 class TestGenerateCollectionSkillsTool:
@@ -233,7 +233,7 @@ class TestGenerateCollectionSkillsTool:
         assert result["total"] == 4
         assert result["succeeded"] + result["failed"] == 4
         assert result["collection_skill"] == "ansible.builtin"
-        assert (tmp_path / "ansible.builtin" / "SKILL.md").exists()
+        assert (tmp_path / "ansible-builtin" / "SKILL.md").exists()
 
     @pytest.mark.asyncio
     async def test_galaxy_batch_fallback(self, tmp_path, mock_ansible_doc, monkeypatch):
@@ -278,7 +278,7 @@ class TestGenerateCollectionSkillsTool:
 
         assert result["total"] == 1
         assert result["succeeded"] == 1
-        assert (tmp_path / "netbox.netbox" / "netbox_device" / "SKILL.md").exists()
+        assert (tmp_path / "netbox-netbox" / "netbox-device" / "SKILL.md").exists()
 
 
 class TestFQCNValidation:
@@ -402,7 +402,7 @@ class TestGetSkillSync:
     def test_returns_content_for_nested_module_skill(self, tmp_path):
         from ansible_know.skills import get_skill_sync
 
-        mod_dir = tmp_path / "netbox.netbox" / "netbox_device"
+        mod_dir = tmp_path / "netbox-netbox" / "netbox-device"
         mod_dir.mkdir(parents=True)
         (mod_dir / "SKILL.md").write_text("module skill content")
         assert get_skill_sync(tmp_path, "netbox.netbox.netbox_device") == "module skill content"
@@ -759,7 +759,7 @@ class TestGalaxyDocsFallback:
             result = await generate_skill("netbox.netbox.netbox_device")
 
         assert "netbox.netbox.netbox_device" in result
-        assert (tmp_path / "netbox.netbox" / "netbox_device" / "SKILL.md").exists()
+        assert (tmp_path / "netbox-netbox" / "netbox-device" / "SKILL.md").exists()
 
 
 class TestResourceFunctions:
@@ -786,7 +786,7 @@ class TestResourceFunctions:
 
     def test_resource_skill_content_reads_nested(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
-        nested = tmp_path / "ansible.builtin" / "copy"
+        nested = tmp_path / "ansible-builtin" / "copy"
         nested.mkdir(parents=True)
         (nested / "SKILL.md").write_text("nested content")
         from ansible_know.server import resource_skill_content
@@ -804,16 +804,16 @@ class TestResourceFunctions:
 
     def test_resource_skills_list_with_nested_skills(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
-        coll_dir = tmp_path / "netbox.netbox"
+        coll_dir = tmp_path / "netbox-netbox"
         coll_dir.mkdir()
         (coll_dir / "SKILL.md").write_text("# Collection skill")
-        mod_dir = coll_dir / "netbox_device"
+        mod_dir = coll_dir / "netbox-device"
         mod_dir.mkdir()
         (mod_dir / "SKILL.md").write_text("# Device skill")
         from ansible_know.server import resource_skills_list
         result = json.loads(resource_skills_list())
-        assert "netbox.netbox" in result
-        assert "netbox.netbox.netbox_device" in result
+        assert "netbox-netbox" in result
+        assert "netbox-device" in result
 
     def test_resource_skill_content_flat_fallback(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
@@ -1436,9 +1436,9 @@ class TestGenerateRoleSkillTool:
         from ansible_know.server import generate_role_skill
         result = await generate_role_skill("fedora.linux_system_roles.gfs2")
         assert "fedora.linux_system_roles.gfs2" in result
-        assert (tmp_path / "fedora.linux_system_roles" / "gfs2" / "SKILL.md").exists()
-        assert (tmp_path / "fedora.linux_system_roles" / "gfs2" / "assets" / "playbook.yml").exists()
-        assert not (tmp_path / "fedora.linux_system_roles" / "gfs2" / "scripts").exists()
+        assert (tmp_path / "fedora-linux-system-roles" / "gfs2" / "SKILL.md").exists()
+        assert (tmp_path / "fedora-linux-system-roles" / "gfs2" / "assets" / "playbook.yml").exists()
+        assert not (tmp_path / "fedora-linux-system-roles" / "gfs2" / "scripts").exists()
 
     @pytest.mark.asyncio
     async def test_validation_error(self):
@@ -1481,7 +1481,7 @@ class TestGenerateRoleSkillTool:
             result = await generate_role_skill("fedora.linux_system_roles.timesync")
 
         assert "fedora.linux_system_roles.timesync" in result
-        assert (tmp_path / "fedora.linux_system_roles" / "timesync" / "SKILL.md").exists()
+        assert (tmp_path / "fedora-linux-system-roles" / "timesync" / "SKILL.md").exists()
 
 
 class TestGetCollectionManifestWithRoles:
@@ -1886,7 +1886,7 @@ class TestGeneratePluginSkill:
 class TestGetPluginSkill:
     @pytest.mark.asyncio
     async def test_finds_plugin_skill_by_fqcn(self, tmp_path):
-        skill_dir = tmp_path / "netbox.netbox" / "lookup__nb_lookup"
+        skill_dir = tmp_path / "netbox-netbox" / "lookup-nb-lookup"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("---\nname: netbox.netbox.nb_lookup\n---\nlookup skill")
         with patch("ansible_know.config.SKILLS_DIR", tmp_path):
@@ -1897,10 +1897,10 @@ class TestGetPluginSkill:
     @pytest.mark.asyncio
     async def test_module_skill_takes_precedence(self, tmp_path):
         # If both a module and plugin skill exist, module (direct name) wins
-        mod_dir = tmp_path / "netbox.netbox" / "nb_lookup"
+        mod_dir = tmp_path / "netbox-netbox" / "nb-lookup"
         mod_dir.mkdir(parents=True)
         (mod_dir / "SKILL.md").write_text("module skill")
-        plugin_dir = tmp_path / "netbox.netbox" / "lookup__nb_lookup"
+        plugin_dir = tmp_path / "netbox-netbox" / "lookup-nb-lookup"
         plugin_dir.mkdir(parents=True)
         (plugin_dir / "SKILL.md").write_text("plugin skill")
         with patch("ansible_know.config.SKILLS_DIR", tmp_path):
@@ -1912,7 +1912,7 @@ class TestGetPluginSkill:
 class TestListPluginSkills:
     @pytest.mark.asyncio
     async def test_strips_type_prefix_from_name(self, tmp_path):
-        skill_dir = tmp_path / "netbox.netbox" / "lookup__nb_lookup"
+        skill_dir = tmp_path / "netbox-netbox" / "lookup-nb-lookup"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("---\nname: test\n---\n")
         with patch("ansible_know.config.SKILLS_DIR", tmp_path):
@@ -1920,19 +1920,18 @@ class TestListPluginSkills:
             result = await list_skills(collection="netbox.netbox")
         names = [s["name"] for s in result]
         assert "netbox.netbox.nb_lookup" in names
-        assert "netbox.netbox.lookup__nb_lookup" not in names
+        assert "netbox.netbox.lookup-nb-lookup" not in names
 
 
 class TestResourceSkillsListPlugins:
-    def test_strips_type_prefix_in_resource(self, tmp_path):
-        skill_dir = tmp_path / "netbox.netbox" / "lookup__nb_lookup"
+    def test_lists_kebab_skill_names_in_resource(self, tmp_path):
+        skill_dir = tmp_path / "netbox-netbox" / "lookup-nb-lookup"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("---\nname: test\n---\n")
         with patch("ansible_know.config.SKILLS_DIR", tmp_path):
             from ansible_know.server import resource_skills_list
             result = json.loads(resource_skills_list())
-        assert "netbox.netbox.nb_lookup" in result
-        assert "netbox.netbox.lookup__nb_lookup" not in result
+        assert "lookup-nb-lookup" in result
 
 
 class TestGetCollectionDocsTool:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -812,8 +812,8 @@ class TestResourceFunctions:
         (mod_dir / "SKILL.md").write_text("# Device skill")
         from ansible_know.server import resource_skills_list
         result = json.loads(resource_skills_list())
-        assert "netbox-netbox" in result
-        assert "netbox-device" in result
+        assert "netbox.netbox" in result
+        assert "netbox.netbox.netbox_device" in result
 
     def test_resource_skill_content_flat_fallback(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
@@ -1924,14 +1924,15 @@ class TestListPluginSkills:
 
 
 class TestResourceSkillsListPlugins:
-    def test_lists_kebab_skill_names_in_resource(self, tmp_path):
+    def test_returns_fqcn_for_plugin_skills(self, tmp_path):
         skill_dir = tmp_path / "netbox-netbox" / "lookup-nb-lookup"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("---\nname: test\n---\n")
         with patch("ansible_know.config.SKILLS_DIR", tmp_path):
             from ansible_know.server import resource_skills_list
             result = json.loads(resource_skills_list())
-        assert "lookup-nb-lookup" in result
+        assert "netbox.netbox.nb_lookup" in result
+        assert "lookup-nb-lookup" not in result
 
 
 class TestGetCollectionDocsTool:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,6 +1,5 @@
 """Tests for ansible_know.skills."""
 
-
 from ansible_know.parser import extract_module_metadata
 from ansible_know.skills import (
     _build_example_args,
@@ -8,12 +7,16 @@ from ansible_know.skills import (
     _extract_example_values,
     _find_common_params,
     _role_template_context,
+    collection_skill_name,
+    fqcn_to_skill_name,
     module_to_skill_name,
+    plugin_skill_name,
     render_collection_skill,
     render_module_skill,
     render_plugin_skill,
     render_role_skill,
     render_skill,
+    role_skill_name,
     write_collection_skill_package,
     write_module_skill_package,
     write_plugin_skill_package,
@@ -22,12 +25,215 @@ from ansible_know.skills import (
 )
 
 
-class TestModuleToSkillName:
-    def test_uses_fqcn(self):
-        assert module_to_skill_name("ansible.builtin.package") == "ansible.builtin.package"
+class TestFqcnToSkillName:
+    """Test the core FQCN-to-kebab-case conversion."""
 
-    def test_preserves_collection_prefix(self):
-        assert module_to_skill_name("netbox.netbox.netbox_device") == "netbox.netbox.netbox_device"
+    def test_module_short_name_underscores_to_hyphens(self):
+        assert fqcn_to_skill_name("netbox.netbox.netbox_device") == "netbox-device"
+
+    def test_module_no_underscores(self):
+        assert fqcn_to_skill_name("ansible.builtin.package") == "package"
+
+    def test_module_multiple_underscores(self):
+        assert fqcn_to_skill_name("ansible.builtin.apt_key") == "apt-key"
+
+    def test_three_part_fqcn(self):
+        assert fqcn_to_skill_name("community.general.redis_info") == "redis-info"
+
+
+class TestPluginSkillName:
+    """Test plugin skill naming: type-prefix + short name."""
+
+    def test_lookup_plugin(self):
+        assert plugin_skill_name("netbox.netbox.nb_lookup", "lookup") == "lookup-nb-lookup"
+
+    def test_filter_plugin(self):
+        assert plugin_skill_name("ansible.builtin.to_yaml", "filter") == "filter-to-yaml"
+
+    def test_inventory_plugin(self):
+        assert plugin_skill_name("netbox.netbox.nb_inventory", "inventory") == "inventory-nb-inventory"
+
+    def test_connection_plugin(self):
+        assert plugin_skill_name("ansible.netcommon.network_cli", "connection") == "connection-network-cli"
+
+    def test_callback_plugin(self):
+        assert plugin_skill_name("ansible.builtin.default", "callback") == "callback-default"
+
+
+class TestRoleSkillName:
+    """Test role skill naming: short name only, kebab-case."""
+
+    def test_simple_role(self):
+        assert role_skill_name("fedora.linux_system_roles.timesync") == "timesync"
+
+    def test_role_with_underscores(self):
+        assert role_skill_name("namespace.collection.my_role_name") == "my-role-name"
+
+
+class TestCollectionSkillName:
+    """Test collection-level skill naming: namespace kebab-case."""
+
+    def test_dotted_namespace(self):
+        assert collection_skill_name("netbox.netbox") == "netbox-netbox"
+
+    def test_namespace_with_underscores(self):
+        assert collection_skill_name("community.general") == "community-general"
+
+    def test_namespace_mixed(self):
+        assert collection_skill_name("fedora.linux_system_roles") == "fedora-linux-system-roles"
+
+
+class TestModuleToSkillName:
+    def test_returns_kebab_short_name(self):
+        assert module_to_skill_name("ansible.builtin.package") == "package"
+
+    def test_underscores_to_hyphens(self):
+        assert module_to_skill_name("netbox.netbox.netbox_device") == "netbox-device"
+
+
+class TestSpecCompliantFrontmatter:
+    """Verify rendered skills contain agentskills.io-compliant frontmatter."""
+
+    def test_module_skill_has_kebab_name(self, sample_module_doc):
+        metadata = extract_module_metadata(sample_module_doc)
+        content = render_module_skill(metadata)
+        assert "\nname: package\n" in content
+
+    def test_module_skill_has_metadata_fqcn(self, sample_module_doc):
+        metadata = extract_module_metadata(sample_module_doc)
+        content = render_module_skill(metadata)
+        assert "fqcn: ansible.builtin.package" in content
+
+    def test_module_skill_has_metadata_collection(self, sample_module_doc):
+        metadata = extract_module_metadata(sample_module_doc)
+        content = render_module_skill(metadata)
+        assert "collection: ansible.builtin" in content
+
+    def test_module_skill_has_metadata_plugin_type(self, sample_module_doc):
+        metadata = extract_module_metadata(sample_module_doc)
+        content = render_module_skill(metadata)
+        assert "plugin-type: module" in content
+
+    def test_module_skill_has_compatibility(self, sample_module_doc):
+        metadata = extract_module_metadata(sample_module_doc)
+        content = render_module_skill(metadata)
+        assert "compatibility:" in content
+        assert "ansible-core" in content
+
+    def test_api_module_skill_has_kebab_name(self, sample_api_module_doc):
+        metadata = extract_module_metadata(sample_api_module_doc)
+        content = render_module_skill(metadata)
+        assert "\nname: netbox-device\n" in content
+
+    def test_api_module_skill_has_metadata(self, sample_api_module_doc):
+        metadata = extract_module_metadata(sample_api_module_doc)
+        content = render_module_skill(metadata)
+        assert "fqcn: netbox.netbox.netbox_device" in content
+        assert "collection: netbox.netbox" in content
+        assert "plugin-type: module" in content
+
+    def test_plugin_skill_has_type_prefix_name(self):
+        metadata = {
+            "plugin_name": "netbox.netbox.nb_lookup",
+            "plugin_type": "lookup",
+            "short_description": "Queries NetBox",
+            "params": [],
+            "examples": "",
+        }
+        content = render_plugin_skill(metadata)
+        assert "\nname: lookup-nb-lookup\n" in content
+
+    def test_plugin_skill_has_metadata(self):
+        metadata = {
+            "plugin_name": "netbox.netbox.nb_lookup",
+            "plugin_type": "lookup",
+            "short_description": "Queries NetBox",
+            "params": [],
+            "examples": "",
+        }
+        content = render_plugin_skill(metadata)
+        assert "fqcn: netbox.netbox.nb_lookup" in content
+        assert "collection: netbox.netbox" in content
+        assert "plugin-type: lookup" in content
+
+    def test_plugin_skill_has_compatibility(self):
+        metadata = {
+            "plugin_name": "netbox.netbox.nb_lookup",
+            "plugin_type": "lookup",
+            "short_description": "Queries NetBox",
+            "params": [],
+            "examples": "",
+        }
+        content = render_plugin_skill(metadata)
+        assert "compatibility:" in content
+        assert "netbox.netbox" in content
+
+    def test_role_skill_has_kebab_name(self):
+        metadata = {
+            "role_name": "fedora.linux_system_roles.timesync",
+            "short_description": "Configure time synchronization",
+            "entry_points": {},
+            "dependencies": [],
+            "examples": "",
+            "doc_source": "local",
+        }
+        content = render_role_skill(metadata)
+        assert "\nname: timesync\n" in content
+
+    def test_role_skill_has_metadata(self):
+        metadata = {
+            "role_name": "fedora.linux_system_roles.timesync",
+            "short_description": "Configure time synchronization",
+            "entry_points": {},
+            "dependencies": [],
+            "examples": "",
+            "doc_source": "local",
+        }
+        content = render_role_skill(metadata)
+        assert "fqcn: fedora.linux_system_roles.timesync" in content
+        assert "collection: fedora.linux_system_roles" in content
+        assert "plugin-type: role" in content
+
+    def test_role_skill_has_compatibility(self):
+        metadata = {
+            "role_name": "fedora.linux_system_roles.timesync",
+            "short_description": "Configure time synchronization",
+            "entry_points": {},
+            "dependencies": [],
+            "examples": "",
+            "doc_source": "local",
+        }
+        content = render_role_skill(metadata)
+        assert "compatibility:" in content
+        assert "fedora.linux_system_roles" in content
+
+    def test_collection_skill_has_kebab_name(self, sample_api_module_doc):
+        metadata = extract_module_metadata(sample_api_module_doc)
+        content = render_collection_skill("netbox.netbox", [metadata])
+        assert "\nname: netbox-netbox\n" in content
+
+    def test_collection_skill_has_metadata(self, sample_api_module_doc):
+        metadata = extract_module_metadata(sample_api_module_doc)
+        content = render_collection_skill("netbox.netbox", [metadata])
+        assert "collection: netbox.netbox" in content
+        assert "plugin-type: collection" in content
+
+    def test_collection_skill_has_compatibility(self, sample_api_module_doc):
+        metadata = extract_module_metadata(sample_api_module_doc)
+        content = render_collection_skill("netbox.netbox", [metadata])
+        assert "compatibility:" in content
+        assert "netbox.netbox" in content
+
+    def test_module_skill_version_in_metadata(self, sample_module_doc):
+        metadata = extract_module_metadata(sample_module_doc)
+        metadata["doc_version"] = "2.15.0"
+        content = render_module_skill(metadata)
+        assert 'version: "2.15.0"' in content
+
+    def test_collection_skill_version_in_metadata(self, sample_api_module_doc):
+        metadata = extract_module_metadata(sample_api_module_doc)
+        content = render_collection_skill("netbox.netbox", [metadata], collection_version="4.1.0")
+        assert 'version: "4.1.0"' in content
 
 
 class TestBackwardCompatAliases:


### PR DESCRIPTION
## Summary

- Convert skill directory and `name` field from FQCN-based (dots, underscores) to spec-compliant kebab-case
- Add `compatibility`, `metadata.fqcn`, `metadata.collection`, `metadata.plugin-type`, and `metadata.version` frontmatter fields to all 4 skill templates (module, plugin, role, collection)
- Update `get_skill_sync`, `list_skills_sync`, `resource_skills_list`, and `collection_manifest.py` path resolution for new naming scheme
- Update all server.py output path calculations for `generate_skill`, `generate_role_skill`, `generate_plugin_skill`, and `generate_collection_skills`
- This is a breaking change — all existing generated skills need regeneration

## Naming changes

| Type | Before | After |
|------|--------|-------|
| Module | `netbox.netbox/netbox_device/` | `netbox-netbox/netbox-device/` |
| Plugin | `netbox.netbox/lookup__nb_lookup/` | `netbox-netbox/lookup-nb-lookup/` |
| Role | `fedora.linux_system_roles/timesync/` | `fedora-linux-system-roles/timesync/` |
| Collection | `netbox.netbox/` | `netbox-netbox/` |

## Review fixes (second commit)

Fixes identified during architecture review:

- **Restored FQCN output in `skills://list` resource** — the resource now returns Ansible FQCNs (e.g., `netbox.netbox.netbox_device`) instead of raw kebab directory names, keeping it compatible with `get_skill` which accepts FQCNs
- **Extracted reusable reverse-mapping functions** — `skill_dir_to_collection_fqcn()` and `skill_dir_to_short_fqcn()` in `skills.py` for converting kebab directories back to FQCNs, used in both `resource_skills_list()` and `list_skills_sync()`
- **Removed `_extract_namespace()` duplication** — uses `validation.extract_namespace()` instead
- **Added `fqcn` field to collection template** — all 4 templates now consistently include `metadata.fqcn`
- **Updated `CollectionSkillContext` TypedDict** — added missing `fqcn`, `spec_name`, `collection`, `plugin_type` fields
- **Removed unnecessary import aliases** in `collection_manifest.py`
- **Filed #152** for follow-up variable naming cleanup (template context variables use wrong Ansible terminology)

## Test plan

- [x] 16 naming conversion tests (fqcn_to_skill_name, plugin_skill_name, role_skill_name, collection_skill_name)
- [x] 18 spec-compliant frontmatter tests (verify metadata block, compatibility, kebab names in rendered output)
- [x] All 736 existing tests passing
- [x] Ruff lint clean
- [x] Architecture review completed (6 dimensions, all findings addressed)

Closes #148

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>