### PR TITLE
fix: add negative cache for Galaxy API discovery failures

### DIFF
--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -99,6 +99,7 @@ class GalaxyClient:
         self._api_root: str | None = None
         self._v3_path: str | None = None
         self._discovery_lock = asyncio.Lock()
+        self._discovery_failed: bool = False
 
     def _build_provenance(
         self,
@@ -222,6 +223,15 @@ class GalaxyClient:
         if self._api_root is not None:
             return
 
+        if self._discovery_failed:
+            server_label = self.server_name or "default"
+            raise GalaxyError(
+                f"Galaxy API discovery previously failed for server "
+                f"'{server_label}'. Check the server URL and credentials "
+                f"in ansible.cfg, then restart the MCP server session "
+                f"to retry."
+            )
+
         async with self._discovery_lock:
             if self._api_root is not None:
                 return
@@ -272,6 +282,7 @@ class GalaxyClient:
 
             server_label = self.server_name or "default"
             if data is None or "available_versions" not in data:
+                self._discovery_failed = True
                 if got_auth_error:
                     raise GalaxyError(
                         f"Galaxy API root discovery failed for server "
@@ -288,6 +299,7 @@ class GalaxyClient:
 
             versions = data["available_versions"]
             if "v3" not in versions:
+                self._discovery_failed = True
                 raise GalaxyError(
                     f"Galaxy server '{server_label}' does not "
                     f"support API v3 (available: {', '.join(versions.keys())}). "
@@ -296,6 +308,7 @@ class GalaxyClient:
 
             v3_path = versions["v3"]
             if ".." in v3_path or not _SAFE_V3_PATH_RE.match(v3_path):
+                self._discovery_failed = True
                 raise GalaxyError(
                     f"Galaxy server '{server_label}' returned "
                     f"unsafe v3 path. Verify the server URL in ansible.cfg."

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -235,6 +235,14 @@ class GalaxyClient:
         async with self._discovery_lock:
             if self._api_root is not None:
                 return
+            if self._discovery_failed:
+                server_label = self.server_name or "default"
+                raise GalaxyError(
+                    f"Galaxy API discovery previously failed for server "
+                    f"'{server_label}'. Check the server URL and credentials "
+                    f"in ansible.cfg, then restart the MCP server session "
+                    f"to retry."
+                )
 
             client = self._get_client()
             headers = await self._resolve_auth_headers()

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -1,5 +1,6 @@
 """Tests for ansible_know.galaxy."""
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 from unittest.mock import patch as stdlib_patch
@@ -1889,6 +1890,38 @@ class TestApiRootDiscovery:
 
         assert gc._discovery_failed is False
         assert gc._api_root is not None
+
+    @pytest.mark.asyncio
+    async def test_negative_cache_concurrent_double_check(self):
+        """Concurrent coroutines don't bypass the negative cache inside the lock."""
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404", request=MagicMock(), response=MagicMock(status_code=404),
+        )
+        mock_resp.content = b""
+
+        call_count = 0
+        mock_client = AsyncMock()
+
+        async def mock_get(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return mock_resp
+        mock_client.get = mock_get
+
+        gc = GalaxyClient(
+            base_url="https://broken.example.com",
+            http_client=mock_client,
+        )
+
+        results = await asyncio.gather(
+            gc._discover_api_root(),
+            gc._discover_api_root(),
+            return_exceptions=True,
+        )
+
+        assert all(isinstance(r, GalaxyError) for r in results)
+        assert call_count == 2
 
 
 class TestBuildV3Url:

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -1808,6 +1808,88 @@ class TestApiRootDiscovery:
         with pytest.raises(GalaxyError, match="authentication failed"):
             await gc._discover_api_root()
 
+    @pytest.mark.asyncio
+    async def test_negative_cache_skips_retry(self):
+        """After discovery fails, subsequent calls raise immediately without HTTP."""
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404", request=MagicMock(), response=MagicMock(status_code=404),
+        )
+        mock_resp.content = b""
+
+        call_count = 0
+        mock_client = AsyncMock()
+
+        async def mock_get(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return mock_resp
+        mock_client.get = mock_get
+
+        gc = GalaxyClient(
+            base_url="https://broken.example.com",
+            http_client=mock_client,
+        )
+
+        with pytest.raises(GalaxyError):
+            await gc._discover_api_root()
+
+        http_calls_after_first = call_count
+
+        with pytest.raises(GalaxyError):
+            await gc._discover_api_root()
+
+        assert call_count == http_calls_after_first
+
+    @pytest.mark.asyncio
+    async def test_negative_cache_message_mentions_restart(self):
+        """Cached failure message tells user to check config and restart."""
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404", request=MagicMock(), response=MagicMock(status_code=404),
+        )
+        mock_resp.content = b""
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        gc = GalaxyClient(
+            base_url="https://broken.example.com",
+            http_client=mock_client,
+            server_name="my_hub",
+        )
+
+        with pytest.raises(GalaxyError):
+            await gc._discover_api_root()
+
+        with pytest.raises(GalaxyError, match="restart") as exc_info:
+            await gc._discover_api_root()
+
+        assert "my_hub" in str(exc_info.value)
+        assert "ansible.cfg" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_negative_cache_not_set_on_success(self):
+        """Successful discovery does not set the failure flag."""
+        discovery_response = {"available_versions": {"v3": "v3/"}}
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = discovery_response
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.content = b"{}"
+        mock_resp.headers = {}
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        gc = GalaxyClient(
+            base_url="https://galaxy.example.com",
+            http_client=mock_client,
+        )
+        await gc._discover_api_root()
+
+        assert gc._discovery_failed is False
+        assert gc._api_root is not None
+
 
 class TestBuildV3Url:
     def test_standard_collection_url(self):


### PR DESCRIPTION
## Summary

- When `_discover_api_root()` fails (wrong URL, auth failure, no v3 support), cache the failure permanently for the client instance
- Subsequent API calls raise `GalaxyError` immediately instead of re-probing the server on every call
- Error message guides users: "Check the server URL and credentials in ansible.cfg, then restart the MCP server session to retry"

## Motivation

In multi-server configs, a misconfigured server (e.g., unreachable Private AH) causes every tool call to pay a 10-20s timeout penalty for discovery probes that will always fail. With the negative cache, only the first call pays the penalty.

## Changes

- `galaxy.py`: Added `_discovery_failed` flag to `__init__`, guard check at top of `_discover_api_root()`, flag set before each error-path raise
- `test_galaxy.py`: 3 new tests — no retry after failure, error message content, flag not set on success

## Test plan

- [x] 3 new tests in `TestApiRootDiscovery` covering all behaviors
- [x] Full suite: 779 passed, 80 skipped
- [x] Ruff lint clean

Fixes #157

Assisted-by: Claude Opus 4.6