### PR TITLE
fix: defense-in-depth hardening from v0.6.0 review

### DIFF
--- a/src/ansible_know/collection_manifest.py
+++ b/src/ansible_know/collection_manifest.py
@@ -170,11 +170,16 @@ def load_cached_manifest(
     if skills_dir is None:
         skills_dir = SKILLS_DIR
 
-    manifest_path = skills_dir / collection_skill_name(collection_namespace) / "MANIFEST.json"
+    collection_dir = (skills_dir / collection_skill_name(collection_namespace)).resolve()
+    validate_path_containment(collection_dir, skills_dir)
+    manifest_path = collection_dir / "MANIFEST.json"
     if not manifest_path.exists():
         return None
 
-    manifest = json.loads(manifest_path.read_text())
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
     if installed_version and manifest.get("collection_version") != installed_version:
         return None
 

--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -222,7 +222,7 @@ async def _search_rtd_api(
                 "audience": [],
                 "lines": 0,
                 "source": f"rtd-search:{source_name}",
-                "url": f"{hit.get('domain', RTD_DOCS_DOMAIN)}{path}",
+                "url": f"{RTD_DOCS_DOMAIN}{path}",
             })
         return hits
 

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -28,7 +28,7 @@ CACHE_TTL_SECONDS = 3600
 
 TIMEOUT_FAST = httpx.Timeout(10.0)
 TIMEOUT_DEFAULT = httpx.Timeout(10.0, read=30.0)
-TIMEOUT_SLOW = httpx.Timeout(10.0, read=60.0)
+TIMEOUT_SLOW = httpx.Timeout(10.0, read=120.0)
 
 ENRICHMENT_CONCURRENCY = 5
 MAX_DISCOVERY_RESPONSE_SIZE = 100_000  # 100KB — discovery payloads are tiny
@@ -155,7 +155,7 @@ class GalaxyClient:
             return self._http_client
         if self._owned_client is None:
             self._owned_client = httpx.AsyncClient(
-                timeout=httpx.Timeout(10.0, read=120.0),
+                timeout=TIMEOUT_SLOW,
                 verify=self._verify,
                 follow_redirects=True,
             )

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -1100,7 +1100,7 @@ class TestTimeoutConstants:
 
     def test_timeout_slow_values(self):
         assert TIMEOUT_SLOW.connect == 10.0
-        assert TIMEOUT_SLOW.read == 60.0
+        assert TIMEOUT_SLOW.read == 120.0
         assert TIMEOUT_SLOW.write == 10.0
         assert TIMEOUT_SLOW.pool == 10.0
 


### PR DESCRIPTION
## Summary

Fixes four defense-in-depth items from the v0.6.0 pre-release review (#133).

1. **Path containment check in `load_cached_manifest`** — mirrors `write_manifest`'s `validate_path_containment` call for consistency (namespace regex already prevents traversal)
2. **`JSONDecodeError`/`OSError` handling in `load_cached_manifest`** — returns `None` on corrupted cache to trigger regeneration instead of propagating
3. **Use `TIMEOUT_SLOW` constant in `GalaxyClient._get_client()`** — replaces hardcoded `httpx.Timeout(10.0, read=120.0)` with the module-level constant; bumps `TIMEOUT_SLOW` from 60s to 120s read to match the original owned-client intent
4. **Always use `RTD_DOCS_DOMAIN` in `_search_rtd_api`** — ignores `domain` field from RTD API response to prevent URL manipulation if API were compromised

**Note on #132:** The type mismatch described in #132 was already resolved on main — all three `resolve_*_doc` functions now return properly typed `Get*DocResult | ErrorResponse` unions. #132 can be closed separately.

## Test plan

- [x] All tests pass (775 passed, 80 skipped; 1 pre-existing failure in `TestFetchModuleDoc::test_returns_ansible_doc_format` unrelated to these changes)
- [x] `ruff check` clean
- [x] `TIMEOUT_SLOW` test updated to reflect 120s read timeout

Closes #133

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>