### PR TITLE
docs: strategy ADRs, ADR format improvements, and skill update

### DIFF
--- a/docs/architecture/adr/0001-fastmcp-framework.md
+++ b/docs/architecture/adr/0001-fastmcp-framework.md
@@ -102,5 +102,5 @@ FastMCP was chosen because:
 
 | Date | Author | Change |
 |------|--------|--------|
-| 2026-06-19 | Leonardo Gallego (AI-assisted) | Initial decision |
-| 2026-06-26 | Leonardo Gallego (AI-assisted) | Added Implementation Notes, Related Decisions, Revision History |
+| 2026-06-19 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial decision |
+| 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Added Implementation Notes, Related Decisions, Revision History |

--- a/docs/architecture/adr/0001-fastmcp-framework.md
+++ b/docs/architecture/adr/0001-fastmcp-framework.md
@@ -4,6 +4,10 @@
 
 Accepted
 
+## Date
+
+2026-06-19
+
 ## Context
 
 The server needs to expose tools, resources, and prompts via the Model Context
@@ -77,3 +81,26 @@ FastMCP was chosen because:
   shutdown.
 - Consider defining a `LifespanContext` TypedDict to type the lifespan
   dict and prevent key typos.
+
+## Implementation Notes
+
+- `server.py` — all tool/resource/prompt registrations via FastMCP decorators
+- `server.py:lifespan()` — startup/shutdown: httpx client, Galaxy server
+  config, PyPI version check
+- `server.py:Context` — injected into tool handlers for progress/warnings
+- Transport: stdio via `mcp.run()`, HTTP/SSE supported by FastMCP but
+  not yet configured
+
+## Related Decisions
+
+- [ADR-0003](0003-module-level-state.md) — state management choices
+  influenced by FastMCP's lifespan context model
+- [ADR-0008](0008-three-layer-distribution.md) — Layer 3 (remote service)
+  depends on FastMCP's HTTP/SSE transport
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-19 | Leonardo Gallego (AI-assisted) | Initial decision |
+| 2026-06-26 | Leonardo Gallego (AI-assisted) | Added Implementation Notes, Related Decisions, Revision History |

--- a/docs/architecture/adr/0002-subprocess-ansible-doc.md
+++ b/docs/architecture/adr/0002-subprocess-ansible-doc.md
@@ -4,6 +4,10 @@
 
 Accepted
 
+## Date
+
+2026-06-19
+
 ## Context
 
 The server needs to extract module and role documentation from installed
@@ -91,3 +95,27 @@ The subprocess approach was chosen because:
 - The Galaxy fallback already handles the "no local installation" case;
   consider making Galaxy-first the default for documentation (with local
   as fallback) to reduce ansible-core dependency.
+
+## Implementation Notes
+
+- `parser.py` — all `subprocess.run()` calls to `ansible-doc`
+- `parser.py:_run_ansible_doc()` — single entry point, mocked in all
+  unit tests
+- `parser.py:_find_ansible_doc()` — binary discovery: venv sibling first,
+  then `shutil.which()`
+- `async_utils.py:run_in_executor()` — bridges blocking subprocess calls
+  to async event loop
+
+## Related Decisions
+
+- [ADR-0004](0004-galaxy-fallback-chain.md) — Galaxy fallback when
+  `ansible-doc` cannot find a collection
+- [ADR-0006](0006-upstream-first-integration.md) — subprocess-based docs
+  are a candidate for upstream contribution to next-mcp
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-19 | Leonardo Gallego (AI-assisted) | Initial decision |
+| 2026-06-26 | Leonardo Gallego (AI-assisted) | Added Implementation Notes, Related Decisions, Revision History |

--- a/docs/architecture/adr/0002-subprocess-ansible-doc.md
+++ b/docs/architecture/adr/0002-subprocess-ansible-doc.md
@@ -117,5 +117,5 @@ The subprocess approach was chosen because:
 
 | Date | Author | Change |
 |------|--------|--------|
-| 2026-06-19 | Leonardo Gallego (AI-assisted) | Initial decision |
-| 2026-06-26 | Leonardo Gallego (AI-assisted) | Added Implementation Notes, Related Decisions, Revision History |
+| 2026-06-19 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial decision |
+| 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Added Implementation Notes, Related Decisions, Revision History |

--- a/docs/architecture/adr/0003-module-level-state.md
+++ b/docs/architecture/adr/0003-module-level-state.md
@@ -4,6 +4,10 @@
 
 Accepted (with known technical debt)
 
+## Date
+
+2026-06-19
+
 ## Context
 
 The server needs to maintain several pieces of mutable state across tool
@@ -116,3 +120,27 @@ to use module-level state remains unchanged.
   This would require moving to session-scoped state management.
 - Consider a `ServerState` dataclass that holds all caches and runtime state,
   initialized in the lifespan and stored in `ctx.lifespan_context`.
+
+## Implementation Notes
+
+- `galaxy.py` — `BoundedCache` instances for `_version_cache`, `_blob_cache`
+- `docs.py` — `BoundedCache` for `_manifest_cache`
+- `collections.py` — `_installed_collections` dict, per-collection locks,
+  `_install_gate`
+- `server.py` — `_missing_collections` set (negative cache)
+- `cache.py` — `BoundedCache[K, V]` with `threading.Lock`, LRU eviction, TTL
+
+## Related Decisions
+
+- [ADR-0001](0001-fastmcp-framework.md) — FastMCP's lifespan context handles
+  startup-initialized state; module-level handles runtime-accumulated state
+- [ADR-0004](0004-galaxy-fallback-chain.md) — Galaxy caches are primary
+  consumers of `BoundedCache`
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-19 | Leonardo Gallego (AI-assisted) | Initial decision |
+| 2026-06-19 | Leonardo Gallego (AI-assisted) | Updated with BoundedCache mitigation (PR #60) |
+| 2026-06-26 | Leonardo Gallego (AI-assisted) | Added Implementation Notes, Related Decisions, Revision History |

--- a/docs/architecture/adr/0003-module-level-state.md
+++ b/docs/architecture/adr/0003-module-level-state.md
@@ -125,10 +125,13 @@ to use module-level state remains unchanged.
 
 - `galaxy.py` — `BoundedCache` instances for `_version_cache`, `_blob_cache`
 - `docs.py` — `BoundedCache` for `_manifest_cache`
-- `collections.py` — `_installed_collections` dict, per-collection locks,
-  `_install_gate`
-- `server.py` — `_missing_collections` set (negative cache)
-- `cache.py` — `BoundedCache[K, V]` with `threading.Lock`, LRU eviction, TTL
+- `collections.py` — `CollectionManager` class (per-session via
+  `SessionManager`): `self._installed`, per-collection locks,
+  `self._install_gate`
+- `state.py` — `SharedState` (process-wide), `ServerState` (per-session
+  including `missing_collections` set), `SessionManager` factory
+- `cache.py` — `BoundedCache[K, V]` with `threading.Lock`, LRU eviction,
+  TTL, optional disk persistence
 
 ## Related Decisions
 
@@ -141,6 +144,6 @@ to use module-level state remains unchanged.
 
 | Date | Author | Change |
 |------|--------|--------|
-| 2026-06-19 | Leonardo Gallego (AI-assisted) | Initial decision |
-| 2026-06-19 | Leonardo Gallego (AI-assisted) | Updated with BoundedCache mitigation (PR #60) |
-| 2026-06-26 | Leonardo Gallego (AI-assisted) | Added Implementation Notes, Related Decisions, Revision History |
+| 2026-06-19 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial decision |
+| 2026-06-19 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Updated with BoundedCache mitigation (PR #60) |
+| 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Added Implementation Notes, Related Decisions, Revision History |

--- a/docs/architecture/adr/0004-galaxy-fallback-chain.md
+++ b/docs/architecture/adr/0004-galaxy-fallback-chain.md
@@ -113,7 +113,8 @@ their installed version.
   collection search, format conversion
 - `readme_parser.py` — Galaxy role README HTML parsing (4 variable
   documentation patterns)
-- `config.py` — Galaxy server configuration parsed from `ansible.cfg`
+- `galaxy_config.py` — Galaxy server configuration parsed from `ansible.cfg`
+  (`load_galaxy_servers()`, `GalaxyServerConfig` dataclass)
 - `server.py:lifespan()` — Galaxy server initialization at startup
 
 ## Related Decisions
@@ -128,6 +129,6 @@ their installed version.
 
 | Date | Author | Change |
 |------|--------|--------|
-| 2026-06-19 | Leonardo Gallego (AI-assisted) | Initial decision |
-| 2026-06-19 | Leonardo Gallego (AI-assisted) | Updated: resolution logic moved to resolution.py (PR #66) |
-| 2026-06-26 | Leonardo Gallego (AI-assisted) | Added Implementation Notes, Related Decisions, Revision History |
+| 2026-06-19 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial decision |
+| 2026-06-19 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Updated: resolution logic moved to resolution.py (PR #66) |
+| 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Added Implementation Notes, Related Decisions, Revision History |

--- a/docs/architecture/adr/0004-galaxy-fallback-chain.md
+++ b/docs/architecture/adr/0004-galaxy-fallback-chain.md
@@ -4,6 +4,10 @@
 
 Accepted
 
+## Date
+
+2026-06-19
+
 ## Context
 
 The server needs to provide module and role documentation to AI agents. Users
@@ -100,3 +104,30 @@ their installed version.
 - Consider making Galaxy-first the default (cheaper than spawning
   `ansible-doc` subprocesses) with local as fallback for custom modules.
 - Support `auth_url` + `client_id` for SSO token refresh (AAP Gateway).
+
+## Implementation Notes
+
+- `resolution.py` — `resolve_module_doc()`, `resolve_role_doc()`:
+  local → Galaxy → graceful degradation
+- `galaxy.py` — Galaxy v3 API client: version lookup, docs-blob fetch,
+  collection search, format conversion
+- `readme_parser.py` — Galaxy role README HTML parsing (4 variable
+  documentation patterns)
+- `config.py` — Galaxy server configuration parsed from `ansible.cfg`
+- `server.py:lifespan()` — Galaxy server initialization at startup
+
+## Related Decisions
+
+- [ADR-0002](0002-subprocess-ansible-doc.md) — local `ansible-doc` is the
+  first tier in the fallback chain
+- [ADR-0003](0003-module-level-state.md) — Galaxy caches use `BoundedCache`
+- [ADR-0006](0006-upstream-first-integration.md) — multi-server Galaxy
+  support is a P0 candidate for upstream contribution
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-19 | Leonardo Gallego (AI-assisted) | Initial decision |
+| 2026-06-19 | Leonardo Gallego (AI-assisted) | Updated: resolution logic moved to resolution.py (PR #66) |
+| 2026-06-26 | Leonardo Gallego (AI-assisted) | Added Implementation Notes, Related Decisions, Revision History |

--- a/docs/architecture/adr/0005-jinja2-skill-generation.md
+++ b/docs/architecture/adr/0005-jinja2-skill-generation.md
@@ -4,6 +4,10 @@
 
 Accepted
 
+## Date
+
+2026-06-19
+
 ## Context
 
 The server's primary output artifact is a "skill package" — a directory
@@ -115,3 +119,27 @@ Scripts are written with executable permissions (`chmod +x`) via
 - If custom skill formats are needed (e.g., for different AI agent
   frameworks), support template overrides via environment variable or
   configuration.
+
+## Implementation Notes
+
+- `skills.py` — context builders, package writers, skill listing/reading
+- `templates/SKILL.md.j2` — module skill template
+- `templates/PLUGIN_SKILL.md.j2` — plugin skill template
+- `templates/ROLE_SKILL.md.j2` — role skill template
+- `templates/COLLECTION_SKILL.md.j2` — collection-level skill template
+- `templates/run.sh.j2`, `check.sh.j2` — execution scripts
+- `templates/playbook.yml.j2`, `role_playbook.yml.j2` — playbook assets
+
+## Related Decisions
+
+- [ADR-0002](0002-subprocess-ansible-doc.md) — metadata extraction feeds
+  the template context
+- [ADR-0007](0007-agentskills-spec-compliance.md) — templates must produce
+  agentskills.io-compliant frontmatter (issue #148)
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-19 | Leonardo Gallego (AI-assisted) | Initial decision |
+| 2026-06-26 | Leonardo Gallego (AI-assisted) | Added Implementation Notes, Related Decisions, Revision History |

--- a/docs/architecture/adr/0005-jinja2-skill-generation.md
+++ b/docs/architecture/adr/0005-jinja2-skill-generation.md
@@ -141,5 +141,5 @@ Scripts are written with executable permissions (`chmod +x`) via
 
 | Date | Author | Change |
 |------|--------|--------|
-| 2026-06-19 | Leonardo Gallego (AI-assisted) | Initial decision |
-| 2026-06-26 | Leonardo Gallego (AI-assisted) | Added Implementation Notes, Related Decisions, Revision History |
+| 2026-06-19 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial decision |
+| 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Added Implementation Notes, Related Decisions, Revision History |

--- a/docs/architecture/adr/0006-upstream-first-integration.md
+++ b/docs/architecture/adr/0006-upstream-first-integration.md
@@ -107,7 +107,7 @@ All contributions must align with next-mcp's ADRs:
 - **Phase 1** (upstream contributions): provide algorithms, patterns, and
   test cases for TypeScript reimplementation in next-mcp. Key features:
   - Multi-server Galaxy via `ansible.cfg`: `galaxy.py`, `config.py`
-  - Structured Galaxy docs fallback: `galaxy.py:get_docs_blob()`
+  - Structured Galaxy docs fallback: `galaxy.py:GalaxyClient._fetch_docs_blob()`
   - Role README HTML parsing: `readme_parser.py`
 - **Phase 2** (tool deprecation): mark overlapping tools as deprecated in
   `server.py`, emit warnings via `ctx.warning()`, remove after one release
@@ -128,4 +128,4 @@ All contributions must align with next-mcp's ADRs:
 
 | Date | Author | Change |
 |------|--------|--------|
-| 2026-06-26 | Leonardo Gallego (AI-assisted) | Initial proposal |
+| 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial proposal |

--- a/docs/architecture/adr/0006-upstream-first-integration.md
+++ b/docs/architecture/adr/0006-upstream-first-integration.md
@@ -1,0 +1,131 @@
+# ADR 0006: Upstream-First Integration with @ansible/mcp-server (next)
+
+## Status
+
+Proposed
+
+## Date
+
+2026-06-26
+
+## Context
+
+The @ansible/mcp-server (next branch) is the official Ansible DevTools MCP
+server, bundled in the VS Code extension. Over time, both servers have built
+overlapping capabilities: collection search, module/plugin docs for
+uninstalled collections, skill listing, and MCP behavioral annotations.
+
+Maintaining two servers with growing overlap creates confusion for agents
+(which server to call?), duplicated maintenance effort, and a weaker pitch
+to stakeholders.
+
+The next-mcp server excels at developer workflow (linting, execution,
+scaffolding, environment management, task generation). ansible-know-mcp
+excels at knowledge retrieval (structured docs, Galaxy fallback, multi-server
+support, README parsing) and skill generation.
+
+The question: should ansible-know-mcp continue as a broad knowledge server,
+or focus on its unique value and contribute the rest upstream?
+
+## Decision
+
+Adopt an upstream-first strategy:
+
+1. **Contribute** knowledge features to next-mcp where they naturally extend
+   existing capabilities. We provide algorithms, patterns, and test cases
+   for TypeScript reimplementation — not code drops.
+
+2. **Keep** skill generation as the core value proposition. The generation
+   pipeline (structured docs → Jinja2 templates → SKILL.md packages) is
+   Python/Jinja2 and doesn't fit in a TypeScript server.
+
+3. **Drop** overlapping tools as upstream absorbs the features.
+
+### Features to upstream
+
+| Priority | Feature | Rationale |
+|---|---|---|
+| P0 | Multi-server Galaxy via `ansible.cfg` | Enterprise blocker — every enterprise deployment has a private hub |
+| P1 | Structured Galaxy docs fallback | Extends existing `get_galaxy_plugin_doc` with structured JSON output |
+| P1 | Role README HTML parsing | Most Galaxy roles lack `argument_specs`; extends existing role docs |
+| Evaluate | Runtime doc search | Depends on next-mcp team's interest; their Starlight site is hosting, not runtime search |
+
+### Features to keep
+
+- `generate_skill`, `generate_plugin_skill`, `generate_role_skill`,
+  `generate_collection_skills` — core generation pipeline
+- `get_collection_manifest`, `get_collection_docs` — feed the generation pipeline
+- `list_skills`, `get_skill` — serve generated skills via MCP resources
+
+### Tools to drop (once upstream absorbs features)
+
+- `search_modules`, `search_plugins` — next-mcp has better relevance scoring
+- `ensure_collection` — next-mcp rebuilds search index after install
+- `search_collections` — multi-server moves upstream
+- `get_module_doc`, `get_plugin_doc`, `get_role_doc` — docs resolution moves upstream
+- `clear_cache` — fewer caches with narrower scope
+
+### Evolution path
+
+```
+Phase 1-3: ansible-know-mcp → ansible-skill-mcp (community, Python)
+Phase 4:   ansible-skill-mcp → aap-mcp-skills (platform, TypeScript)
+```
+
+## Consequences
+
+### Positive
+
+- **Cleaner story**: "We contributed the knowledge infrastructure. What we
+  kept is the generation engine that turns knowledge into agent-ready skills."
+- **No agent confusion**: one server for knowledge + workflow (next-mcp),
+  one server for skill generation (ansible-skill-mcp). Clear boundary.
+- **Enterprise gap closed**: multi-server Galaxy support lands in the
+  official tooling, not a community add-on.
+- **Reduced maintenance**: fewer tools, narrower scope, less surface area.
+
+### Negative
+
+- **Dependency on next-mcp team**: upstream contributions require their
+  acceptance and reimplementation capacity. Timeline is theirs, not ours.
+- **Transition period**: during Phase 2, both servers have overlapping
+  tools. Agent confusion persists until tools are dropped.
+- **Standalone degradation**: ansible-skill-mcp without next-mcp loses
+  the documentation tools. The remote service model (Layer 3) mitigates
+  this — skill generation still works via Galaxy fallback internally.
+
+### ADR compliance with next-mcp
+
+All contributions must align with next-mcp's ADRs:
+- ADR-018: Behavioral annotations, structured JSON errors
+- ADR-014: agentskills.io-compatible SKILL.md frontmatter
+- ADR-013: Galaxy fallback complements SCM-based docs
+- ADR-019: Python tooling works within tiered env model
+
+## Implementation Notes
+
+- **Phase 1** (upstream contributions): provide algorithms, patterns, and
+  test cases for TypeScript reimplementation in next-mcp. Key features:
+  - Multi-server Galaxy via `ansible.cfg`: `galaxy.py`, `config.py`
+  - Structured Galaxy docs fallback: `galaxy.py:get_docs_blob()`
+  - Role README HTML parsing: `readme_parser.py`
+- **Phase 2** (tool deprecation): mark overlapping tools as deprecated in
+  `server.py`, emit warnings via `ctx.warning()`, remove after one release
+- **Phase 3** (rename): `ansible-know-mcp` → `ansible-skill-mcp` — PyPI
+  package rename, CLI entrypoint, documentation updates
+- **Pitch document**: `docs/research/upstream-integration-proposal-2026-06-26.md`
+
+## Related Decisions
+
+- [ADR-0004](0004-galaxy-fallback-chain.md) — Galaxy fallback and
+  multi-server support are the primary upstream contribution candidates
+- [ADR-0007](0007-agentskills-spec-compliance.md) — spec compliance is
+  required for interoperability with next-mcp's SkillRegistry
+- [ADR-0008](0008-three-layer-distribution.md) — three-layer model defines
+  how ansible-skill-mcp integrates with next-mcp post-upstream
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-26 | Leonardo Gallego (AI-assisted) | Initial proposal |

--- a/docs/architecture/adr/0007-agentskills-spec-compliance.md
+++ b/docs/architecture/adr/0007-agentskills-spec-compliance.md
@@ -1,0 +1,175 @@
+# ADR 0007: agentskills.io Specification Compliance
+
+## Status
+
+Proposed
+
+## Date
+
+2026-06-26
+
+## Context
+
+The [agentskills.io specification](https://agentskills.io/specification) is
+the emerging standard for AI agent skills, supported by 40+ coding agents
+including Claude Code, Cursor, GitHub Copilot, VS Code, Gemini CLI, OpenAI
+Codex, Junie (JetBrains), and others.
+
+Our generated SKILL.md packages do not comply with the spec:
+
+- `name` field uses Ansible FQCNs with dots and underscores
+  (`netbox.netbox.netbox_device`) — the spec requires lowercase + hyphens only
+- Directory names don't match the `name` field
+- Missing metadata fields (`compatibility`, `metadata.fqcn`, etc.)
+
+Non-compliance blocks interoperability with the agent ecosystem and with
+distribution tools like [Lola](https://github.com/LobsterTrap/lola) and
+the [vscode-ansible skill registry](https://github.com/ansible/vscode-ansible).
+
+The [client implementation guide](https://agentskills.io/client-implementation/adding-skills-support)
+recommends 4-6 levels of scan depth. Our nested output (collection/skill/SKILL.md
+= 2 levels) is within spec bounds. Consumers that scan only 1 level (next-mcp's
+`_loadLocalSource`, Lola's per-module scan) are below the spec recommendation.
+
+## Decision
+
+### One output format, spec-compliant
+
+No layout options or output modes. Every generated skill is a valid
+agentskills.io skill. The collection grouping directory is organizational
+structure, not a format — the spec doesn't constrain parent directories.
+
+### Naming conventions
+
+**Skill names** use kebab-case derived from the short module/plugin/role
+name. The collection directory provides the namespace — short names are
+unambiguous within their collection.
+
+**Modules** get no type prefix (they're the default):
+
+```
+netbox-netbox/
+  netbox-device/SKILL.md       name: netbox-device
+  netbox-site/SKILL.md         name: netbox-site
+```
+
+**Plugins** get their type as prefix to prevent collision (a module and a
+plugin can share a name within a collection):
+
+```
+netbox-netbox/
+  lookup-nb-lookup/SKILL.md    name: lookup-nb-lookup
+  filter-some-filter/SKILL.md  name: filter-some-filter
+```
+
+**Roles** get no prefix (roles cannot collide with modules in a collection):
+
+```
+fedora-linux-system-roles/
+  timesync/SKILL.md            name: timesync
+```
+
+**Collection-level skills** use the collection namespace as the name:
+
+```
+netbox-netbox/
+  SKILL.md                     name: netbox-netbox (matches parent dir)
+```
+
+### Metadata fields
+
+Every generated skill includes:
+
+```yaml
+---
+name: netbox-device
+description: >-
+  Manage devices within NetBox.
+  Use when managing netbox device resources via API with Ansible.
+compatibility: Requires ansible-core and the netbox.netbox collection
+metadata:
+  fqcn: netbox.netbox.netbox_device
+  collection: netbox.netbox
+  plugin-type: module
+  version: "4.6.0"
+---
+```
+
+- `name`: kebab-case, matches parent directory, max 64 chars
+- `description`: what + when, max 1024 chars
+- `compatibility`: runtime requirements
+- `metadata.fqcn`: original fully-qualified collection name (for programmatic use)
+- `metadata.collection`: collection namespace
+- `metadata.plugin-type`: `module`, `lookup`, `filter`, `test`, `connection`,
+  `become`, `strategy`, `callback`, `inventory`, `cache`, `cliconf`,
+  `httpapi`, `netconf`, `shell`, `vars`, or `role`
+- `metadata.version`: collection version when known
+
+### Nesting is spec-compliant
+
+Our output structure (collection/skill/SKILL.md = 2 levels) is within the
+spec's recommended 4-6 level scan depth. The 1-level limitation in some
+consumers (next-mcp `_loadLocalSource`, Lola per-module scan) is a consumer
+gap, not a spec violation on our side.
+
+We propose patching next-mcp's `_loadLocalSource` to scan 2+ levels,
+citing the spec. This benefits all skill producers that use namespace grouping.
+
+### Lola packaging is a user concern
+
+Lola is a distribution channel, not a generation format. Our spec-compliant
+output can be wrapped into a Lola module by the user as a packaging step.
+No special output mode needed.
+
+## Consequences
+
+### Positive
+
+- **40+ agent compatibility**: any agent following the spec can discover
+  and load our skills.
+- **Lola distribution**: spec-compliant skills can be packaged into Lola
+  modules for cross-agent installation.
+- **next-mcp registry**: skills work with GitHub sources (Lola format,
+  2-level scan) today, and with local sources once scan depth is expanded.
+- **Validation**: generated skills can be validated with `skills-ref validate`.
+- **One format**: no configuration, no layout modes, no confusion.
+
+### Negative
+
+- **Breaking change**: existing generated skills use FQCN names and
+  underscore directories. Regeneration required.
+- **Plugin type prefix verbosity**: `lookup-nb-lookup` is longer than
+  `nb_lookup`. Trade-off for collision avoidance.
+- **Consumer limitations**: 1-level scanners miss module-level skills until
+  they expand their scan depth. Mitigated by the proposed next-mcp patch
+  and by the GitHub source path (which already scans 2 levels).
+
+## Implementation Notes
+
+Issue [#148](https://github.com/leogallego/ansible-know-mcp/issues/148)
+tracks the implementation. Changes required:
+
+- **Templates**: `SKILL.md.j2`, `PLUGIN_SKILL.md.j2`, `ROLE_SKILL.md.j2`,
+  `COLLECTION_SKILL.md.j2` — add `compatibility`, `metadata` block
+- **Code**: `skills.py` — FQCN-to-kebab-case name generation, plugin type
+  prefix logic, directory naming, metadata context building
+- **Validation**: frontmatter validation against spec constraints (name
+  format, length, required fields)
+- **Tests**: update all skill generation tests for new naming/metadata
+- **Validator**: `pip install skills-ref`, CLI `agentskills validate` —
+  confirmed passing with proposed format
+
+## Related Decisions
+
+- [ADR-0005](0005-jinja2-skill-generation.md) — templates must be updated
+  to produce spec-compliant frontmatter
+- [ADR-0006](0006-upstream-first-integration.md) — spec compliance is
+  required for interoperability with next-mcp's SkillRegistry
+- [ADR-0008](0008-three-layer-distribution.md) — one output format makes
+  the three-layer model possible
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-26 | Leonardo Gallego (AI-assisted) | Initial proposal |

--- a/docs/architecture/adr/0007-agentskills-spec-compliance.md
+++ b/docs/architecture/adr/0007-agentskills-spec-compliance.md
@@ -172,4 +172,4 @@ tracks the implementation. Changes required:
 
 | Date | Author | Change |
 |------|--------|--------|
-| 2026-06-26 | Leonardo Gallego (AI-assisted) | Initial proposal |
+| 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial proposal |

--- a/docs/architecture/adr/0008-three-layer-distribution.md
+++ b/docs/architecture/adr/0008-three-layer-distribution.md
@@ -1,0 +1,127 @@
+# ADR 0008: Three-Layer Skill Distribution Model
+
+## Status
+
+Proposed
+
+## Date
+
+2026-06-26
+
+## Context
+
+Generated skills need to reach developers across different deployment
+contexts: individual developers working locally, teams sharing curated
+skill sets, and enterprise environments with DevSpaces or portal-based
+workflows.
+
+A single distribution mechanism doesn't cover all cases:
+- Local filesystem works for individual developers but not for teams
+- GitHub repos work for teams but require manual setup
+- Remote services work for enterprise but add infrastructure
+
+The question: should we pick one distribution model, or design for all
+three as additive layers?
+
+## Decision
+
+Adopt a three-layer distribution model. Each layer is additive — builds
+on the previous, uses the same spec-compliant skills throughout.
+
+### Layer 1: Local (now)
+
+ansible-skill-mcp runs alongside next-mcp on a developer's machine.
+Skills are generated in real time from collections resolved via multiple
+endpoints (locally installed, private Automation Hub, public Galaxy).
+
+- Skills land in `ANSIBLE_KNOW_SKILLS_DIR` (our env var, default `./skills/`)
+- next-mcp reads via `type: "local"` source in `ANSIBLE_SKILL_SOURCES`
+  (next-mcp's env var — JSON array of `SkillSource` objects with
+  `{id, type, url, trust}`)
+- Developer gets immediate access via `skill_search`
+
+**Value:** Real-time generation from any collection source. No pre-work,
+no publishing step.
+
+### Layer 2: Repository (next)
+
+Skills are generated once by a platform team, pushed to a GitHub repo,
+consumed by multiple developers.
+
+Two consumption paths:
+- **next-mcp SkillRegistry:** `type: "github"` source. Lola format
+  detection scans 2 levels — works today.
+- **Lola:** Users wrap skills into a Lola module and distribute to
+  40+ agents via `lola install`.
+
+**Value:** Persistence, sharing, version control, cross-agent reach.
+
+### Layer 3: Remote Service (future)
+
+ansible-skill-mcp runs as an HTTP/SSE MCP server deployed by a platform
+team. Any MCP client calls it directly for on-demand skill generation.
+
+Target environments:
+- Ansible DevSpaces (containerized dev environments)
+- Ansible Self-Service Portal (potential integration)
+- Enterprise teams with centralized skill curation
+
+**Value:** On-demand generation without local installation. Skills
+generated once per collection version, served to all developers.
+
+## Consequences
+
+### Positive
+
+- **Additive, not exclusive**: each layer serves a different use case.
+  Teams can use any combination.
+- **Same output format**: spec-compliant skills at every layer. No
+  format variations or compatibility concerns.
+- **Incremental rollout**: Layer 1 works today. Layer 2 requires
+  publishing to a repo. Layer 3 requires infrastructure.
+
+### Negative
+
+- **Layer 1 gap**: next-mcp's `_loadLocalSource` scans 1 level. Our
+  2-level output (collection/skill) is within spec bounds but missed
+  by the current implementation. Proposed patch pending.
+- **Layer 3 infrastructure**: remote deployment requires hosting,
+  authentication, and monitoring. Not trivial for enterprise environments.
+- **Scope creep risk**: three layers could expand the project's scope
+  beyond skill generation. Mitigated by keeping distribution as a
+  consumption concern — we generate spec-compliant skills, consumers
+  handle their own distribution mechanics.
+
+### Design constraint
+
+The three-layer model reinforces ADR-0007's decision: one output format,
+spec-compliant. If skills needed different formats per layer, the model
+would break. Spec compliance makes the layers possible.
+
+## Implementation Notes
+
+- **Layer 1** (local): `ANSIBLE_KNOW_SKILLS_DIR` env var (default
+  `./skills/`), configured in `config.py`. next-mcp reads via
+  `ANSIBLE_SKILL_SOURCES` with `type: "local"` pointing to the same path.
+- **Layer 2** (repository): generated skills pushed to a GitHub repo.
+  next-mcp reads via `ANSIBLE_SKILL_SOURCES` with `type: "github"`.
+  Lola-compatible packaging is a separate user concern.
+- **Layer 3** (remote): FastMCP HTTP/SSE transport (see ADR-0001). Not
+  yet implemented — requires hosting, auth, and monitoring infrastructure.
+- **Scan depth gap**: next-mcp `_loadLocalSource` scans 1 level; our
+  2-level output requires a patch (draft at `tmp/draft-issue-local-scan-depth.md`).
+
+## Related Decisions
+
+- [ADR-0001](0001-fastmcp-framework.md) — FastMCP's HTTP/SSE transport
+  enables Layer 3
+- [ADR-0006](0006-upstream-first-integration.md) — three-layer model
+  defines the post-upstream integration path
+- [ADR-0007](0007-agentskills-spec-compliance.md) — one output format
+  makes the three-layer model possible
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-26 | Leonardo Gallego (AI-assisted) | Initial proposal |

--- a/docs/architecture/adr/0008-three-layer-distribution.md
+++ b/docs/architecture/adr/0008-three-layer-distribution.md
@@ -124,4 +124,4 @@ would break. Spec compliance makes the layers possible.
 
 | Date | Author | Change |
 |------|--------|--------|
-| 2026-06-26 | Leonardo Gallego (AI-assisted) | Initial proposal |
+| 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial proposal |

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -10,10 +10,10 @@ decision with its context, rationale, and consequences.
 |-----|-------|--------|
 | [0001](0001-fastmcp-framework.md) | FastMCP as MCP Server Framework | Accepted |
 | [0002](0002-subprocess-ansible-doc.md) | Subprocess-Based ansible-doc Integration | Accepted |
-| [0003](0003-module-level-state.md) | Module-Level Mutable State | Accepted (with known debt) |
+| [0003](0003-module-level-state.md) | Module-Level Mutable State | Accepted (with known technical debt) |
 | [0004](0004-galaxy-fallback-chain.md) | Galaxy Fallback Chain with Multi-Server Support | Accepted |
 | [0005](0005-jinja2-skill-generation.md) | Jinja2-Based Skill Package Generation | Accepted |
-| [0006](0006-upstream-first-integration.md) | Upstream-First Integration with next-mcp | Proposed |
+| [0006](0006-upstream-first-integration.md) | Upstream-First Integration with @ansible/mcp-server (next) | Proposed |
 | [0007](0007-agentskills-spec-compliance.md) | agentskills.io Specification Compliance | Proposed |
 | [0008](0008-three-layer-distribution.md) | Three-Layer Skill Distribution Model | Proposed |
 

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -13,6 +13,9 @@ decision with its context, rationale, and consequences.
 | [0003](0003-module-level-state.md) | Module-Level Mutable State | Accepted (with known debt) |
 | [0004](0004-galaxy-fallback-chain.md) | Galaxy Fallback Chain with Multi-Server Support | Accepted |
 | [0005](0005-jinja2-skill-generation.md) | Jinja2-Based Skill Package Generation | Accepted |
+| [0006](0006-upstream-first-integration.md) | Upstream-First Integration with next-mcp | Proposed |
+| [0007](0007-agentskills-spec-compliance.md) | agentskills.io Specification Compliance | Proposed |
+| [0008](0008-three-layer-distribution.md) | Three-Layer Skill Distribution Model | Proposed |
 
 ## Format
 

--- a/docs/architecture/project-strategy.md
+++ b/docs/architecture/project-strategy.md
@@ -18,7 +18,7 @@
 | Resources | 6 |
 | Prompts | 5 |
 | Tests | 776 (unit + integration) |
-| Modules | 22 Python source modules |
+| Modules | 21 Python source modules |
 
 ### Core capabilities
 
@@ -88,7 +88,7 @@ All significant decisions are recorded in [docs/architecture/adr/](adr/). Decisi
 
 | ADR | Title | Status | Summary |
 |---|---|---|---|
-| [0006](adr/0006-upstream-first-integration.md) | Upstream-First Integration with next-mcp | Proposed | Contribute knowledge features upstream, keep skill generation |
+| [0006](adr/0006-upstream-first-integration.md) | Upstream-First Integration with @ansible/mcp-server (next) | Proposed | Contribute knowledge features upstream, keep skill generation |
 | [0007](adr/0007-agentskills-spec-compliance.md) | agentskills.io Specification Compliance | Proposed | One output format, spec-compliant; naming and metadata conventions |
 | [0008](adr/0008-three-layer-distribution.md) | Three-Layer Skill Distribution Model | Proposed | Local → Repository → Remote, additive layers |
 
@@ -110,7 +110,7 @@ Prior decisions:
 
 The Ansible DevTools MCP server, bundled in the VS Code extension. Our primary integration partner.
 
-- **Local copy:** `/home/lgallego/Claude/vscode-ansible` (next branch)
+- **Local copy:** clone of `github.com/ansible/vscode-ansible` (next branch)
 - **Repo:** `github.com/ansible/vscode-ansible`
 - **Version:** 0.0.1 (pre-release)
 - **Relationship:** We upstream knowledge features; they distribute skills via the SkillRegistry

--- a/docs/architecture/project-strategy.md
+++ b/docs/architecture/project-strategy.md
@@ -1,0 +1,165 @@
+# ansible-know-mcp: Project Strategy and Evolution
+
+**Last updated:** 2026-06-26
+**Status:** Active
+
+---
+
+## Project Status
+
+**ansible-know-mcp** is a community MCP server for Ansible knowledge retrieval and AI skill generation.
+
+| Dimension | Current (v0.6.0) |
+|---|---|
+| Language | Python (FastMCP) |
+| License | GPL-3.0-or-later |
+| Distribution | PyPI (`uvx ansible-know-mcp`) |
+| Tools | 18 |
+| Resources | 6 |
+| Prompts | 5 |
+| Tests | 776 (unit + integration) |
+| Modules | 22 Python source modules |
+
+### Core capabilities
+
+| Capability | Purpose |
+|---|---|
+| Module/plugin/role documentation | Structured docs with Galaxy fallback, multi-server support, README parsing |
+| Collection discovery | Concurrent multi-server search via `ansible.cfg`, enriched manifests |
+| Skill generation | AI-ready SKILL.md packages from module, plugin, role, and collection metadata |
+| Documentation search | Upstream doc manifests (ansible-core, lint, navigator, builder, creator, molecule) + RTD fallback |
+
+---
+
+## Strategic Direction
+
+### Upstream-first integration with @ansible/mcp-server (next)
+
+Rather than maintain two servers that increasingly overlap, contribute knowledge features upstream and focus on what's unique.
+
+**Contribute upstream:**
+- P0: Multi-server Galaxy via `ansible.cfg` (enterprise blocker)
+- P1: Structured Galaxy docs fallback (extends existing `get_galaxy_plugin_doc`)
+- P1: Role README HTML parsing (extends existing role docs)
+- Evaluate: Runtime doc search (depends on next-mcp team's interest)
+
+**Keep:**
+- Skill generation pipeline (all 4 generation tools + supporting tools)
+- Skill sharing as team service (remote HTTP/SSE deployment)
+
+**Drop** (once upstream absorbs the features):
+- `search_modules`, `search_plugins` → next-mcp's `search_ansible_plugins` has better scoring
+- `ensure_collection` → next-mcp's `install_ansible_collection` rebuilds search index
+- `search_collections` → next-mcp covers Galaxy + GitHub orgs
+- `get_module_doc`, `get_plugin_doc`, `get_role_doc` → next-mcp with upstream Galaxy fallback + README parsing
+- `clear_cache` → fewer caches to manage
+
+See [ADR-0006](adr/0006-upstream-first-integration.md) for the full decision record.
+
+### Evolution path
+
+```
+Phase 1-3 (now → mid-term):
+  ansible-know-mcp → ansible-skill-mcp
+  Python, community project, focused on skill generation + distribution
+
+Phase 4 (future):
+  ansible-skill-mcp → aap-mcp-skills
+  TypeScript, platform component alongside aap-mcp-server
+```
+
+### Three-layer distribution model
+
+Each layer is additive — same spec-compliant skills at every layer.
+
+| Layer | When | How | Value |
+|---|---|---|---|
+| **Local** | Now | Paired with next-mcp, shared directory | Real-time generation from locally installed, private hub, and Galaxy collections |
+| **Repository** | Next | Generated skills pushed to GitHub repo | Persistence, sharing, version control, Lola distribution to 40+ agents |
+| **Remote service** | Future | HTTP/SSE MCP server | On-demand generation for DevSpaces, Ansible Self-Service Portal, enterprise teams |
+
+See [ADR-0008](adr/0008-three-layer-distribution.md) for the full decision record.
+
+---
+
+## Architecture Decisions
+
+All significant decisions are recorded in [docs/architecture/adr/](adr/). Decisions from the strategy discussion (2026-06-26):
+
+| ADR | Title | Status | Summary |
+|---|---|---|---|
+| [0006](adr/0006-upstream-first-integration.md) | Upstream-First Integration with next-mcp | Proposed | Contribute knowledge features upstream, keep skill generation |
+| [0007](adr/0007-agentskills-spec-compliance.md) | agentskills.io Specification Compliance | Proposed | One output format, spec-compliant; naming and metadata conventions |
+| [0008](adr/0008-three-layer-distribution.md) | Three-Layer Skill Distribution Model | Proposed | Local → Repository → Remote, additive layers |
+
+Prior decisions:
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](adr/0001-fastmcp-framework.md) | FastMCP as MCP Server Framework | Accepted |
+| [0002](adr/0002-subprocess-ansible-doc.md) | Subprocess-Based ansible-doc Integration | Accepted |
+| [0003](adr/0003-module-level-state.md) | Module-Level Mutable State | Accepted (with known debt) |
+| [0004](adr/0004-galaxy-fallback-chain.md) | Galaxy Fallback Chain with Multi-Server Support | Accepted |
+| [0005](adr/0005-jinja2-skill-generation.md) | Jinja2-Based Skill Package Generation | Accepted |
+
+---
+
+## Key Relationships
+
+### @ansible/mcp-server (next branch)
+
+The Ansible DevTools MCP server, bundled in the VS Code extension. Our primary integration partner.
+
+- **Local copy:** `/home/lgallego/Claude/vscode-ansible` (next branch)
+- **Repo:** `github.com/ansible/vscode-ansible`
+- **Version:** 0.0.1 (pre-release)
+- **Relationship:** We upstream knowledge features; they distribute skills via the SkillRegistry
+- **Integration point:** Shared skill directory (local) or GitHub source (Lola format, 2-level scan)
+- **Gap:** `_loadLocalSource` scans 1 level; spec recommends 4-6. Patch proposed.
+- **Pitch document:** [upstream-integration-proposal-2026-06-26.md](../research/upstream-integration-proposal-2026-06-26.md)
+
+### aap-mcp-server
+
+The AAP platform MCP server for Controller, EDA, and Gateway operations.
+
+- **Repo:** `github.com/ansible/aap-mcp-server`
+- **Relationship:** Future home for `aap-mcp-skills` (Phase 4, TypeScript rewrite)
+- **No current integration** — the platform MCP ecosystem is the long-term direction
+
+### Lola
+
+Cross-agent AI skill package manager by Red Hat Product Security.
+
+- **Repo:** `github.com/LobsterTrap/lola`
+- **Marketplace:** `github.com/RedHatProductSecurity/lola-market`
+- **Relationship:** Distribution channel. Users wrap our spec-compliant skills into Lola modules for cross-agent installation (40+ agents).
+- **Not a generation format** — Lola packaging is a user's distribution step, not our output format.
+
+### agentskills.io
+
+The standard specification for AI agent skills.
+
+- **Spec:** `agentskills.io/specification`
+- **Validator:** `github.com/agentskills/agentskills/tree/main/skills-ref`
+- **Our compliance:** Issue #148. Fixing name format, metadata fields, directory naming.
+- **See:** [ADR-0007](adr/0007-agentskills-spec-compliance.md)
+
+---
+
+## Open Items
+
+1. **Finalize issue #148** — update body with all decisions from ADR-0007
+2. **Draft next-mcp scan depth proposal** — venue (issue/comment/PR) and wording
+3. **Update upstream integration proposal** — add agentskills.io findings and three-layer model
+4. **Validate with `skills-ref`** — generate sample skills with new format, run the validator
+
+---
+
+## Supporting Documents
+
+| Document | Purpose |
+|---|---|
+| [upstream-integration-proposal-2026-06-26.md](../research/upstream-integration-proposal-2026-06-26.md) | External pitch to next-mcp team |
+| [comparison-2026-06-26.md](../research/comparison-2026-06-26.md) | Technical feature comparison |
+| [skills-distribution-strategy-2026-06-26.md](../research/skills-distribution-strategy-2026-06-26.md) | Skills distribution technical details |
+| [service-contracts.md](service-contracts.md) | MCP server contracts and invariants |

--- a/skills/pr-architecture-review/SKILL.md
+++ b/skills/pr-architecture-review/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: pr-architecture-review
 description: >-
-  Use when reviewing a PR or branch changes against ansible-know-mcp
-  architecture contracts. Use when asked to review a PR, check
-  architecture, audit layer dependencies, or do a multidimensional
-  code review of this project.
-user-invocable: true
-argument-hint: "[PR number or branch name, defaults to current branch vs main]"
+  Review PR or branch changes against ansible-know-mcp architecture
+  contracts, layer dependencies, and ADRs. Use when asked to review
+  a PR, check architecture, audit layer dependencies, or do a
+  multidimensional code review of this project.
+compatibility: Requires git and access to the ansible-know-mcp repository
+metadata:
+  project: ansible-know-mcp
+  version: "0.6.0"
 ---
 
 # PR Architecture Review
@@ -20,7 +22,8 @@ Load these reference materials before starting — they define the layer
 boundaries, allowed dependencies, and known violations:
 
 1. Read `docs/architecture/service-contracts.md`
-2. Read all ADRs in `docs/architecture/adr/`
+2. Read all ADRs in `docs/architecture/adr/` (0001–0008)
+3. Read `docs/architecture/project-strategy.md` for strategic context
 
 Pass the relevant sections to each subagent in Phase 2.
 
@@ -48,6 +51,7 @@ context. Dimensions are independent — run them in parallel.
 | **Async/sync & state management** | Steps 4–5 | `python-try-except` |
 | **PEP 8 & Python standards** | Step 7 | `python-alignment-chart`, `python-concept-analysis` |
 | **Security** | Step 8 | — |
+| **ADR & strategy compliance** | Step 9 | — |
 
 Each subagent should load its listed local skills from `skills/` for
 additional context. Instruct each to return structured findings using
@@ -58,6 +62,28 @@ the Reporting format at the bottom of this skill.
 Merge all subagent findings. Deduplicate (same file+line across
 dimensions). Sort by severity: Error → Warning → Info. Present a
 single consolidated report.
+
+## Self-update check
+
+After completing the review, check whether the PR being reviewed
+changes any of the following. If it does, prompt the user to update
+this skill before merging:
+
+- **Layer map changes**: new modules added to `src/ansible_know/`,
+  modules renamed or removed, modules moved between layers
+- **service-contracts.md**: new violations added, existing violations
+  fixed, layer rules changed
+- **ADRs**: new ADRs added, existing ADRs updated or superseded
+- **State architecture**: changes to `state.py`, `SessionManager`,
+  `SharedState`, or `ServerState`
+- **project-strategy.md**: strategy or evolution path changes
+
+If any of these changed, add a finding:
+
+> **Info** — This PR changes architecture contracts/ADRs/layer structure.
+> Update `skills/pr-architecture-review/SKILL.md` to reflect the new
+> state before merging. See the Revision History at the bottom for
+> what was last updated.
 
 ---
 
@@ -75,6 +101,7 @@ Classify each changed file into its architecture layer:
 | `src/ansible_know/skills.py` | **Domain** |
 | `src/ansible_know/collection_manifest.py` | **Domain** |
 | `src/ansible_know/docs.py` | **Domain** |
+| `src/ansible_know/resolution.py` | **Domain** |
 | `src/ansible_know/galaxy.py` | **External Access** |
 | `src/ansible_know/collections.py` | **External Access** |
 | `src/ansible_know/readme_parser.py` | **External Access** |
@@ -84,9 +111,12 @@ Classify each changed file into its architecture layer:
 | `src/ansible_know/async_utils.py` | **Foundation** |
 | `src/ansible_know/state.py` | **Foundation** |
 | `src/ansible_know/tagging.py` | **Foundation** |
+| `src/ansible_know/text_utils.py` | **Foundation** |
 | `src/ansible_know/validation.py` | **Foundation** |
 | `src/ansible_know/errors.py` | **Foundation** |
 | `src/ansible_know/types.py` | **Foundation** |
+| `src/ansible_know/manifest_builder.py` | **Build-time** (not runtime) |
+| `src/ansible_know/cli.py` | **CLI** (entrypoint) |
 | `src/ansible_know/templates/*` | **Domain** (templates) |
 | `tests/*` | **Test** (check mirrors source layer) |
 
@@ -122,11 +152,10 @@ Foundation   → no internal dependencies
 
 #### Known existing violations (do not worsen)
 
-- `server.py` contains `_resolve_module_doc()` and `_resolve_role_doc()`
-  (business logic in Orchestration — V-D7/V-L2).
-- `server.py` calls `GalaxyClient` directly (V-E1/V-L1).
-- `galaxy.py` imports `readme_parser` (External → Domain — V-L3).
-- `parser.py` imports `collections` (Domain → External — V-L4).
+- V-D6 (Info): Some Domain functions still return `dict[str, Any]`
+  where TypedDicts exist. Partially addressed.
+- V-L3 (Info): `galaxy.py` lazy-imports `readme_parser.py` and
+  `parser.py` for pure data transformers — accepted cross-layer calls.
 
 **Rule**: do not add new violations. If a PR must cross a layer boundary,
 document why and file a follow-up issue.
@@ -137,7 +166,8 @@ For changes that modify function signatures or return types:
 
 - [ ] **Typed returns**: functions returning structured data should use
   the `TypedDict` definitions from `types.py` (`ModuleMetadata`,
-  `RoleMetadata`, `DocProvenance`), not bare `dict[str, Any]`.
+  `RoleMetadata`, `DocProvenance`, `ParamDict`, `EntryPointInfo`),
+  not bare `dict[str, Any]`.
 - [ ] **New TypedDicts**: if a function returns a new structured shape,
   add a `TypedDict` to `types.py` rather than using `dict[str, Any]`.
 - [ ] **Exception types**: new error conditions should use the existing
@@ -153,7 +183,7 @@ For changes that add or modify function calls between layers:
 
 - [ ] **Sync functions in async context**: any synchronous function that
   does I/O (subprocess, file system, network) MUST be wrapped in
-  `_run_in_executor()` when called from an async handler. Never call
+  `run_in_executor()` when called from an async handler. Never call
   blocking functions directly from a tool handler.
 - [ ] **New subprocess calls**: must use `subprocess.run()` with
   `capture_output=True`, `text=True`, and a `timeout` parameter.
@@ -163,21 +193,19 @@ For changes that add or modify function calls between layers:
 
 ### Step 5: Check State Management
 
-For changes that add or modify module-level state:
+For changes that add or modify module-level or session-level state:
 
-- [ ] **New module-level mutable state**: any new `dict`, `set`, `list`,
-  or mutable object at module scope MUST have explicit thread-safety
-  documentation. If accessed from `_run_in_executor()` threads, it
-  MUST use `threading.Lock`. If accessed from async code only, it
-  SHOULD use `asyncio.Lock`.
-- [ ] **Cache additions**: new caches SHOULD use `BoundedCache` from
-  `cache.py` (thread-safe, LRU-bounded, optional TTL). Do not
-  introduce new ad-hoc `OrderedDict` + `Lock` patterns — use the
-  shared abstraction. If `BoundedCache` does not fit the use case,
-  document why.
-- [ ] **Global state mutation**: check that `set.add()`, `dict[key] = val`,
-  and similar mutations on module-level state are safe under the
-  concurrency model being used.
+- [ ] **State architecture**: process-wide state belongs in `SharedState`
+  (created at lifespan). Per-session state belongs in `ServerState`
+  (created per session via `SessionManager`). Both are defined in
+  `state.py`.
+- [ ] **New caches**: SHOULD use `BoundedCache` from `cache.py`
+  (thread-safe, LRU-bounded, optional TTL, optional disk persistence).
+  Do not introduce ad-hoc `OrderedDict` + `Lock` patterns.
+- [ ] **Collection state**: must go through `CollectionManager` (per-session,
+  created by `SessionManager`). Never use module-level collection state.
+- [ ] **Thread safety**: any state accessed from `run_in_executor()` threads
+  MUST use `threading.Lock`. Async-only state within a session is safe.
 
 ### Step 6: Check Public API Surface
 
@@ -231,6 +259,26 @@ For changes that handle external input or subprocess calls:
 - [ ] **Response size**: large responses must pass through
   `truncate_response()` to prevent memory exhaustion.
 
+### Step 9: ADR and Strategy Compliance
+
+For changes that affect architecture or project direction:
+
+- [ ] **Upstream-first alignment** (ADR-0006): new knowledge tools that
+  overlap with next-mcp should not be added. Focus on skill generation
+  and sharing.
+- [ ] **Spec compliance** (ADR-0007): generated skills must use
+  kebab-case names, include `metadata.fqcn`, `metadata.collection`,
+  `metadata.plugin-type`, and `compatibility` fields. Validate with
+  `agentskills validate`.
+- [ ] **Distribution model** (ADR-0008): skill output must work at all
+  three layers (local, repository, remote) without format changes.
+- [ ] **ADR consistency**: if a PR contradicts an existing ADR, it must
+  either update the ADR or document why the deviation is necessary.
+- [ ] **Tools to keep vs drop**: changes to tools marked for upstream
+  deprecation (search_modules, search_plugins, ensure_collection,
+  get_module_doc, get_plugin_doc, get_role_doc, clear_cache) should
+  not add new features — maintain only.
+
 ---
 
 ## Reporting
@@ -242,13 +290,24 @@ For each finding, report:
 2. **Severity**: Error (must fix before merge), Warning (should fix or
    file follow-up issue), Info (note for future improvement).
 3. **File and line**: exact location of the violation.
-4. **Rule**: which contract, layer rule, or PEP 8 section is violated.
+4. **Rule**: which contract, layer rule, ADR, or PEP 8 section is violated.
 5. **Recommendation**: what to change.
 
 ### Severity Guide
 
 | Severity | Criteria | Action |
 |----------|----------|--------|
-| Error | Thread safety bug, layer skip introducing new coupling, security vulnerability, bare `except:`, `None` equality comparison | Block merge |
-| Warning | Missing types at boundary, private function access across modules, missing validation, missing `__all__`, new untyped state | Fix or file issue before merge |
+| Error | Thread safety bug, layer skip introducing new coupling, security vulnerability, bare `except:`, `None` equality comparison, ADR contradiction without update | Block merge |
+| Warning | Missing types at boundary, private function access across modules, missing validation, missing `__all__`, new untyped state, overlap with upstream-marked tools | Fix or file issue before merge |
 | Info | Loose typing (`dict[str, Any]` where TypedDict exists), minor naming inconsistencies, missing type annotations on internal functions | Note in review, fix opportunistically |
+
+---
+
+## Last reviewed: 2026-06-27
+
+## Revision History
+
+| Date | Change |
+|------|--------|
+| 2026-06-19 | Initial skill — layer map, 8 review checklists, parallel dispatch model |
+| 2026-06-27 | Updated layer map (added resolution.py, text_utils.py, manifest_builder.py, cli.py). Updated known violations to current state (most fixed). Added Step 9: ADR and strategy compliance (ADRs 0006-0008). Updated state management checklist for SharedState/ServerState/SessionManager/CollectionManager. Made frontmatter agentskills.io spec-compliant. Added revision history. |

--- a/skills/pr-architecture-review/SKILL.md
+++ b/skills/pr-architecture-review/SKILL.md
@@ -205,7 +205,9 @@ For changes that add or modify module-level or session-level state:
 - [ ] **Collection state**: must go through `CollectionManager` (per-session,
   created by `SessionManager`). Never use module-level collection state.
 - [ ] **Thread safety**: any state accessed from `run_in_executor()` threads
-  MUST use `threading.Lock`. Async-only state within a session is safe.
+  MUST use `threading.Lock`. Async-only state SHOULD use `asyncio.Lock`
+  if multiple coroutines may mutate it concurrently (e.g., `set.add()`,
+  `dict[key] = val`).
 
 ### Step 6: Check Public API Surface
 
@@ -275,9 +277,9 @@ For changes that affect architecture or project direction:
 - [ ] **ADR consistency**: if a PR contradicts an existing ADR, it must
   either update the ADR or document why the deviation is necessary.
 - [ ] **Tools to keep vs drop**: changes to tools marked for upstream
-  deprecation (search_modules, search_plugins, ensure_collection,
-  get_module_doc, get_plugin_doc, get_role_doc, clear_cache) should
-  not add new features — maintain only.
+  deprecation (search_modules, search_plugins, search_collections,
+  ensure_collection, get_module_doc, get_plugin_doc, get_role_doc,
+  clear_cache) should not add new features — maintain only.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add three new ADRs for the upstream integration strategy (ADR-0006 upstream-first, ADR-0007 agentskills.io spec compliance, ADR-0008 three-layer distribution) — all status Proposed
- Add `docs/architecture/project-strategy.md` as central strategy reference
- Backfill all existing ADRs (0001-0005) with Date, Implementation Notes, Related Decisions, and Revision History sections
- Update `pr-architecture-review` skill: current layer map, spec-compliant frontmatter, Step 9 (ADR/strategy compliance), self-update check, revision history

## Test plan

- [x] ADR format consistent across all 8 ADRs (Date, Implementation Notes, Related Decisions, Revision History)
- [x] ADR README index matches all files
- [x] project-strategy.md cross-references are valid
- [x] pr-architecture-review skill passes `agentskills validate`
- [x] No code changes — docs and skill only

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>