### PR TITLE
refactor: deduplicate DocProvenance and skill listing logic

### DIFF
--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -91,13 +91,13 @@ class GalaxyClient:
         self,
         resolved_version: str,
         is_latest: bool,
-        warning: str | None = None,
+        warning: str,
     ) -> DocProvenance:
         meta: DocProvenance = {
             "doc_source": "galaxy",
             "doc_version": resolved_version,
         }
-        if is_latest and warning:
+        if is_latest:
             meta["doc_warning"] = warning
         if self.server_name:
             meta["doc_source_server"] = self.server_name

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -87,6 +87,22 @@ class GalaxyClient:
             ENRICHMENT_CONCURRENCY,
         )
 
+    def _build_provenance(
+        self,
+        resolved_version: str,
+        is_latest: bool,
+        warning: str | None = None,
+    ) -> DocProvenance:
+        meta: DocProvenance = {
+            "doc_source": "galaxy",
+            "doc_version": resolved_version,
+        }
+        if is_latest and warning:
+            meta["doc_warning"] = warning
+        if self.server_name:
+            meta["doc_source_server"] = self.server_name
+        return meta
+
     @classmethod
     def from_config(
         cls,
@@ -378,18 +394,12 @@ class GalaxyClient:
         from ansible_know.parser import transform_galaxy_to_ansible_doc_format
         doc = transform_galaxy_to_ansible_doc_format(module_name, module_entry)
 
-        meta: DocProvenance = {
-            "doc_source": "galaxy",
-            "doc_version": resolved_version,
-        }
-        if is_latest:
-            meta["doc_warning"] = (
-                f"Documentation sourced from Galaxy "
-                f"({namespace}.{name} {resolved_version}). "
-                f"Your installed version may differ."
-            )
-        if self.server_name:
-            meta["doc_source_server"] = self.server_name
+        meta = self._build_provenance(
+            resolved_version, is_latest,
+            f"Documentation sourced from Galaxy "
+            f"({namespace}.{name} {resolved_version}). "
+            f"Your installed version may differ.",
+        )
         return doc, meta
 
     async def fetch_role_doc(
@@ -443,16 +453,10 @@ class GalaxyClient:
             "examples": parsed.get("examples", ""),
         }
 
-        meta: DocProvenance = {
-            "doc_source": "galaxy",
-            "doc_version": resolved_version,
-        }
-        if is_latest:
-            meta["doc_warning"] = (
-                "Documentation parsed from Galaxy README (best-effort)."
-            )
-        if self.server_name:
-            meta["doc_source_server"] = self.server_name
+        meta = self._build_provenance(
+            resolved_version, is_latest,
+            "Documentation parsed from Galaxy README (best-effort).",
+        )
         return role_metadata, meta
 
     async def fetch_plugin_doc(
@@ -478,18 +482,12 @@ class GalaxyClient:
         from ansible_know.parser import transform_galaxy_to_ansible_doc_format
         doc = transform_galaxy_to_ansible_doc_format(plugin_name, plugin_entry)
 
-        meta: DocProvenance = {
-            "doc_source": "galaxy",
-            "doc_version": resolved_version,
-        }
-        if is_latest:
-            meta["doc_warning"] = (
-                f"Documentation sourced from Galaxy "
-                f"({namespace}.{name} {resolved_version}). "
-                f"Your installed version may differ."
-            )
-        if self.server_name:
-            meta["doc_source_server"] = self.server_name
+        meta = self._build_provenance(
+            resolved_version, is_latest,
+            f"Documentation sourced from Galaxy "
+            f"({namespace}.{name} {resolved_version}). "
+            f"Your installed version may differ.",
+        )
         return doc, meta
 
     async def fetch_collection_docs(
@@ -545,18 +543,12 @@ class GalaxyClient:
             except Exception:
                 logger.warning("Skipping module %s: metadata extraction failed", fqcn, exc_info=True)
 
-        meta: DocProvenance = {
-            "doc_source": "galaxy",
-            "doc_version": resolved_version,
-        }
-        if is_latest:
-            meta["doc_warning"] = (
-                f"Documentation sourced from Galaxy "
-                f"({namespace}.{name} {resolved_version}). "
-                f"Your installed version may differ."
-            )
-        if self.server_name:
-            meta["doc_source_server"] = self.server_name
+        meta = self._build_provenance(
+            resolved_version, is_latest,
+            f"Documentation sourced from Galaxy "
+            f"({namespace}.{name} {resolved_version}). "
+            f"Your installed version may differ.",
+        )
         return result, meta
 
     async def list_collection_modules(

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -823,8 +823,8 @@ async def ensure_collection(
 async def list_skills(
     collection: Annotated[
         str | None,
-        "Optional collection namespace to list skills within (e.g. 'netbox.netbox'). "
-        "Without this, returns collection-level skill entries and standalone skills only.",
+        "Optional collection namespace to filter skills (e.g. 'netbox.netbox'). "
+        "Without this, returns all skills.",
     ] = None,
 ) -> list[SkillEntry] | ErrorResponse:
     """List all available generated skills. Returns name, description, path for each.

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1334,31 +1334,11 @@ async def clear_cache(
 def resource_skills_list() -> str:
     import json
 
-    from ansible_know.config import PLUGIN_TYPES, SKILLS_DIR
-    from ansible_know.skills import (
-        PLUGIN_SKILL_DIR_RE,
-        skill_dir_to_collection_fqcn,
-        skill_dir_to_short_fqcn,
-    )
+    from ansible_know.config import SKILLS_DIR
+    from ansible_know.skills import list_skills_sync
 
-    skills_list: list[str] = []
-    if SKILLS_DIR.exists():
-        for skill_dir in sorted(SKILLS_DIR.iterdir()):
-            if not skill_dir.is_dir() or skill_dir.is_symlink():
-                continue
-            collection_fqcn = skill_dir_to_collection_fqcn(skill_dir.name)
-            skill_md = skill_dir / "SKILL.md"
-            if skill_md.exists():
-                skills_list.append(collection_fqcn)
-            for sub_dir in sorted(skill_dir.iterdir()):
-                if sub_dir.is_dir() and not sub_dir.is_symlink() and (sub_dir / "SKILL.md").exists():
-                    dir_name = sub_dir.name
-                    match = PLUGIN_SKILL_DIR_RE.match(dir_name)
-                    if match and match.group(1) in PLUGIN_TYPES:
-                        skills_list.append(f"{collection_fqcn}.{skill_dir_to_short_fqcn(match.group(2))}")
-                    else:
-                        skills_list.append(f"{collection_fqcn}.{skill_dir_to_short_fqcn(dir_name)}")
-    return json.dumps(skills_list, indent=2)
+    entries = list_skills_sync(SKILLS_DIR, collection=None)
+    return json.dumps([e["name"] for e in entries], indent=2)
 
 
 @mcp.resource(

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -215,16 +215,45 @@ def extract_skill_description(skill_md: Path) -> str:
     return ""
 
 
+def _list_nested_skills(
+    collection_dir: Path,
+    collection_fqcn: str,
+) -> list[SkillEntry]:
+    """List module/role/plugin skills within a collection directory."""
+    from ansible_know.config import PLUGIN_TYPES
+
+    results: list[SkillEntry] = []
+    for sub_dir in sorted(collection_dir.iterdir()):
+        try:
+            skill_md = sub_dir / "SKILL.md"
+            if sub_dir.is_dir() and not sub_dir.is_symlink() and skill_md.exists():
+                dir_name = sub_dir.name
+                match = PLUGIN_SKILL_DIR_RE.match(dir_name)
+                if match and match.group(1) in PLUGIN_TYPES:
+                    display_name = f"{collection_fqcn}.{skill_dir_to_short_fqcn(match.group(2))}"
+                else:
+                    display_name = f"{collection_fqcn}.{skill_dir_to_short_fqcn(dir_name)}"
+                results.append({
+                    "name": display_name,
+                    "description": extract_skill_description(skill_md),
+                    "path": str(sub_dir),
+                })
+        except OSError:
+            logger.warning("Skipping unreadable skill: %s", sub_dir.name)
+            continue
+    return results
+
+
 def list_skills_sync(
     skills_dir: Path, collection: str | None,
 ) -> list[SkillEntry]:
     """List generated skills from *skills_dir*.
 
     When *collection* is given, returns module/role/plugin skills within that
-    collection directory.  Otherwise returns top-level (collection-level and
-    standalone) skill entries.
+    collection directory.  Otherwise returns all skills: collection-level
+    entries followed by their nested module/role/plugin skills.
     """
-    results: list[dict[str, str]] = []
+    results: list[SkillEntry] = []
     if not skills_dir.exists():
         return results
 
@@ -234,40 +263,24 @@ def list_skills_sync(
         validate_path_containment(collection_dir, skills_dir)
         if not collection_dir.is_dir():
             return results
-        for sub_dir in sorted(collection_dir.iterdir()):
-            try:
-                skill_md = sub_dir / "SKILL.md"
-                if sub_dir.is_dir() and not sub_dir.is_symlink() and skill_md.exists():
-                    dir_name = sub_dir.name
-                    from ansible_know.config import PLUGIN_TYPES
-                    match = PLUGIN_SKILL_DIR_RE.match(dir_name)
-                    if match and match.group(1) in PLUGIN_TYPES:
-                        display_name = f"{collection}.{skill_dir_to_short_fqcn(match.group(2))}"
-                    else:
-                        display_name = f"{collection}.{skill_dir_to_short_fqcn(dir_name)}"
-                    results.append({
-                        "name": display_name,
-                        "description": extract_skill_description(skill_md),
-                        "path": str(sub_dir),
-                    })
-            except OSError:
-                logger.warning("Skipping unreadable skill: %s", sub_dir.name)
+        return _list_nested_skills(collection_dir, collection)
+
+    for skill_dir in sorted(skills_dir.iterdir()):
+        try:
+            if not skill_dir.is_dir() or skill_dir.is_symlink():
                 continue
-    else:
-        for skill_dir in sorted(skills_dir.iterdir()):
-            try:
-                if not skill_dir.is_dir() or skill_dir.is_symlink():
-                    continue
-                skill_md = skill_dir / "SKILL.md"
-                if skill_md.exists():
-                    results.append({
-                        "name": skill_dir.name,
-                        "description": extract_skill_description(skill_md),
-                        "path": str(skill_dir),
-                    })
-            except OSError:
-                logger.warning("Skipping unreadable skill: %s", skill_dir.name)
-                continue
+            collection_fqcn = skill_dir_to_collection_fqcn(skill_dir.name)
+            skill_md = skill_dir / "SKILL.md"
+            if skill_md.exists():
+                results.append({
+                    "name": collection_fqcn,
+                    "description": extract_skill_description(skill_md),
+                    "path": str(skill_dir),
+                })
+            results.extend(_list_nested_skills(skill_dir, collection_fqcn))
+        except OSError:
+            logger.warning("Skipping unreadable skill: %s", skill_dir.name)
+            continue
     return results
 
 


### PR DESCRIPTION
## Summary

- **#136**: Extract `_build_provenance()` helper in `GalaxyClient` to replace 4 inline `DocProvenance` dict constructions across `fetch_module_doc`, `fetch_role_doc`, `fetch_plugin_doc`, and `fetch_collection_docs`
- **#131**: Extend `list_skills_sync(collection=None)` to return nested module/plugin skills (not just top-level entries), then delegate `resource_skills_list` resource handler to it — eliminating ~20 lines of duplicated directory traversal in `server.py`

Both refactors were identified during architecture reviews of PRs #130 and #135.

## Changes

### `galaxy.py`
- New `_build_provenance(resolved_version, is_latest, warning)` private method
- 4 call sites simplified from 8-12 lines each to 4-5 lines

### `skills.py`
- Extracted `_list_nested_skills()` helper for sub-directory traversal (used by both code paths)
- `list_skills_sync(collection=None)` now returns all skills (collection-level + nested), using `skill_dir_to_collection_fqcn` for consistent FQCN naming
- Fixed `results` type annotation from `list[dict[str, str]]` to `list[SkillEntry]`

### `server.py`
- `resource_skills_list` reduced from 22 lines to 5 lines, delegating entirely to `list_skills_sync`

## Test plan

- [x] All 736 unit tests pass
- [x] Ruff lint clean
- [ ] Verify `skills://list` resource returns same results as before
- [ ] Verify `list_skills` tool returns comprehensive results (now includes nested skills)

Closes #131, closes #136

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>