### PR TITLE
fix: harden fetch_doc against Cloudflare challenges and transient failures

### DIFF
--- a/src/ansible_know/config.py
+++ b/src/ansible_know/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from importlib.metadata import version as pkg_version
 from pathlib import Path
 
 _PKG_DIR = Path(__file__).resolve().parent
@@ -23,6 +24,15 @@ def _get_cache_dir() -> Path:
 
 
 CACHE_DIR = _get_cache_dir()
+
+try:
+    USER_AGENT = (
+        f"ansible-know-mcp/{pkg_version('ansible-know-mcp')}"
+        " (+https://github.com/leogallego/ansible-know-mcp)"
+    )
+except Exception:
+    USER_AGENT = "ansible-know-mcp/unknown (+https://github.com/leogallego/ansible-know-mcp)"
+
 
 def __getattr__(name: str):
     if name == "SKILLS_DIR":

--- a/src/ansible_know/config.py
+++ b/src/ansible_know/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from pathlib import Path
 
@@ -30,7 +31,7 @@ try:
         f"ansible-know-mcp/{pkg_version('ansible-know-mcp')}"
         " (+https://github.com/leogallego/ansible-know-mcp)"
     )
-except Exception:
+except PackageNotFoundError:
     USER_AGENT = "ansible-know-mcp/unknown (+https://github.com/leogallego/ansible-know-mcp)"
 
 

--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from itertools import zip_longest
 from pathlib import Path
 from typing import Any
@@ -17,7 +18,13 @@ from typing import Any
 import httpx
 
 from ansible_know.cache import BoundedCache
-from ansible_know.config import CACHE_DIR, RTD_PROJECT_SLUGS, SEARCH_DOCS_LIMIT, get_doc_sources
+from ansible_know.config import (
+    CACHE_DIR,
+    RTD_PROJECT_SLUGS,
+    SEARCH_DOCS_LIMIT,
+    USER_AGENT,
+    get_doc_sources,
+)
 from ansible_know.errors import AnsibleKnowError
 from ansible_know.text_utils import clean_rtd_markdown
 from ansible_know.types import FetchDocResult, SearchDocsEntry
@@ -42,6 +49,48 @@ _manifest_cache: BoundedCache[str, list[dict[str, Any]]] = BoundedCache(
     path=CACHE_DIR / "doc-manifests.json",
 )
 
+PAGE_CACHE_TTL = 86400
+PAGE_CACHE_MAX = 100
+DOC_RATE_LIMIT_INTERVAL = 1.0
+MAX_RETRY_ATTEMPTS = 3
+RETRY_BACKOFF_BASE = 2.0
+RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+_page_cache: BoundedCache[str, dict[str, Any]] = BoundedCache(
+    max_size=PAGE_CACHE_MAX, ttl=PAGE_CACHE_TTL,
+    path=CACHE_DIR / "doc-pages.json",
+)
+
+_doc_throttle_lock = asyncio.Lock()
+_doc_last_request: float = 0.0
+
+
+async def _throttle_doc_request() -> None:
+    """Enforce minimum interval between docs.ansible.com requests."""
+    global _doc_last_request
+    async with _doc_throttle_lock:
+        now = time.monotonic()
+        elapsed = now - _doc_last_request
+        if _doc_last_request > 0 and elapsed < DOC_RATE_LIMIT_INTERVAL:
+            await asyncio.sleep(DOC_RATE_LIMIT_INTERVAL - elapsed)
+        _doc_last_request = time.monotonic()
+
+
+def _is_cf_challenge(resp: httpx.Response) -> bool:
+    """Detect Cloudflare managed challenge responses."""
+    return "challenge" in resp.headers.get("cf-mitigated", "").lower()
+
+
+def _parse_retry_after(resp: httpx.Response, attempt: int) -> float:
+    """Extract retry delay from Retry-After header or use exponential backoff."""
+    header = resp.headers.get("retry-after", "")
+    if header:
+        try:
+            delay = float(header)
+            return min(delay, 30.0)
+        except ValueError:
+            pass
+    return min(RETRY_BACKOFF_BASE ** attempt, 30.0)
 
 
 def _postprocess_entries(
@@ -339,8 +388,9 @@ async def search_docs(
 
 
 def clear_cache() -> None:
-    """Clear the manifest cache."""
+    """Clear the manifest and page caches."""
     _manifest_cache.clear()
+    _page_cache.clear()
 
 
 MAX_DOC_FETCH_SIZE = 2_000_000  # 2MB
@@ -352,6 +402,10 @@ async def fetch_doc_content(
 ) -> FetchDocResult:
     """Fetch a docs.ansible.com page as clean markdown.
 
+    Uses a disk-backed page cache (24h TTL), rate limiting (1 req/sec),
+    retry with backoff for transient errors, and Cloudflare challenge
+    detection.
+
     Args:
         url: Full docs.ansible.com URL (caller must validate first).
         max_tokens: If set, raise when page exceeds this token count.
@@ -361,44 +415,49 @@ async def fetch_doc_content(
         FetchDocResult on success.
 
     Raises:
-        httpx.HTTPError: On HTTP request failure.
-        AnsibleKnowError: On content-type mismatch, size/token limit, or redirect to unexpected domain.
+        httpx.HTTPError: On HTTP request failure after retries.
+        AnsibleKnowError: On CF challenge, content-type mismatch,
+            size/token limit, or redirect to unexpected domain.
     """
+    cached = _page_cache.get(url)
+    if cached is not None:
+        if max_tokens is not None and cached.get("tokens", 0) > max_tokens:
+            raise AnsibleKnowError(
+                f"Page has {cached['tokens']} tokens (max_tokens={max_tokens}). "
+                f"Fetch without max_tokens or increase the limit."
+            )
+        return cached  # type: ignore[return-value]
+
     client = http_client
     should_close = False
     if client is None:
-        client = httpx.AsyncClient(timeout=httpx.Timeout(30.0))
+        client = httpx.AsyncClient(
+            timeout=httpx.Timeout(30.0),
+            headers={"User-Agent": USER_AGENT},
+        )
         should_close = True
 
     try:
-        resp = await client.get(
-            url,
-            headers={"Accept": "text/markdown"},
-            follow_redirects=True,
-            timeout=30.0,
-        )
-        resp.raise_for_status()
-
-        if resp.url.host != "docs.ansible.com":
-            raise AnsibleKnowError(f"Redirect to unexpected domain: {resp.url.host}")
-
-        if len(resp.content) > MAX_DOC_FETCH_SIZE:
-            raise AnsibleKnowError(
-                f"Response too large: {len(resp.content)} bytes (max {MAX_DOC_FETCH_SIZE})"
-            )
-
-        resp_text = resp.text
-        resp_headers = resp.headers
-        resp_url = str(resp.url)
+        resp = await _fetch_with_retry(client, url)
     finally:
         if should_close:
             await client.aclose()
 
-    content_type = resp_headers.get("content-type", "")
-    if "text/markdown" not in content_type:
-        raise AnsibleKnowError(f"Expected text/markdown but got {content_type!r} for {url}")
+    if resp.url.host != "docs.ansible.com":
+        raise AnsibleKnowError(f"Redirect to unexpected domain: {resp.url.host}")
 
-    tokens_str = resp_headers.get("x-markdown-tokens", "0")
+    if len(resp.content) > MAX_DOC_FETCH_SIZE:
+        raise AnsibleKnowError(
+            f"Response too large: {len(resp.content)} bytes (max {MAX_DOC_FETCH_SIZE})"
+        )
+
+    content_type = resp.headers.get("content-type", "")
+    if "text/markdown" not in content_type:
+        raise AnsibleKnowError(
+            f"Expected text/markdown but got {content_type!r} for {url}"
+        )
+
+    tokens_str = resp.headers.get("x-markdown-tokens", "0")
     try:
         tokens = int(tokens_str)
     except ValueError:
@@ -410,12 +469,67 @@ async def fetch_doc_content(
             f"Fetch without max_tokens or increase the limit."
         )
 
-    content, title = clean_rtd_markdown(resp_text)
+    content, title = clean_rtd_markdown(resp.text)
     content = truncate_response(content)
 
-    return {
+    result: FetchDocResult = {
         "content": content,
         "title": title,
         "tokens": tokens,
-        "source_url": resp_url,
+        "source_url": str(resp.url),
     }
+    _page_cache.put(url, result)
+    return result
+
+
+async def _fetch_with_retry(
+    client: httpx.AsyncClient, url: str,
+) -> httpx.Response:
+    """Fetch a URL with rate limiting, retry, and CF challenge detection."""
+    last_exc: Exception | None = None
+
+    for attempt in range(MAX_RETRY_ATTEMPTS):
+        await _throttle_doc_request()
+
+        try:
+            resp = await client.get(
+                url,
+                headers={"Accept": "text/markdown", "User-Agent": USER_AGENT},
+                follow_redirects=True,
+                timeout=30.0,
+            )
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+            last_exc = exc
+            if attempt < MAX_RETRY_ATTEMPTS - 1:
+                delay = min(RETRY_BACKOFF_BASE ** attempt, 30.0)
+                logger.debug(
+                    "fetch_doc attempt %d/%d failed (%s), retrying in %.1fs",
+                    attempt + 1, MAX_RETRY_ATTEMPTS, type(exc).__name__, delay,
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise
+
+        if _is_cf_challenge(resp):
+            raise AnsibleKnowError(
+                "docs.ansible.com returned a Cloudflare managed challenge "
+                "(bot detection). This is transient — try again later. "
+                "Use search_docs for local results that don't require network access."
+            )
+
+        if resp.status_code in RETRYABLE_STATUS_CODES:
+            if attempt < MAX_RETRY_ATTEMPTS - 1:
+                delay = _parse_retry_after(resp, attempt)
+                logger.debug(
+                    "fetch_doc attempt %d/%d got HTTP %d, retrying in %.1fs",
+                    attempt + 1, MAX_RETRY_ATTEMPTS, resp.status_code, delay,
+                )
+                await asyncio.sleep(delay)
+                continue
+            resp.raise_for_status()
+
+        resp.raise_for_status()
+        return resp
+
+    assert last_exc is not None
+    raise last_exc

--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -62,13 +62,15 @@ _page_cache: BoundedCache[str, FetchDocResult] = BoundedCache(
     path=CACHE_DIR / "doc-pages.json",
 )
 
-_doc_throttle_lock = asyncio.Lock()
+_doc_throttle_lock: asyncio.Lock | None = None
 _doc_last_request: float = 0.0
 
 
 async def _throttle_doc_request() -> None:
     """Enforce minimum interval between docs.ansible.com requests."""
-    global _doc_last_request
+    global _doc_last_request, _doc_throttle_lock
+    if _doc_throttle_lock is None:
+        _doc_throttle_lock = asyncio.Lock()
     async with _doc_throttle_lock:
         now = time.monotonic()
         elapsed = now - _doc_last_request
@@ -433,10 +435,7 @@ async def fetch_doc_content(
     client = http_client
     should_close = False
     if client is None:
-        client = httpx.AsyncClient(
-            timeout=httpx.Timeout(30.0),
-            headers={"User-Agent": USER_AGENT},
-        )
+        client = httpx.AsyncClient(timeout=httpx.Timeout(30.0))
         should_close = True
 
     try:
@@ -488,8 +487,6 @@ async def _fetch_with_retry(
     client: httpx.AsyncClient, url: str,
 ) -> httpx.Response:
     """Fetch a URL with rate limiting, retry, and CF challenge detection."""
-    last_exc: Exception | None = None
-
     for attempt in range(MAX_RETRY_ATTEMPTS):
         await _throttle_doc_request()
 
@@ -501,7 +498,6 @@ async def _fetch_with_retry(
                 timeout=30.0,
             )
         except httpx.TransportError as exc:
-            last_exc = exc
             if attempt < MAX_RETRY_ATTEMPTS - 1:
                 delay = min(RETRY_BACKOFF_BASE ** attempt, 30.0)
                 logger.debug(
@@ -533,5 +529,4 @@ async def _fetch_with_retry(
         resp.raise_for_status()
         return resp
 
-    assert last_exc is not None
-    raise last_exc
+    raise RuntimeError("unreachable")

--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import time
 from itertools import zip_longest
 from pathlib import Path
@@ -56,7 +57,7 @@ MAX_RETRY_ATTEMPTS = 3
 RETRY_BACKOFF_BASE = 2.0
 RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
 
-_page_cache: BoundedCache[str, dict[str, Any]] = BoundedCache(
+_page_cache: BoundedCache[str, FetchDocResult] = BoundedCache(
     max_size=PAGE_CACHE_MAX, ttl=PAGE_CACHE_TTL,
     path=CACHE_DIR / "doc-pages.json",
 )
@@ -87,7 +88,8 @@ def _parse_retry_after(resp: httpx.Response, attempt: int) -> float:
     if header:
         try:
             delay = float(header)
-            return min(delay, 30.0)
+            if math.isfinite(delay):
+                return max(0.0, min(delay, 30.0))
         except ValueError:
             pass
     return min(RETRY_BACKOFF_BASE ** attempt, 30.0)
@@ -426,7 +428,7 @@ async def fetch_doc_content(
                 f"Page has {cached['tokens']} tokens (max_tokens={max_tokens}). "
                 f"Fetch without max_tokens or increase the limit."
             )
-        return cached  # type: ignore[return-value]
+        return cached
 
     client = http_client
     should_close = False
@@ -498,7 +500,7 @@ async def _fetch_with_retry(
                 follow_redirects=True,
                 timeout=30.0,
             )
-        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+        except httpx.TransportError as exc:
             last_exc = exc
             if attempt < MAX_RETRY_ATTEMPTS - 1:
                 delay = min(RETRY_BACKOFF_BASE ** attempt, 30.0)

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -120,10 +120,13 @@ async def app_lifespan(server):
         auth_type = "token" if gs.token else ("basic" if gs.username else "none")
         logger.info("Galaxy server: %s (%s, auth=%s)", gs.name, gs.url, auth_type)
 
+    from ansible_know.config import USER_AGENT
+
     async with httpx.AsyncClient(
         timeout=httpx.Timeout(10.0, read=120.0),
         verify=True,
         follow_redirects=True,
+        headers={"User-Agent": USER_AGENT},
     ) as client:
         shared.version_info = await _check_pypi_version(client)
         check_task = asyncio.create_task(
@@ -1306,7 +1309,7 @@ async def clear_cache(
 ) -> ClearCacheResult | ErrorResponse:
     """Clear server caches.
 
-    Clears Galaxy version/docs-blob caches, doc manifest caches, or both.
+    Clears Galaxy version/docs-blob caches, doc manifest/page caches, or both.
     Useful when cached data becomes stale during long-running sessions.
     """
     logger.info("clear_cache scope=%r", scope)
@@ -1323,7 +1326,7 @@ async def clear_cache(
     if scope in (None, "docs"):
         from ansible_know import docs
         docs.clear_cache()
-        cleared.append("doc_manifests")
+        cleared.extend(["doc_manifests", "doc_pages"])
 
     return {"cleared": cleared}
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -604,9 +604,11 @@ def _reset_fetch_doc_state():
     """Reset page cache and throttle between tests."""
     docs_mod._page_cache.clear()
     docs_mod._doc_last_request = 0.0
+    docs_mod._doc_throttle_lock = None
     yield
     docs_mod._page_cache.clear()
     docs_mod._doc_last_request = 0.0
+    docs_mod._doc_throttle_lock = None
 
 
 class TestFetchDocUserAgent:
@@ -692,6 +694,47 @@ class TestFetchDocRateLimit:
             if c.args and c.args[0] > 0
         ]
         assert len(sleep_calls) >= 1
+
+
+class TestParseRetryAfter:
+    """Direct tests for _parse_retry_after edge cases."""
+
+    def _make_resp(self, retry_after: str) -> MagicMock:
+        resp = MagicMock()
+        resp.headers = {"retry-after": retry_after}
+        return resp
+
+    @pytest.mark.parametrize("header,expected", [
+        ("2", 2.0),
+        ("0", 0.0),
+        ("30", 30.0),
+        ("60", 30.0),       # capped at 30
+        ("-5", 0.0),        # negative → clamped to 0
+        ("nan", None),      # NaN → fallback
+        ("inf", None),      # inf → fallback
+        ("-inf", None),     # -inf → fallback
+        ("not-a-number", None),  # non-numeric → fallback
+        ("Wed, 01 Jul 2026 00:00:00 GMT", None),  # HTTP-date → fallback
+    ])
+    def test_edge_cases(self, header, expected):
+        from ansible_know.docs import _parse_retry_after
+
+        resp = self._make_resp(header)
+        result = _parse_retry_after(resp, attempt=1)
+        if expected is not None:
+            assert result == expected
+        else:
+            # Should fall back to exponential backoff: 2.0 ** 1 = 2.0
+            assert result == 2.0
+
+    def test_empty_header_uses_backoff(self):
+        from ansible_know.docs import _parse_retry_after
+
+        resp = MagicMock()
+        resp.headers = {}
+        assert _parse_retry_after(resp, attempt=0) == 1.0   # 2**0
+        assert _parse_retry_after(resp, attempt=1) == 2.0   # 2**1
+        assert _parse_retry_after(resp, attempt=2) == 4.0   # 2**2
 
 
 class TestFetchDocRetry:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+import ansible_know.docs as docs_mod
 from ansible_know.docs import _search_rtd_api, clear_cache, fetch_doc_content, search_docs
 from ansible_know.text_utils import clean_rtd_markdown
 
@@ -571,3 +572,280 @@ class TestSearchDocsFallback:
             results = await search_docs("ansible", topic="nonexistent_topic_xyz")
         mock_rtd.assert_not_called()
         assert results == []
+
+
+# --- Helpers for fetch_doc hardening tests ---
+
+def _make_ok_response(
+    url_str: str = "https://docs.ansible.com/projects/ansible/latest/guide.html",
+    text: str = "# Test Page\n\nContent here.",
+    tokens: int = 100,
+    extra_headers: dict | None = None,
+) -> MagicMock:
+    """Build a mock httpx.Response that passes all fetch_doc validations."""
+    resp = MagicMock()
+    resp.status_code = 200
+    headers = {
+        "content-type": "text/markdown; charset=utf-8",
+        "x-markdown-tokens": str(tokens),
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    resp.headers = headers
+    resp.text = text
+    resp.content = text.encode()
+    resp.raise_for_status = MagicMock()
+    resp.url = _mock_url(url_str)
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def _reset_fetch_doc_state():
+    """Reset page cache and throttle between tests."""
+    docs_mod._page_cache.clear()
+    docs_mod._doc_last_request = 0.0
+    yield
+    docs_mod._page_cache.clear()
+    docs_mod._doc_last_request = 0.0
+
+
+class TestFetchDocUserAgent:
+    @pytest.mark.asyncio
+    async def test_user_agent_sent_on_request(self):
+        from ansible_know.config import USER_AGENT
+
+        mock_resp = _make_ok_response()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        await fetch_doc_content(
+            "https://docs.ansible.com/projects/ansible/latest/guide.html",
+            http_client=mock_client,
+        )
+
+        call_kwargs = mock_client.get.call_args
+        sent_headers = call_kwargs.kwargs.get("headers", {})
+        assert sent_headers.get("User-Agent") == USER_AGENT
+
+
+class TestFetchDocPageCache:
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_http(self):
+        mock_resp = _make_ok_response()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        url = "https://docs.ansible.com/projects/ansible/latest/guide.html"
+        result1 = await fetch_doc_content(url, http_client=mock_client)
+        result2 = await fetch_doc_content(url, http_client=mock_client)
+
+        assert result1 == result2
+        assert mock_client.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_max_tokens_checked_on_cached_result(self):
+        from ansible_know.errors import AnsibleKnowError
+
+        mock_resp = _make_ok_response(tokens=5000)
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        url = "https://docs.ansible.com/projects/ansible/latest/big.html"
+        await fetch_doc_content(url, http_client=mock_client)
+
+        with pytest.raises(AnsibleKnowError, match="5000"):
+            await fetch_doc_content(url, max_tokens=1000, http_client=mock_client)
+
+        assert mock_client.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_clear_cache_invalidates(self):
+        mock_resp = _make_ok_response()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        url = "https://docs.ansible.com/projects/ansible/latest/guide.html"
+        await fetch_doc_content(url, http_client=mock_client)
+        clear_cache()
+        await fetch_doc_content(url, http_client=mock_client)
+
+        assert mock_client.get.call_count == 2
+
+
+class TestFetchDocRateLimit:
+    @pytest.mark.asyncio
+    async def test_throttle_delays_rapid_requests(self):
+        mock_resp = _make_ok_response()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        url1 = "https://docs.ansible.com/projects/ansible/latest/page1.html"
+        url2 = "https://docs.ansible.com/projects/ansible/latest/page2.html"
+
+        with patch("ansible_know.docs.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await fetch_doc_content(url1, http_client=mock_client)
+            docs_mod._doc_last_request = docs_mod.time.monotonic()
+            await fetch_doc_content(url2, http_client=mock_client)
+
+        sleep_calls = [
+            c for c in mock_sleep.call_args_list
+            if c.args and c.args[0] > 0
+        ]
+        assert len(sleep_calls) >= 1
+
+
+class TestFetchDocRetry:
+    @pytest.mark.asyncio
+    async def test_retries_on_timeout_then_succeeds(self):
+        mock_resp = _make_ok_response()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=[httpx.TimeoutException("timeout"), mock_resp],
+        )
+
+        with patch("ansible_know.docs.asyncio.sleep", new_callable=AsyncMock):
+            result = await fetch_doc_content(
+                "https://docs.ansible.com/projects/ansible/latest/guide.html",
+                http_client=mock_client,
+            )
+
+        assert result["title"] == "Test Page"
+        assert mock_client.get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retries_on_429_with_retry_after(self):
+        retry_resp = MagicMock()
+        retry_resp.status_code = 429
+        retry_resp.headers = {"retry-after": "2"}
+        retry_resp.raise_for_status = MagicMock()
+
+        ok_resp = _make_ok_response()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[retry_resp, ok_resp])
+
+        with patch("ansible_know.docs.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await fetch_doc_content(
+                "https://docs.ansible.com/projects/ansible/latest/guide.html",
+                http_client=mock_client,
+            )
+
+        assert result["title"] == "Test Page"
+        assert mock_client.get.call_count == 2
+        retry_sleep = [c for c in mock_sleep.call_args_list if c.args and c.args[0] >= 2.0]
+        assert len(retry_sleep) >= 1
+
+    @pytest.mark.asyncio
+    async def test_exhausts_retries_and_raises(self):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=httpx.TimeoutException("timeout"),
+        )
+
+        with patch("ansible_know.docs.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(httpx.TimeoutException):
+                await fetch_doc_content(
+                    "https://docs.ansible.com/projects/ansible/latest/guide.html",
+                    http_client=mock_client,
+                )
+
+        assert mock_client.get.call_count == docs_mod.MAX_RETRY_ATTEMPTS
+
+    @pytest.mark.asyncio
+    async def test_retries_on_server_error(self):
+        error_resp = MagicMock()
+        error_resp.status_code = 503
+        error_resp.headers = {}
+        error_resp.raise_for_status = MagicMock()
+
+        ok_resp = _make_ok_response()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[error_resp, ok_resp])
+
+        with patch("ansible_know.docs.asyncio.sleep", new_callable=AsyncMock):
+            result = await fetch_doc_content(
+                "https://docs.ansible.com/projects/ansible/latest/guide.html",
+                http_client=mock_client,
+            )
+
+        assert result["title"] == "Test Page"
+        assert mock_client.get.call_count == 2
+
+
+class TestFetchDocCfChallenge:
+    @pytest.mark.asyncio
+    async def test_cf_challenge_raises_immediately(self):
+        from ansible_know.errors import AnsibleKnowError
+
+        cf_resp = MagicMock()
+        cf_resp.status_code = 429
+        cf_resp.headers = {"cf-mitigated": "challenge", "content-type": "text/html"}
+        cf_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=cf_resp)
+
+        with pytest.raises(AnsibleKnowError, match="Cloudflare managed challenge"):
+            await fetch_doc_content(
+                "https://docs.ansible.com/projects/ansible/latest/guide.html",
+                http_client=mock_client,
+            )
+
+    @pytest.mark.asyncio
+    async def test_cf_challenge_no_retry(self):
+        from ansible_know.errors import AnsibleKnowError
+
+        cf_resp = MagicMock()
+        cf_resp.status_code = 429
+        cf_resp.headers = {"cf-mitigated": "challenge", "content-type": "text/html"}
+        cf_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=cf_resp)
+
+        with pytest.raises(AnsibleKnowError):
+            await fetch_doc_content(
+                "https://docs.ansible.com/projects/ansible/latest/guide.html",
+                http_client=mock_client,
+            )
+
+        assert mock_client.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_regular_429_retries_but_cf_429_does_not(self):
+        from ansible_know.errors import AnsibleKnowError
+
+        cf_resp = MagicMock()
+        cf_resp.status_code = 429
+        cf_resp.headers = {"cf-mitigated": "challenge", "content-type": "text/html"}
+        cf_resp.raise_for_status = MagicMock()
+
+        regular_429 = MagicMock()
+        regular_429.status_code = 429
+        regular_429.headers = {"retry-after": "1"}
+        regular_429.raise_for_status = MagicMock()
+
+        ok_resp = _make_ok_response()
+
+        mock_client_cf = AsyncMock()
+        mock_client_cf.get = AsyncMock(return_value=cf_resp)
+
+        mock_client_regular = AsyncMock()
+        mock_client_regular.get = AsyncMock(side_effect=[regular_429, ok_resp])
+
+        with pytest.raises(AnsibleKnowError, match="Cloudflare"):
+            await fetch_doc_content(
+                "https://docs.ansible.com/projects/ansible/latest/guide.html",
+                http_client=mock_client_cf,
+            )
+        assert mock_client_cf.get.call_count == 1
+
+        docs_mod._page_cache.clear()
+        docs_mod._doc_last_request = 0.0
+
+        with patch("ansible_know.docs.asyncio.sleep", new_callable=AsyncMock):
+            result = await fetch_doc_content(
+                "https://docs.ansible.com/projects/ansible/latest/guide.html",
+                http_client=mock_client_regular,
+            )
+        assert result["title"] == "Test Page"
+        assert mock_client_regular.get.call_count == 2

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -771,6 +771,49 @@ class TestFetchDocRetry:
         assert mock_client.get.call_count == 2
 
 
+    @pytest.mark.asyncio
+    async def test_retries_on_connect_error_then_succeeds(self):
+        mock_resp = _make_ok_response()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=[httpx.ConnectError("connection refused"), mock_resp],
+        )
+
+        with patch("ansible_know.docs.asyncio.sleep", new_callable=AsyncMock):
+            result = await fetch_doc_content(
+                "https://docs.ansible.com/projects/ansible/latest/guide.html",
+                http_client=mock_client,
+            )
+
+        assert result["title"] == "Test Page"
+        assert mock_client.get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_exhausts_retries_on_server_error_and_raises(self):
+        error_resp = MagicMock()
+        error_resp.status_code = 503
+        error_resp.headers = {}
+        error_resp.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "503 Service Unavailable",
+                request=MagicMock(),
+                response=error_resp,
+            )
+        )
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=error_resp)
+
+        with patch("ansible_know.docs.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(httpx.HTTPStatusError):
+                await fetch_doc_content(
+                    "https://docs.ansible.com/projects/ansible/latest/guide.html",
+                    http_client=mock_client,
+                )
+
+        assert mock_client.get.call_count == docs_mod.MAX_RETRY_ATTEMPTS
+
+
 class TestFetchDocCfChallenge:
     @pytest.mark.asyncio
     async def test_cf_challenge_raises_immediately(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1768,7 +1768,7 @@ class TestClearCache:
              patch("ansible_know.docs.clear_cache") as mock_docs:
             result = await clear_cache()
 
-        assert result == {"cleared": ["galaxy_versions", "galaxy_blobs", "doc_manifests"]}
+        assert result == {"cleared": ["galaxy_versions", "galaxy_blobs", "doc_manifests", "doc_pages"]}
         mock_galaxy.assert_called_once()
         mock_docs.assert_called_once()
 
@@ -1792,7 +1792,7 @@ class TestClearCache:
              patch("ansible_know.docs.clear_cache") as mock_docs:
             result = await clear_cache(scope="docs")
 
-        assert result == {"cleared": ["doc_manifests"]}
+        assert result == {"cleared": ["doc_manifests", "doc_pages"]}
         mock_galaxy.assert_not_called()
         mock_docs.assert_called_once()
 


### PR DESCRIPTION
## Summary

- Set honest User-Agent (verified bot convention with `+URL`) on all outbound HTTP clients
- Add disk-backed page cache (100 entries, 24h TTL) to eliminate redundant requests
- Add rate limiting (1 req/sec to docs.ansible.com) to avoid triggering Cloudflare behavioral detection
- Add retry with exponential backoff (3 attempts, `Retry-After` header parsing) for transient HTTP errors
- Detect Cloudflare managed challenges (`cf-mitigated: challenge`) and raise clear, actionable errors
- Update `clear_cache` tool to also clear the new page cache

## Motivation

`fetch_doc` had zero resilience — no User-Agent, no caching, no retry, no rate limiting, no Cloudflare challenge detection. When docs.ansible.com's Cloudflare WAF issued a managed challenge, it failed with a generic HTTP error. Investigation confirmed the block is transient (behavior/IP-based), so client-side hardening is the right fix.

Full investigation: `docs/research/cloudflare-fetch-doc-429-investigation-2026-06-30.md`

## Changes

| File | Change |
|------|--------|
| `config.py` | Add `USER_AGENT` constant |
| `docs.py` | Page cache, throttle, retry loop, CF detection, `_fetch_with_retry()` helper |
| `server.py` | User-Agent on lifespan client, `clear_cache` scope update |
| `test_docs.py` | 12 new tests across 5 classes |
| `test_server.py` | Update 2 existing assertions for new cache scope |

## Test plan

- [x] 802 passed, 80 skipped, 0 failures
- [x] Ruff lint clean
- [x] 12 new tests: UserAgent, PageCache (3), RateLimit, Retry (4), CfChallenge (3)
- [ ] Manual: call `fetch_doc` twice for same URL — second should be instant (cache hit)

## Related

- Fixes #167
- Part of fetch_doc resilience trilogy: **this PR** (hardening), #168 (RTD fallback), #169 (upstream coordination)

Assisted-by: Claude Opus 4.6