### PR TITLE
fix: store full canonical URLs in AAP manifests

### DIFF
--- a/scripts/build_aap_manifests.py
+++ b/scripts/build_aap_manifests.py
@@ -96,11 +96,10 @@ def _build_manifest_entries(landing: dict, version: str) -> list[dict]:
             if not url or "/documentation/" not in url:
                 continue
 
-            path_parts = url.rstrip("/").rsplit("/", 1)
-            slug = path_parts[-1].strip() if len(path_parts) > 1 else ""
-
+            # Store the full canonical URL from the landing page.
+            # The Red Hat MCP server rejects shortened slug-only URLs.
             entries.append({
-                "path": slug,
+                "url": url.strip(),
                 "topic": topic,
                 "title": name,
                 "audience": "admin",

--- a/src/ansible_know/data/aap_25_manifest.json
+++ b/src/ansible_know/data/aap_25_manifest.json
@@ -1,10 +1,10 @@
 {
   "version": "2.0",
-  "generated": "2026-07-17T02:52:40.583396+00:00",
+  "generated": "2026-07-17T04:40:39.049557+00:00",
   "base_url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5",
   "files": [
     {
-      "path": "release_notes",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/release_notes",
       "topic": "release_notes",
       "title": "Release notes",
       "audience": "admin",
@@ -15,7 +15,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "ansible_automation_platform_migration",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/ansible_automation_platform_migration",
       "topic": "tech_preview",
       "title": "Ansible Automation Platform migration",
       "audience": "admin",
@@ -26,7 +26,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "managing_device_fleets_with_the_red_hat_edge_manager",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/managing_device_fleets_with_the_red_hat_edge_manager",
       "topic": "tech_preview",
       "title": "Managing device fleets with the Red Hat Edge Manager",
       "audience": "admin",
@@ -37,7 +37,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "deploying-chatbot-operator",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/installing_on_openshift_container_platform/deploying-chatbot-operator",
       "topic": "tech_preview",
       "title": "Ansible Lightspeed intelligent assistant",
       "audience": "admin",
@@ -48,7 +48,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "using_ansible_development_workspaces_for_automation_content_development",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_ansible_development_workspaces_for_automation_content_development",
       "topic": "tech_preview",
       "title": "Using Ansible development workspaces for automation content development",
       "audience": "admin",
@@ -59,7 +59,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "tested_deployment_models",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/tested_deployment_models",
       "topic": "installing",
       "title": "Tested deployment models",
       "audience": "admin",
@@ -70,7 +70,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "planning_your_installation",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/planning_your_installation",
       "topic": "installing",
       "title": "Planning your installation",
       "audience": "admin",
@@ -81,7 +81,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "rpm_installation",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation",
       "topic": "installing",
       "title": "RPM installation",
       "audience": "admin",
@@ -92,7 +92,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "containerized_installation",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation",
       "topic": "installing",
       "title": "Containerized installation",
       "audience": "admin",
@@ -103,7 +103,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "installing_on_openshift_container_platform",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/installing_on_openshift_container_platform",
       "topic": "installing",
       "title": "Installing on OpenShift Container Platform",
       "audience": "admin",
@@ -114,7 +114,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "rpm_upgrade_and_migration",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_upgrade_and_migration",
       "topic": "upgrading",
       "title": "RPM upgrade and migration",
       "audience": "admin",
@@ -125,7 +125,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "index#operator-upgrade_licensing-gw",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/installing_on_openshift_container_platform/index#operator-upgrade_licensing-gw",
       "topic": "upgrading",
       "title": "Upgrading on OpenShift Container Platform",
       "audience": "admin",
@@ -136,7 +136,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "maintaining-containerized-aap#updating-containerized-ansible-automation-platform",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/maintaining-containerized-aap#updating-containerized-ansible-automation-platform",
       "topic": "upgrading",
       "title": "Updating from 2.5 to 2.5.x in a Containerized Environment",
       "audience": "admin",
@@ -147,7 +147,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "getting_started_with_ansible_automation_platform",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/getting_started_with_ansible_automation_platform",
       "topic": "about",
       "title": "Getting started with Ansible Automation Platform",
       "audience": "admin",
@@ -158,7 +158,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "access_management_and_authentication",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/access_management_and_authentication",
       "topic": "about",
       "title": "Access management and authentication",
       "audience": "admin",
@@ -169,7 +169,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "getting_started_with_playbooks",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/getting_started_with_playbooks",
       "topic": "about",
       "title": "Getting started with playbooks",
       "audience": "admin",
@@ -180,7 +180,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "getting_started_with_hashicorp_and_ansible_automation_platform",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/getting_started_with_hashicorp_and_ansible_automation_platform",
       "topic": "about",
       "title": "Getting started with HashiCorp and Ansible Automation Platform",
       "audience": "admin",
@@ -191,7 +191,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "operating_ansible_automation_platform",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/operating_ansible_automation_platform",
       "topic": "configure_and_operate",
       "title": "Operating Ansible Automation Platform",
       "audience": "admin",
@@ -202,7 +202,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "automation_mesh_for_managed_cloud_or_operator_environments",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/automation_mesh_for_managed_cloud_or_operator_environments",
       "topic": "configure_and_operate",
       "title": "Automation mesh for managed cloud or operator environments",
       "audience": "admin",
@@ -213,7 +213,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "automation_mesh_for_vm_environments",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/automation_mesh_for_vm_environments",
       "topic": "configure_and_operate",
       "title": "Automation mesh for VM environments",
       "audience": "admin",
@@ -224,7 +224,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "performance_considerations_for_operator_environments",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/performance_considerations_for_operator_environments",
       "topic": "configure_and_operate",
       "title": "Performance considerations for operator environments",
       "audience": "admin",
@@ -235,7 +235,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "troubleshooting_ansible_automation_platform",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/troubleshooting_ansible_automation_platform",
       "topic": "configure_and_operate",
       "title": "Troubleshooting Ansible Automation Platform",
       "audience": "admin",
@@ -246,7 +246,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "performance_tuning_for_ansible_automation_platform",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/performance_tuning_for_ansible_automation_platform",
       "topic": "configure_and_operate",
       "title": "Performance tuning for Ansible Automation Platform",
       "audience": "admin",
@@ -257,7 +257,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "backup_and_recovery_for_operator_environments",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/backup_and_recovery_for_operator_environments",
       "topic": "configure_and_operate",
       "title": "Backup and recovery for operator environments",
       "audience": "admin",
@@ -268,7 +268,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "hardening_and_compliance",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/hardening_and_compliance",
       "topic": "configure_and_operate",
       "title": "Hardening and compliance",
       "audience": "admin",
@@ -279,7 +279,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "configuring_automation_execution",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/configuring_automation_execution",
       "topic": "automation_execution",
       "title": "Configuring automation execution",
       "audience": "admin",
@@ -290,7 +290,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "using_automation_execution",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_execution",
       "topic": "automation_execution",
       "title": "Using automation execution",
       "audience": "admin",
@@ -301,7 +301,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "automation_execution_api_overview",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/automation_execution_api_overview",
       "topic": "automation_execution",
       "title": "Automation execution API overview",
       "audience": "admin",
@@ -312,7 +312,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "using_automation_decisions",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions",
       "topic": "automation_decisions",
       "title": "Using automation decisions",
       "audience": "admin",
@@ -323,7 +323,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "managing_automation_content",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/managing_automation_content",
       "topic": "automation_content",
       "title": "Managing automation content",
       "audience": "admin",
@@ -334,7 +334,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "implementing_security_automation",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/implementing_security_automation",
       "topic": "security_automation",
       "title": "Implementing security automation",
       "audience": "admin",
@@ -345,7 +345,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "using_automation_analytics",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_analytics",
       "topic": "automation_analytics",
       "title": "Using automation analytics",
       "audience": "admin",
@@ -356,7 +356,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "using_automation_dashboard",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_dashboard",
       "topic": "automation_analytics",
       "title": "Using Automation Dashboard",
       "audience": "admin",
@@ -367,7 +367,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "creating_and_using_execution_environments",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/creating_and_using_execution_environments",
       "topic": "developer_resources",
       "title": "Creating and using execution environments",
       "audience": "admin",
@@ -378,7 +378,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "developing_automation_content",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/developing_automation_content",
       "topic": "developer_resources",
       "title": "Developing automation content",
       "audience": "admin",
@@ -389,7 +389,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "using_content_navigator",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_content_navigator",
       "topic": "developer_resources",
       "title": "Using content navigator",
       "audience": "admin",
@@ -400,7 +400,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "installing_ansible_plug-ins_for_red_hat_developer_hub",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/installing_ansible_plug-ins_for_red_hat_developer_hub",
       "topic": "developer_resources",
       "title": "Installing Ansible plug-ins for Red Hat Developer Hub",
       "audience": "admin",
@@ -411,7 +411,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "using_ansible_plug-ins_for_red_hat_developer_hub",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_ansible_plug-ins_for_red_hat_developer_hub",
       "topic": "developer_resources",
       "title": "Using Ansible plug-ins for Red Hat Developer Hub",
       "audience": "admin",
@@ -422,8 +422,8 @@
       "aap_version": "2.5"
     },
     {
-      "path": "2.x_latest",
-      "topic": "cloud",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest",
+      "topic": "cloud_services",
       "title": "Red Hat Ansible Lightspeed with IBM watsonx Code Assistant",
       "audience": "admin",
       "core": false,
@@ -433,8 +433,8 @@
       "aap_version": "2.5"
     },
     {
-      "path": "2.x",
-      "topic": "cloud",
+      "url": "https://docs.redhat.com/en/documentation/ansible_on_clouds/2.x",
+      "topic": "cloud_services",
       "title": "Ansible on clouds",
       "audience": "admin",
       "core": false,
@@ -444,7 +444,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "installing_self-service_automation_portal",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/installing_self-service_automation_portal",
       "topic": "self-service_automation_portal",
       "title": "Installing self-service automation portal",
       "audience": "admin",
@@ -455,7 +455,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "configuring_self-service_automation_portal",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/configuring_self-service_automation_portal",
       "topic": "self-service_automation_portal",
       "title": "Configuring self-service automation portal",
       "audience": "admin",
@@ -466,7 +466,7 @@
       "aap_version": "2.5"
     },
     {
-      "path": "using_self-service_automation_portal",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_self-service_automation_portal",
       "topic": "self-service_automation_portal",
       "title": "Using self-service automation portal",
       "audience": "admin",

--- a/src/ansible_know/data/aap_26_manifest.json
+++ b/src/ansible_know/data/aap_26_manifest.json
@@ -1,10 +1,10 @@
 {
   "version": "2.0",
-  "generated": "2026-07-17T02:52:40.834893+00:00",
+  "generated": "2026-07-17T04:40:39.487728+00:00",
   "base_url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6",
   "files": [
     {
-      "path": "whats_new-aap_26",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/whats_new-aap_26",
       "topic": "whats_new",
       "title": "Release notes",
       "audience": "admin",
@@ -15,7 +15,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "whats_new-async_updates",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/whats_new-async_updates",
       "topic": "whats_new",
       "title": "Patch releases",
       "audience": "admin",
@@ -26,7 +26,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "whats_new-ansible_core_2_19",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/whats_new-ansible_core_2_19",
       "topic": "tech_preview",
       "title": "ansible_core 2_19",
       "audience": "admin",
@@ -37,7 +37,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "whats_new-assembly_workspaces_intro",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/whats_new-assembly_workspaces_intro",
       "topic": "tech_preview",
       "title": "Access preconfigured development tools with Ansible development workspaces",
       "audience": "admin",
@@ -48,7 +48,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "get_started-assembly_gs_auto_dev",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/get_started-assembly_gs_auto_dev",
       "topic": "get_started",
       "title": "Get started as an administrator",
       "audience": "admin",
@@ -59,7 +59,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "get_started-assembly_gs_auto_dev",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/get_started-assembly_gs_auto_dev",
       "topic": "get_started",
       "title": "Get started as a developer",
       "audience": "admin",
@@ -70,7 +70,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "get_started-assembly_intro_to_playbooks_1",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/get_started-assembly_intro_to_playbooks_1",
       "topic": "get_started",
       "title": "Get started automating with playbooks",
       "audience": "admin",
@@ -81,7 +81,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "plan-assembly_overview_tested_deployment_models",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/plan-assembly_overview_tested_deployment_models",
       "topic": "plan",
       "title": "Choose a deployment method and topology",
       "audience": "admin",
@@ -92,7 +92,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "plan-proc_attaching_subscriptions",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/plan-proc_attaching_subscriptions",
       "topic": "plan",
       "title": "Attach your Ansible Automation Platform subscription",
       "audience": "admin",
@@ -103,7 +103,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "install-proc_installing_containerized_aap",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/install-proc_installing_containerized_aap",
       "topic": "install",
       "title": "Install containerized Ansible Automation Platform",
       "audience": "admin",
@@ -114,7 +114,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "install-assembly_operator_install_operator",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/install-assembly_operator_install_operator",
       "topic": "install",
       "title": "Install on OpenShift Container Platform",
       "audience": "admin",
@@ -125,7 +125,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "install-assembly_platform_install_overview",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/install-assembly_platform_install_overview",
       "topic": "install",
       "title": "Installing RPM-based Ansible Automation Platform",
       "audience": "admin",
@@ -136,7 +136,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "install-assembly_appendix_inventory_file_vars",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/install-assembly_appendix_inventory_file_vars",
       "topic": "install",
       "title": "Inventory file variables",
       "audience": "admin",
@@ -147,7 +147,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "install-assembly_aap_activate_1",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/install-assembly_aap_activate_1",
       "topic": "install",
       "title": "Activate your Ansible Automation Platform subscription",
       "audience": "admin",
@@ -158,7 +158,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "install-assembly_devtools_install",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/install-assembly_devtools_install",
       "topic": "install",
       "title": "Install Ansible development tools",
       "audience": "admin",
@@ -169,7 +169,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "install-assembly_rhdh_intro",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/install-assembly_rhdh_intro",
       "topic": "install",
       "title": "Install Ansible plug-ins for Red Hat Developer Hub",
       "audience": "admin",
@@ -180,7 +180,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "install-assembly_self_service_about",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/install-assembly_self_service_about",
       "topic": "install",
       "title": "Install Ansible automation portal (OpenShift Container Platform only)",
       "audience": "admin",
@@ -191,7 +191,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "install-assembly_view_key_metrics",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/install-assembly_view_key_metrics",
       "topic": "install",
       "title": "Install automation dashboard to calculate savings (RHEL only)",
       "audience": "admin",
@@ -202,7 +202,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "install-proc_installing_builder",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/install-proc_installing_builder",
       "topic": "install",
       "title": "Install Ansible Builder to create or edit execution environments",
       "audience": "admin",
@@ -213,7 +213,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "Extend-assembly_deploying_ansible_mcp_server",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/Extend-assembly_deploying_ansible_mcp_server",
       "topic": "extend",
       "title": "Deploy an MCP server",
       "audience": "admin",
@@ -224,7 +224,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "Extend-assembly_deploying_alia",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/Extend-assembly_deploying_alia",
       "topic": "extend",
       "title": "Deploy the automation intelligent assistant",
       "audience": "admin",
@@ -235,7 +235,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "extend-enable_ai_in_the_ansible_vs_code_extension_with_the_mcp_server",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/extend-enable_ai_in_the_ansible_vs_code_extension_with_the_mcp_server",
       "topic": "extend",
       "title": "Enable AI in the Ansible VS Code extension",
       "audience": "admin",
@@ -246,7 +246,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "upgrade-con_aap_upgrade_overview",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/upgrade-con_aap_upgrade_overview",
       "topic": "upgrade",
       "title": "Plan your upgrade to 2.6",
       "audience": "admin",
@@ -257,7 +257,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "upgrade-ref_upgrade_scenarios_container",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/upgrade-ref_upgrade_scenarios_container",
       "topic": "upgrade",
       "title": "Containerized upgrade on RHEL",
       "audience": "admin",
@@ -268,7 +268,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "upgrade-ref_upgrade_scenarios_openshift",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/upgrade-ref_upgrade_scenarios_openshift",
       "topic": "upgrade",
       "title": "Upgrade on OpenShift Container Platform",
       "audience": "admin",
@@ -279,7 +279,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "upgrade-ansible_automation_platform_upgrade",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/upgrade-ansible_automation_platform_upgrade",
       "topic": "upgrade",
       "title": "RPM-based upgrade on RHEL",
       "audience": "admin",
@@ -290,7 +290,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "upgrade-upgrade_additional_services_for_ansible_automation_platform",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/upgrade-upgrade_additional_services_for_ansible_automation_platform",
       "topic": "upgrade",
       "title": "Upgrade additional services",
       "audience": "admin",
@@ -301,7 +301,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "upgrade-assembly_upgrade_support_matrix",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/upgrade-assembly_upgrade_support_matrix",
       "topic": "upgrade",
       "title": "Supported upgrade and migration scenarios",
       "audience": "admin",
@@ -312,7 +312,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "upgrade-assembly_upgrade_data_movement",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/upgrade-assembly_upgrade_data_movement",
       "topic": "upgrade",
       "title": "Identity and access management during upgrade",
       "audience": "admin",
@@ -323,7 +323,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "upgrade-proc_upgrading_automation_dashboard",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/upgrade-proc_upgrading_automation_dashboard",
       "topic": "upgrade",
       "title": "Upgrade automation dashboard",
       "audience": "admin",
@@ -334,7 +334,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "upgrade-assembly_rhdh_upgrade_ocp_helm",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/upgrade-assembly_rhdh_upgrade_ocp_helm",
       "topic": "upgrade",
       "title": "Upgrade Ansible plug-ins for Red Hat Developer Hub",
       "audience": "admin",
@@ -345,7 +345,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "upgrade-assembly_self_service_upgrading",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/upgrade-assembly_self_service_upgrading",
       "topic": "upgrade",
       "title": "Upgrade Ansible automation portal",
       "audience": "admin",
@@ -356,7 +356,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "migrate-con_introduction_and_objectives",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/migrate-con_introduction_and_objectives",
       "topic": "migrate",
       "title": "Migrate from existing deployment topologies",
       "audience": "admin",
@@ -367,7 +367,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "secure-assembly_gw_configure_authentication",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/secure-assembly_gw_configure_authentication",
       "topic": "security",
       "title": "Configure central authentication for Ansible Automation Platform",
       "audience": "admin",
@@ -378,7 +378,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "administer-assembly_planning_mesh",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/administer-assembly_planning_mesh",
       "topic": "admin",
       "title": "Scale your infrastructure",
       "audience": "admin",
@@ -389,7 +389,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "administer-assembly_aap_backup",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/administer-assembly_aap_backup",
       "topic": "admin",
       "title": "Backup and restore Ansible Automation Platform",
       "audience": "admin",
@@ -400,7 +400,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "develop-assembly_intro_to_playbooks",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/develop-assembly_intro_to_playbooks",
       "topic": "develop",
       "title": "Get started automating with playbooks",
       "audience": "admin",
@@ -411,7 +411,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "configure-assembly_gw_settings",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/configure-assembly_gw_settings",
       "topic": "configure",
       "title": "Configure Ansible Automation Platform",
       "audience": "admin",
@@ -422,7 +422,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "configure-distribute_workloads_with_clustering",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/configure-distribute_workloads_with_clustering",
       "topic": "configure",
       "title": "Distribute workloads with clustering",
       "audience": "admin",
@@ -433,7 +433,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "configure-configure_a_proxy_to_communicate_with_external_systems",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/configure-configure_a_proxy_to_communicate_with_external_systems",
       "topic": "configure",
       "title": "Configure a proxy to communicate with external systems",
       "audience": "admin",
@@ -444,7 +444,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "integrate-assembly_terraform_introduction",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/integrate-assembly_terraform_introduction",
       "topic": "integrate",
       "title": "Integrate with HashiCorp Terraform",
       "audience": "admin",
@@ -455,7 +455,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "integrate-assembly_vault_introduction",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/integrate-assembly_vault_introduction",
       "topic": "integrate",
       "title": "Integrate with HashiCorp Vault",
       "audience": "admin",
@@ -466,7 +466,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "integrate-assembly_ug_controller_setting_up_insights",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/integrate-assembly_ug_controller_setting_up_insights",
       "topic": "integrate",
       "title": "Integrate with Red Hat Lightspeed",
       "audience": "admin",
@@ -477,7 +477,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "integrate-assembly_controller_pac",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/integrate-assembly_controller_pac",
       "topic": "integrate",
       "title": "Implement policy enforcement",
       "audience": "admin",
@@ -488,7 +488,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "observe-ensure_system_health_and_efficiency_through_monitoring",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/observe-ensure_system_health_and_efficiency_through_monitoring",
       "topic": "observability",
       "title": "Metrics for monitoring automation controller application",
       "audience": "admin",
@@ -499,7 +499,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "observe-assembly_metrics_utility",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/observe-assembly_metrics_utility",
       "topic": "observability",
       "title": "Generate reports with the metrics utility",
       "audience": "admin",
@@ -510,7 +510,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "observe-assembly_controller_logging_aggregation",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/observe-assembly_controller_logging_aggregation",
       "topic": "observability",
       "title": "Configure logging",
       "audience": "admin",
@@ -521,7 +521,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "optimize-optimize_platform_performance",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/optimize-optimize_platform_performance",
       "topic": "performance",
       "title": "Optimize platform performance",
       "audience": "admin",
@@ -532,7 +532,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "optimize-assembly_controller_improving_performance",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/optimize-assembly_controller_improving_performance",
       "topic": "performance",
       "title": "Tune automation controller to improve performance",
       "audience": "admin",
@@ -543,7 +543,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "optimize-con_user_data_tracking",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/optimize-con_user_data_tracking",
       "topic": "performance",
       "title": "Get insights on automation across your environment with Automation Analytics",
       "audience": "admin",
@@ -554,7 +554,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "troubleshoot-proc_settings_troubleshooting",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/troubleshoot-proc_settings_troubleshooting",
       "topic": "troubleshoot",
       "title": "Troubleshoot Ansible Automation Platform",
       "audience": "admin",
@@ -565,7 +565,7 @@
       "aap_version": "2.6"
     },
     {
-      "path": "reference-ansible_automation_platform_custom_resources",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/reference-ansible_automation_platform_custom_resources",
       "topic": "reference",
       "title": "Ansible Automation Platform Operator API reference",
       "audience": "admin",

--- a/src/ansible_know/data/aap_27_manifest.json
+++ b/src/ansible_know/data/aap_27_manifest.json
@@ -1,10 +1,10 @@
 {
   "version": "2.0",
-  "generated": "2026-07-17T02:52:41.115637+00:00",
+  "generated": "2026-07-17T04:40:39.968032+00:00",
   "base_url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7",
   "files": [
     {
-      "path": "whats_new-overview_of_redhat_ansible_intro",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/whats_new-overview_of_redhat_ansible_intro",
       "topic": "whats_new",
       "title": "Release notes",
       "audience": "admin",
@@ -15,7 +15,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "whats_new-bring_your_own_knowledge_with_the_automation_intelligent_assistant",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/whats_new-bring_your_own_knowledge_with_the_automation_intelligent_assistant",
       "topic": "tech_preview",
       "title": "Bring your own knowledge to the automation intelligent assistant",
       "audience": "admin",
@@ -26,7 +26,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "whats_new-oidc_authentication_for_hashicorp_vault",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/whats_new-oidc_authentication_for_hashicorp_vault",
       "topic": "tech_preview",
       "title": "OIDC credential types for HashiCorp Vault",
       "audience": "admin",
@@ -37,7 +37,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "whats_new-con_understand_automation_dashboard_architecture",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/whats_new-con_understand_automation_dashboard_architecture",
       "topic": "tech_preview",
       "title": "Analyze automation usage with automation dashboard",
       "audience": "admin",
@@ -48,7 +48,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "discover-what_is_ansible_automation_platform",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/discover-what_is_ansible_automation_platform",
       "topic": "overview",
       "title": "What is Ansible Automation Platform",
       "audience": "admin",
@@ -59,7 +59,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "get_started-assembly_gs_platform_admin",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/get_started-assembly_gs_platform_admin",
       "topic": "get_started",
       "title": "Get started as an administrator",
       "audience": "admin",
@@ -70,7 +70,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "get_started-assembly_gs_auto_dev",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/get_started-assembly_gs_auto_dev",
       "topic": "get_started",
       "title": "Get started as a developer",
       "audience": "admin",
@@ -81,7 +81,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "plan-assembly_overview_tested_deployment_models",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/plan-assembly_overview_tested_deployment_models",
       "topic": "plan",
       "title": "Choose a deployment method and topology",
       "audience": "admin",
@@ -92,7 +92,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "install-proc_installing_containerized_aap",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/install-proc_installing_containerized_aap",
       "topic": "install",
       "title": "Install containerized Ansible Automation Platform",
       "audience": "admin",
@@ -103,7 +103,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "install-assembly_appendix_inventory_file_vars",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/install-assembly_appendix_inventory_file_vars",
       "topic": "install",
       "title": "Inventory file variables",
       "audience": "admin",
@@ -114,7 +114,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "install-assembly_operator_install_operator",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/install-assembly_operator_install_operator",
       "topic": "install",
       "title": "Install on OpenShift Container Platform",
       "audience": "admin",
@@ -125,7 +125,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "install-assembly_aap_activate",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/install-assembly_aap_activate",
       "topic": "install",
       "title": "Activate your subscription",
       "audience": "admin",
@@ -136,7 +136,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "install-assembly_devtools_install",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/install-assembly_devtools_install",
       "topic": "install",
       "title": "Install Ansible developer tools",
       "audience": "admin",
@@ -147,7 +147,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "install-con_self_service_rhel_appliances",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/install-con_self_service_rhel_appliances",
       "topic": "install",
       "title": "Deploy Ansible automation portal RHEL appliance",
       "audience": "admin",
@@ -158,7 +158,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "install-assembly_self_service_about",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/install-assembly_self_service_about",
       "topic": "install",
       "title": "Install automation portal on OpenShift Container Platform",
       "audience": "admin",
@@ -169,7 +169,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "install-assembly_view_key_metrics",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/install-assembly_view_key_metrics",
       "topic": "install",
       "title": "Install automation dashboard",
       "audience": "admin",
@@ -180,7 +180,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "install-proc_installing_builder",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/install-proc_installing_builder",
       "topic": "install",
       "title": "Install Ansible Builder",
       "audience": "admin",
@@ -191,7 +191,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "install-con_understand_metrics_service_architecture",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/install-con_understand_metrics_service_architecture",
       "topic": "install",
       "title": "Understand and install metrics service",
       "audience": "admin",
@@ -202,7 +202,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "extend-assembly_deploying_ansible_mcp_server",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/extend-assembly_deploying_ansible_mcp_server",
       "topic": "extend",
       "title": "Deploy an MCP server",
       "audience": "admin",
@@ -213,7 +213,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "extend-assembly_rhdh_intro",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/extend-assembly_rhdh_intro",
       "topic": "extend",
       "title": "Ansible plug-ins for Red Hat Developer Hub",
       "audience": "admin",
@@ -224,7 +224,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "upgrade-plan_your_ansible_automation_platform_upgrade",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/upgrade-plan_your_ansible_automation_platform_upgrade",
       "topic": "upgrade",
       "title": "Plan your upgrade to 2.7",
       "audience": "admin",
@@ -235,7 +235,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "upgrade-proc_update_aap_container",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/upgrade-proc_update_aap_container",
       "topic": "upgrade",
       "title": "Containerized upgrade on RHEL",
       "audience": "admin",
@@ -246,7 +246,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "upgrade-assembly_operator_upgrade",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/upgrade-assembly_operator_upgrade",
       "topic": "upgrade",
       "title": "Upgrade on OpenShift Container Platform",
       "audience": "admin",
@@ -257,7 +257,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "upgrade-upgrade_plug_ins_for_rhdh",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/upgrade-upgrade_plug_ins_for_rhdh",
       "topic": "upgrade",
       "title": "Upgrade Ansible plug-ins for Red Hat Developer Hub",
       "audience": "admin",
@@ -268,7 +268,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "upgrade-assembly_self_service_upgrading",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/upgrade-assembly_self_service_upgrading",
       "topic": "upgrade",
       "title": "Upgrade Ansible automation portal",
       "audience": "admin",
@@ -279,7 +279,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "upgrade-proc_self_service_rhel_upgrade",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/upgrade-proc_self_service_rhel_upgrade",
       "topic": "upgrade",
       "title": "Upgrade the Ansible automation portal RHEL appliance",
       "audience": "admin",
@@ -290,7 +290,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "upgrade-task_upgrade_metrics_service",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/upgrade-task_upgrade_metrics_service",
       "topic": "upgrade",
       "title": "Upgrade metrics service",
       "audience": "admin",
@@ -301,7 +301,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "develop-assembly_intro_to_playbooks",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/develop-assembly_intro_to_playbooks",
       "topic": "develop",
       "title": "Get started automating with playbooks",
       "audience": "admin",
@@ -312,7 +312,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "migrate-migrate_from_existing_deployment_topologies",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/migrate-migrate_from_existing_deployment_topologies",
       "topic": "migrate",
       "title": "Migrate from existing deployment topologies",
       "audience": "admin",
@@ -323,7 +323,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "secure-assembly_gw_configure_authentication",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/secure-assembly_gw_configure_authentication",
       "topic": "security",
       "title": "Configure central authentication for Ansible Automation Platform",
       "audience": "admin",
@@ -334,7 +334,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "secure-assembly_gw_managing_access",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/secure-assembly_gw_managing_access",
       "topic": "security",
       "title": "Manage access with role-based access control",
       "audience": "admin",
@@ -345,7 +345,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "administer-assembly_planning_mesh",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/administer-assembly_planning_mesh",
       "topic": "admin",
       "title": "Scale your infrastructure with automation mesh",
       "audience": "admin",
@@ -356,7 +356,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "administer-back_up_and_restore_your_containerized_deployment",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/administer-back_up_and_restore_your_containerized_deployment",
       "topic": "admin",
       "title": "Backup and restore your containerized deployment",
       "audience": "admin",
@@ -367,7 +367,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "configure-assembly_gw_settings",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/configure-assembly_gw_settings",
       "topic": "configure",
       "title": "Configure Ansible Automation Platform",
       "audience": "admin",
@@ -378,7 +378,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "configure-distribute_workloads_with_clustering",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/configure-distribute_workloads_with_clustering",
       "topic": "configure",
       "title": "Distribute workloads with clustering",
       "audience": "admin",
@@ -389,7 +389,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "configure-configure_a_proxy_to_communicate_with_external_systems",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/configure-configure_a_proxy_to_communicate_with_external_systems",
       "topic": "configure",
       "title": "Configure a proxy to communicate with external systems",
       "audience": "admin",
@@ -400,7 +400,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "integrate-assembly_terraform_introduction",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/integrate-assembly_terraform_introduction",
       "topic": "integrate",
       "title": "Integrate with HashiCorp Terraform",
       "audience": "admin",
@@ -411,7 +411,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "integrate-assembly_vault_introduction",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/integrate-assembly_vault_introduction",
       "topic": "integrate",
       "title": "Integrate with HashiCorp Vault",
       "audience": "admin",
@@ -422,7 +422,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "integrate-assembly_ug_controller_setting_up_insights",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/integrate-assembly_ug_controller_setting_up_insights",
       "topic": "integrate",
       "title": "Integrate with Red Hat Lightspeed",
       "audience": "admin",
@@ -433,7 +433,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "integrate-assembly_controller_pac",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/integrate-assembly_controller_pac",
       "topic": "integrate",
       "title": "Implement policy enforcement",
       "audience": "admin",
@@ -444,7 +444,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "observe-ensure_system_health_and_efficiency_through_monitoring",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/observe-ensure_system_health_and_efficiency_through_monitoring",
       "topic": "observability",
       "title": "Metrics for monitoring automation controller application",
       "audience": "admin",
@@ -455,7 +455,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "observe-assembly_metrics_utility",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/observe-assembly_metrics_utility",
       "topic": "observability",
       "title": "Generate reports with the metrics utility",
       "audience": "admin",
@@ -466,7 +466,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "observe-assembly_controller_logging_aggregation",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/observe-assembly_controller_logging_aggregation",
       "topic": "observability",
       "title": "Configure logging",
       "audience": "admin",
@@ -477,7 +477,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "optimize-optimize_platform_performance",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/optimize-optimize_platform_performance",
       "topic": "performance",
       "title": "Optimize platform performance",
       "audience": "admin",
@@ -488,7 +488,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "optimize-assembly_controller_improving_performance",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/optimize-assembly_controller_improving_performance",
       "topic": "performance",
       "title": "Tune automation controller to improve performance",
       "audience": "admin",
@@ -499,7 +499,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "optimize-con_user_data_tracking",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/optimize-con_user_data_tracking",
       "topic": "performance",
       "title": "Get insights on automation across your environment with Automation Analytics",
       "audience": "admin",
@@ -510,7 +510,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "troubleshoot-proc_settings_troubleshooting",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/troubleshoot-proc_settings_troubleshooting",
       "topic": "troubleshoot",
       "title": "Troubleshoot Ansible Automation Platform",
       "audience": "admin",
@@ -521,7 +521,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "troubleshoot-ref_troubleshoot_metrics_service",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/troubleshoot-ref_troubleshoot_metrics_service",
       "topic": "troubleshoot",
       "title": "Troubleshoot metrics service",
       "audience": "admin",
@@ -532,7 +532,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "troubleshoot-ref_troubleshoot_ee_builder",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/troubleshoot-ref_troubleshoot_ee_builder",
       "topic": "troubleshoot",
       "title": "Troubleshoot execution environment builder",
       "audience": "admin",
@@ -543,7 +543,7 @@
       "aap_version": "2.7"
     },
     {
-      "path": "reference-ansible_automation_platform_custom_resources",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/reference-ansible_automation_platform_custom_resources",
       "topic": "reference",
       "title": "Custom resources for Ansible Automation Platform",
       "audience": "admin",
@@ -554,8 +554,8 @@
       "aap_version": "2.7"
     },
     {
-      "path": "2.x",
-      "topic": "cloud",
+      "url": "https://docs.redhat.com/en/documentation/ansible_on_clouds/2.x",
+      "topic": "cloud_services",
       "title": "Ansible on Clouds",
       "audience": "admin",
       "core": false,

--- a/tests/test_doc_manifests.py
+++ b/tests/test_doc_manifests.py
@@ -7,7 +7,9 @@ import pytest
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "src" / "ansible_know" / "data"
 
-REQUIRED_FILE_KEYS = {"path", "title", "summary"}
+# Entries need either "path" (resolved via base_url) or "url" (direct)
+REQUIRED_FILE_KEYS = {"title", "summary"}
+REQUIRED_LOCATION_KEYS = {"path", "url"}
 
 MINIMUM_COUNTS = {
     "ansible_core_manifest.json": 300,
@@ -43,6 +45,8 @@ def test_manifest_entries_have_required_keys(manifest):
     for i, entry in enumerate(data["files"]):
         missing = REQUIRED_FILE_KEYS - set(entry.keys())
         assert not missing, f"{name}: entry {i} missing keys: {missing}"
+        has_location = REQUIRED_LOCATION_KEYS & set(entry.keys())
+        assert has_location, f"{name}: entry {i} needs 'path' or 'url'"
 
 
 def test_manifest_entry_count_above_minimum(manifest):


### PR DESCRIPTION
## Summary

- Fix `scripts/build_aap_manifests.py` to store full canonical URLs from the landing page JSON instead of extracting only the last path segment (slug)
- Regenerate all three AAP manifests (2.5, 2.6, 2.7) with correct URLs
- Update manifest test to accept entries with either `path` (resolved via `base_url`) or `url` (direct)

## Root cause

The build script at line 99-100 was doing `url.rsplit("/", 1)[-1]` to extract a slug, then storing it as `path`. At search time, `_postprocess_entries` reconstructed the URL as `base_url + "/" + slug`, producing URLs like:

```
https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/whats_new-overview_of_redhat_ansible_intro
```

The Red Hat MCP server rejects this format. It expects the full canonical URL with `/html/` path segment:

```
https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/html/whats_new-overview_of_redhat_ansible_intro
```

## Test plan

- [x] 861 unit tests pass (1 pre-existing failure, unrelated)
- [x] Lint clean
- [x] All three manifests regenerated with full canonical URLs
- [x] Manifest test validates entries have either `path` or `url`

Closes #177

Assisted-by: Claude Opus 4.6