### PR TITLE
fix: set ANSIBLE_LOCAL_TMP for subprocess calls in restricted environments

### DIFF
--- a/src/ansible_know/collections.py
+++ b/src/ansible_know/collections.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -121,6 +122,9 @@ class CollectionManager:
             collection_spec = f"{collection_fqcn}:=={version}" if version else collection_fqcn
             cmd = [galaxy, "collection", "install", collection_spec, "-p", tmpdir, "--force", "--no-cache"]
 
+            env = os.environ.copy()
+            env.setdefault("ANSIBLE_LOCAL_TMP", tempfile.gettempdir())
+
             with self._install_gate:
                 try:
                     result = subprocess.run(
@@ -128,6 +132,7 @@ class CollectionManager:
                         capture_output=True,
                         text=True,
                         timeout=120,
+                        env=env,
                     )
                 except subprocess.TimeoutExpired as exc:
                     raise CollectionInstallError(

--- a/src/ansible_know/parser.py
+++ b/src/ansible_know/parser.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -66,9 +67,9 @@ def _run_ansible_doc(
     cmd = [ansible_doc, *args]
 
     logger.debug("Running: %s (collections_path=%s)", " ".join(cmd), collections_path)
-    env = None
+    env = os.environ.copy()
+    env.setdefault("ANSIBLE_LOCAL_TMP", tempfile.gettempdir())
     if collections_path:
-        env = os.environ.copy()
         existing = env.get("ANSIBLE_COLLECTIONS_PATH", "")
         env["ANSIBLE_COLLECTIONS_PATH"] = (
             f"{collections_path}{os.pathsep}{existing}" if existing else collections_path

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -71,6 +71,14 @@ class TestEnsureCollectionInstalls:
         assert "install" in args
         assert "netbox.netbox" in args
 
+    def test_install_sets_ansible_local_tmp(self, mgr):
+        galaxy_stdout = "Installing 'netbox.netbox:4.1.0' to '<path>'\nnetbox.netbox:4.1.0 was installed successfully"
+        with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):
+            with patch("subprocess.run", return_value=_make_subprocess_result(stdout=galaxy_stdout)) as mock_run:
+                mgr.ensure_collection("netbox.netbox")
+        env = mock_run.call_args[1]["env"]
+        assert "ANSIBLE_LOCAL_TMP" in env
+
     def test_installs_with_version_pin(self, mgr):
         galaxy_stdout = "Installing 'netbox.netbox:3.9.0' to '<path>'\nnetbox.netbox:3.9.0 was installed successfully"
         with patch("ansible_know.collections._find_ansible_galaxy", return_value="/usr/bin/ansible-galaxy"):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -154,7 +154,7 @@ class TestRunAnsibleDocEnvInjection:
                     assert env["ANSIBLE_COLLECTIONS_PATH"].startswith("/tmp/ansible_know_abc123")
                     assert "/existing/path" in env["ANSIBLE_COLLECTIONS_PATH"]
 
-    def test_no_injection_when_no_collections(self):
+    def test_no_collections_path_still_sets_ansible_local_tmp(self):
         with patch("ansible_know.parser._find_ansible_doc", return_value="/usr/bin/ansible-doc"):
             with patch("subprocess.run", return_value=MagicMock(
                 returncode=0, stdout='{}', stderr='',
@@ -162,7 +162,10 @@ class TestRunAnsibleDocEnvInjection:
                 from ansible_know.parser import _run_ansible_doc
                 _run_ansible_doc("--list", "--json")
                 call_kwargs = mock_run.call_args[1]
-                assert call_kwargs.get("env") is None
+                env = call_kwargs.get("env")
+                assert env is not None
+                assert "ANSIBLE_LOCAL_TMP" in env
+                assert "ANSIBLE_COLLECTIONS_PATH" not in env
 
 
 class TestCollectionNotFoundDetection:


### PR DESCRIPTION
## Summary

- Set `ANSIBLE_LOCAL_TMP` to `tempfile.gettempdir()` in subprocess env for both `ansible-doc` and `ansible-galaxy` calls
- Prevents crashes in sandboxed/restricted environments where `~/.ansible/tmp/` is read-only
- Uses `setdefault` so explicit user overrides are respected

## Root cause

ansible-doc crashes at startup in restricted environments (Claude Code sandbox, read-only containers) because Ansible tries to create `~/.ansible/tmp/`. The error surfaces as `doc_source: "unavailable"` for `ansible.builtin.*` modules since they have no Galaxy fallback.

## Test plan

- [x] Updated `test_no_collections_path_still_sets_ansible_local_tmp` in test_parser.py
- [x] Added `test_install_sets_ansible_local_tmp` in test_collections.py
- [x] Full suite: 816 passed, 80 skipped
- [x] Lint: all checks passed

Closes #173

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>"