### PR TITLE
feat: project-scoped skills with AGENTS.md discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,36 @@ Add to `.vscode/mcp.json` in your workspace:
 }
 ```
 
+Skill packages default to `{project}/skills/`. Claude Code injects
+`CLAUDE_PROJECT_DIR` automatically; set `ANSIBLE_KNOW_PROJECT_DIR` for other
+clients. After `generate_collection_skills`, a managed section in `AGENTS.md`
+points host agents at that tree.
+
+#### Pairing with Ansible Devtools MCP (next-mcp)
+
+know-mcp and next-mcp use different env vars. To share one skills directory,
+also configure next-mcp's local skill source (extension setting
+`ansibleEnvironments.skillSources`, or `ANSIBLE_SKILL_SOURCES`):
+
+```json
+{
+  "ansibleEnvironments.skillSources": [
+    {
+      "id": "know-generated",
+      "type": "local",
+      "url": "${workspaceFolder}/skills",
+      "trust": "community"
+    }
+  ]
+}
+```
+
+Use `{id, type, url, trust}` — next-mcp's loader expects `url` (directory path),
+not `path`/`repo` alone. Until next-mcp expands local scan depth past one level,
+`skill_*` tools see collection-level `SKILL.md` files; nested module skills remain
+available to host agents via the `AGENTS.md` pointer. See
+`docs/superpowers/specs/2026-08-02-skill-discoverability-alignment.md`.
+
 ### Any MCP client
 
 The server communicates over stdio by default:
@@ -284,7 +314,10 @@ url = https://galaxy.ansible.com/api/
 
 | Environment Variable | Description | Default |
 |---------------------|-------------|---------|
-| `ANSIBLE_KNOW_SKILLS_DIR` | Where to write generated skills | `./skills/` |
+| `ANSIBLE_KNOW_SKILLS_DIR` | Explicit skills directory (wins over project-dir chain) | *(not set)* |
+| `ANSIBLE_KNOW_PROJECT_DIR` | Project root; skills go to `{root}/skills` | *(not set)* |
+| `CLAUDE_PROJECT_DIR` | Same as project dir when set by Claude Code | *(not set)* |
+| *(skills fallback)* | If none of the above are set | `cwd/skills/` |
 | `ANSIBLE_KNOW_DOC_SOURCES` | JSON dict of doc manifest sources | Built-in ansible-core source |
 | `ANSIBLE_KNOW_GALAXY_URL` | Galaxy API base URL | `https://galaxy.ansible.com` |
 | `ANSIBLE_KNOW_SKIP_UPDATE_CHECK` | Set to `1` to disable PyPI version check at startup | *(not set)* |

--- a/README.md
+++ b/README.md
@@ -118,6 +118,21 @@ Add to `.vscode/mcp.json` in your workspace:
 }
 ```
 
+VS Code Copilot (`.vscode/mcp.json`):
+```json
+{
+  "servers": {
+    "ansible-know": {
+      "command": "uvx",
+      "args": ["ansible-know-mcp"],
+      "env": {
+        "ANSIBLE_KNOW_PROJECT_DIR": "${workspaceFolder}"
+      }
+    }
+  }
+}
+```
+
 ### Any MCP client
 
 The server communicates over stdio by default:

--- a/README.md
+++ b/README.md
@@ -112,19 +112,7 @@ Add to `.vscode/mcp.json` in your workspace:
     "ansible-know": {
       "command": "uvx",
       "args": ["ansible-know-mcp"],
-      "type": "stdio"
-    }
-  }
-}
-```
-
-VS Code Copilot (`.vscode/mcp.json`):
-```json
-{
-  "servers": {
-    "ansible-know": {
-      "command": "uvx",
-      "args": ["ansible-know-mcp"],
+      "type": "stdio",
       "env": {
         "ANSIBLE_KNOW_PROJECT_DIR": "${workspaceFolder}"
       }

--- a/docs/architecture/adr/0008-three-layer-distribution.md
+++ b/docs/architecture/adr/0008-three-layer-distribution.md
@@ -30,18 +30,29 @@ on the previous, uses the same spec-compliant skills throughout.
 
 ### Layer 1: Local (now)
 
-ansible-skill-mcp runs alongside next-mcp on a developer's machine.
+ansible-know-mcp runs alongside next-mcp on a developer's machine.
 Skills are generated in real time from collections resolved via multiple
 endpoints (locally installed, private Automation Hub, public Galaxy).
 
-- Skills land in `ANSIBLE_KNOW_SKILLS_DIR` (our env var, default `./skills/`)
-- next-mcp reads via `type: "local"` source in `ANSIBLE_SKILL_SOURCES`
-  (next-mcp's env var — JSON array of `SkillSource` objects with
-  `{id, type, url, trust}`)
-- Developer gets immediate access via `skill_search`
+- Skills land under the project by default via the `SKILLS_DIR` env chain
+  (`ANSIBLE_KNOW_SKILLS_DIR` → `ANSIBLE_KNOW_PROJECT_DIR/skills` →
+  `CLAUDE_PROJECT_DIR/skills` → `cwd/skills`) — see issue #181
+- **Host-agent discovery:** `generate_collection_skills` updates a managed
+  section in project-root `AGENTS.md` pointing agents at `skills/`.
+  This is Layer 1 host discovery, not repository distribution.
+  Skipped when skills are written outside `{project_root}/skills`
+  (explicit `install_to` or non-project `ANSIBLE_KNOW_SKILLS_DIR`)
+- **next-mcp registry:** dual-config — point `ANSIBLE_SKILL_SOURCES`
+  (or `ansibleEnvironments.skillSources`) `type: "local"` `url` at the
+  same skills directory (`{id, type, url, trust}`). know-mcp and next-mcp
+  do not read each other's env vars
+- next-mcp `_loadLocalSource` currently scans **1 level**, so nested
+  module skills are missed until upstream scan depth is expanded
+  (local tracking: #200; upstream issue TBD)
 
 **Value:** Real-time generation from any collection source. No pre-work,
-no publishing step.
+no publishing step. Host agents find skills via `AGENTS.md` even when
+next-mcp's local scanner is shallow.
 
 ### Layer 2: Repository (next)
 
@@ -50,15 +61,19 @@ consumed by multiple developers.
 
 Two consumption paths:
 - **next-mcp SkillRegistry:** `type: "github"` source. Lola format
-  detection scans 2 levels — works today.
+  detection can load nested skills **only** when the repo uses Lola
+  layout (`{module}/skills/{skill}/SKILL.md`). Raw ansible-know output
+  (`skills/{collection}/{module}/SKILL.md`) is **not** Lola layout —
+  wrap via #149 (or equivalent) before relying on GitHub Lola loading.
+  Vercel/generic GitHub loaders remain 1-level.
 - **Lola:** Users wrap skills into a Lola module and distribute to
-  40+ agents via `lola install`.
+  40+ agents via `lola install` (#149).
 
 **Value:** Persistence, sharing, version control, cross-agent reach.
 
 ### Layer 3: Remote Service (future)
 
-ansible-skill-mcp runs as an HTTP/SSE MCP server deployed by a platform
+ansible-know-mcp runs as an HTTP/SSE MCP server deployed by a platform
 team. Any MCP client calls it directly for on-demand skill generation.
 
 Target environments:
@@ -77,14 +92,17 @@ generated once per collection version, served to all developers.
   Teams can use any combination.
 - **Same output format**: spec-compliant skills at every layer. No
   format variations or compatibility concerns.
-- **Incremental rollout**: Layer 1 works today. Layer 2 requires
-  publishing to a repo. Layer 3 requires infrastructure.
+- **Incremental rollout**: Layer 1 works today (host agents + know MCP
+  tools). Layer 2 requires publishing/packaging. Layer 3 requires
+  infrastructure.
 
 ### Negative
 
-- **Layer 1 gap**: next-mcp's `_loadLocalSource` scans 1 level. Our
-  2-level output (collection/skill) is within spec bounds but missed
-  by the current implementation. Proposed patch pending.
+- **Layer 1 gap (next-mcp)**: `_loadLocalSource` scans 1 level. Our
+  2-level output (collection/skill) is within agentskills.io bounds but
+  missed by the current implementation until upstream expands depth.
+- **Layer 2 packaging**: Lola/GitHub Lola consumption needs a wrap step
+  (#149); not automatic from raw nested trees.
 - **Layer 3 infrastructure**: remote deployment requires hosting,
   authentication, and monitoring. Not trivial for enterprise environments.
 - **Scope creep risk**: three layers could expand the project's scope
@@ -100,16 +118,21 @@ would break. Spec compliance makes the layers possible.
 
 ## Implementation Notes
 
-- **Layer 1** (local): `ANSIBLE_KNOW_SKILLS_DIR` env var (default
-  `./skills/`), configured in `config.py`. next-mcp reads via
-  `ANSIBLE_SKILL_SOURCES` with `type: "local"` pointing to the same path.
-- **Layer 2** (repository): generated skills pushed to a GitHub repo.
-  next-mcp reads via `ANSIBLE_SKILL_SOURCES` with `type: "github"`.
-  Lola-compatible packaging is a separate user concern.
+- **Layer 1** (local): `get_project_root()` + `SKILLS_DIR` in `config.py`;
+  `update_agents_md()` in `skills.py`; wired from `generate_collection_skills`.
+  Alignment details:
+  [`docs/superpowers/specs/2026-08-02-skill-discoverability-alignment.md`](../../superpowers/specs/2026-08-02-skill-discoverability-alignment.md)
+- **Layer 2** (repository): generated skills pushed to a GitHub repo;
+  Lola packaging is a separate user concern (#149).
 - **Layer 3** (remote): FastMCP HTTP/SSE transport (see ADR-0001). Not
-  yet implemented — requires hosting, auth, and monitoring infrastructure.
-- **Scan depth gap**: next-mcp `_loadLocalSource` scans 1 level; our
-  2-level output requires a patch (draft at `tmp/draft-issue-local-scan-depth.md`).
+  yet implemented — requires hosting, auth, and monitoring infrastructure
+  (#71).
+- **Scan depth gap**: next-mcp `_loadLocalSource` / content reload assume
+  flat `{root}/{name}/SKILL.md`. Tracked in #200; upstream patch against
+  ansible/vscode-ansible `next` comes after our side is consistent.
+  Draft notes live in `tmp/draft-issue-local-scan-depth.md` (algorithm
+  must always scan nested skills even when a collection-level
+  `SKILL.md` exists).
 
 ## Related Decisions
 
@@ -125,3 +148,4 @@ would break. Spec compliance makes the layers possible.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial proposal |
+| 2026-08-03 | Leonardo Gallego (Assisted-by: Cursor) | Layer 1: project-scoped skills + AGENTS.md host discovery; correct Lola/GitHub claims; dual-config; scan-depth tracking |

--- a/docs/superpowers/specs/2026-07-17-project-scoped-skills-design.md
+++ b/docs/superpowers/specs/2026-07-17-project-scoped-skills-design.md
@@ -116,14 +116,20 @@ def update_agents_md(project_root: Path, skills_dir: Path) -> None:
 
 Called from `generate_collection_skills` in `server.py` after all skills are written. Since this is a sync function doing file I/O called from an async tool handler, it must be wrapped in `run_in_executor()` — same pattern as `write_module_skill_package` and friends.
 
-The call in `server.py` must be wrapped in its own `try/except OSError` so AGENTS.md failures don't mask successful skill generation:
+The call in `server.py` must be wrapped so AGENTS.md failures don't mask
+successful skill generation. Catch at least `(OSError, ValidationError)` —
+`validate_install_path` raises `ValidationError`, not `OSError`.
+
+Only call `update_agents_md` when `base_dir.resolve() == (project_root / "skills").resolve()`.
+Otherwise skip (explicit `install_to` or non-project `ANSIBLE_KNOW_SKILLS_DIR`).
 
 ```python
 project_root = get_project_root()
-if project_root is not None and project_root.is_dir():
+project_skills = (project_root / "skills").resolve()
+if project_root.is_dir() and base_dir.resolve() == project_skills:
     try:
         await run_in_executor(skills.update_agents_md, project_root, base_dir)
-    except OSError as exc:
+    except (OSError, ValidationError) as exc:
         logger.warning("AGENTS.md update failed: %s", sanitize_error(str(exc)))
 ```
 
@@ -132,14 +138,15 @@ if project_root is not None and project_root.is_dir():
 Lives in `config.py`.
 
 ```python
-def get_project_root() -> Path | None:
+def get_project_root() -> Path:
 ```
 
-Walks the env var chain (`ANSIBLE_KNOW_PROJECT_DIR` → `CLAUDE_PROJECT_DIR` → `cwd`). Returns `None` if no project root can be determined (defensive — shouldn't happen in practice since `cwd` always exists).
+Walks the env var chain (`ANSIBLE_KNOW_PROJECT_DIR` → `CLAUDE_PROJECT_DIR` →
+`cwd`). Always returns a `Path` (cwd fallback).
 
-`ANSIBLE_KNOW_SKILLS_DIR` is intentionally excluded from this chain — it points to a skills directory, not a project root. A user who sets `ANSIBLE_KNOW_SKILLS_DIR=/opt/shared/skills` doesn't want AGENTS.md written to `/opt/shared/`.
-
-When `get_project_root()` returns `None`, `generate_collection_skills` skips the AGENTS.md update silently (log a debug message). Skills are still written to `SKILLS_DIR` — only the AGENTS.md step is skipped.
+`ANSIBLE_KNOW_SKILLS_DIR` is intentionally excluded from this chain — it points
+to a skills directory, not a project root. AGENTS.md updates are skipped when
+skills were written outside `{project_root}/skills`.
 
 #### Files changed
 
@@ -176,7 +183,7 @@ The AGENTS.md update runs inside `generate_collection_skills`, which already has
 
 ### 5. Documentation
 
-Update tool descriptions for `generate_skill`, `generate_role_skill`, `generate_plugin_skill`, and `generate_collection_skills` to mention that `install_to` defaults to the project directory (not the server directory).
+Update tool descriptions for `generate_skill`, `generate_role_skill`, `generate_plugin_skill`, and `generate_collection_skills` to mention that `install_to` defaults to the project `skills/` directory (not the server cwd and not the project root itself).
 
 Update README registration section to note that `ANSIBLE_KNOW_PROJECT_DIR` can be set for non-Claude clients.
 
@@ -207,9 +214,10 @@ discovery, not Layer 2) and defines dual-config with `ANSIBLE_SKILL_SOURCES`.
 ## Follow-Up Issues
 
 1. **Multi-path search for `list_skills`/`get_skill`** (#182): search both project-local and a secondary path (e.g., pre-baked devcontainer skills). Enables shared + project-specific skill coexistence. Blocked on this design landing first.
-2. **`generate_collection_skills` AGENTS.md for single-module generators**: if users frequently call `generate_skill` directly (not via collection batch), consider updating AGENTS.md from those tools too.
-3. ~~**Update ADR-0008**: add AGENTS.md as a third Layer 2 consumption path~~ — **Superseded** by the alignment addendum: AGENTS.md is Layer 1; ADR-0008 revision is tracked under #196.
-4. **Validate `SKILLS_DIR` against sensitive prefixes**: pre-existing gap — `ANSIBLE_KNOW_SKILLS_DIR` env var is not validated through `validate_install_path()`. Include in #181 implementation (see alignment addendum).
+2. **AGENTS.md from single-module generators** (intentional non-goal of #181): only `generate_collection_skills` updates AGENTS.md. Per-module/role/plugin generators do not — avoids noisy rewrites when called in a loop. Revisit only if operators commonly generate one-off skills without the collection batch tool. No GitHub issue yet; not required for this design.
+3. ~~**Update ADR-0008**~~ — **Done in #181 / PR #184**: ADR-0008 revised for Layer 1 AGENTS.md + dual-config; Lola/GitHub claims corrected.
+4. ~~**Validate `SKILLS_DIR` against sensitive prefixes**~~ — **Done in #181 / PR #184**: `SKILLS_DIR` resolution runs through `validate_install_path()`.
+5. **next-mcp local scan depth** (#200) — nested module skills missed by `_loadLocalSource` (1-level). Upstream vscode-ansible patch after our side is consistent.
 
 ## References
 

--- a/docs/superpowers/specs/2026-07-17-project-scoped-skills-design.md
+++ b/docs/superpowers/specs/2026-07-17-project-scoped-skills-design.md
@@ -196,12 +196,20 @@ Add VS Code example to README:
 }
 ```
 
+## Alignment addendum
+
+Discoverability across host agents, next-mcp `SkillRegistry`, and Lola is
+specified in
+[2026-08-02-skill-discoverability-alignment.md](2026-08-02-skill-discoverability-alignment.md).
+That addendum supersedes follow-up item 3 below (AGENTS.md is Layer 1 host
+discovery, not Layer 2) and defines dual-config with `ANSIBLE_SKILL_SOURCES`.
+
 ## Follow-Up Issues
 
-1. **Multi-path search for `list_skills`/`get_skill`** (#182): search both project-local and a secondary path (e.g., pre-baked devcontainer skills). Enables shared + project-specific skill coexistence.
+1. **Multi-path search for `list_skills`/`get_skill`** (#182): search both project-local and a secondary path (e.g., pre-baked devcontainer skills). Enables shared + project-specific skill coexistence. Blocked on this design landing first.
 2. **`generate_collection_skills` AGENTS.md for single-module generators**: if users frequently call `generate_skill` directly (not via collection batch), consider updating AGENTS.md from those tools too.
-3. **Update ADR-0008**: add AGENTS.md as a third Layer 2 consumption path (alongside next-mcp `type: "github"` and Lola).
-4. **Validate `SKILLS_DIR` against sensitive prefixes**: pre-existing gap — `ANSIBLE_KNOW_SKILLS_DIR` env var is not validated through `validate_install_path()`. Low risk but worth hardening.
+3. ~~**Update ADR-0008**: add AGENTS.md as a third Layer 2 consumption path~~ — **Superseded** by the alignment addendum: AGENTS.md is Layer 1; ADR-0008 revision is tracked under #196.
+4. **Validate `SKILLS_DIR` against sensitive prefixes**: pre-existing gap — `ANSIBLE_KNOW_SKILLS_DIR` env var is not validated through `validate_install_path()`. Include in #181 implementation (see alignment addendum).
 
 ## References
 

--- a/docs/superpowers/specs/2026-08-02-skill-discoverability-alignment.md
+++ b/docs/superpowers/specs/2026-08-02-skill-discoverability-alignment.md
@@ -159,9 +159,8 @@ Managed section **must not**:
 | **#181** | Implement; body/comments: dual-config, A+B only, link this doc; harden `SKILLS_DIR` validation | Our side — now |
 | **#182** | Comment: blocked on #181; know-only multi-path; not next-mcp | Our side — after #181 |
 | **#149** | Comment: required for Layer 2 Lola/GitHub Lola; not a substitute for local scan depth | Our side — later |
-| **#196** | Checklist: Accept ADR-0007; revise ADR-0008 layers/`AGENTS.md`/Lola claims; fix July 31 skill tree example; clear stale project-strategy open items (#148 done) | Our side — with or right after #181 |
-| **Upstream scan depth** | Keep draft at `tmp/draft-issue-local-scan-depth.md`; **fix algorithm before filing** (see below) | Upstream — after our docs/issues agree |
-| Optional tracker | Open “Skill discoverability alignment” only if useful to link 181/182/149/196 + upstream | Optional |
+| **#196** | Remaining v0.7 docs drift only (service-contracts counts, ADR-0003, ADR-0007 Accepted, July 31 comparison, strategy table). ADR-0008 / discoverability owned by #181 | After #181 |
+| **#200** | next-mcp local scan depth tracking; draft at `tmp/draft-issue-local-scan-depth.md` (fix algorithm before filing upstream) | After #181; then upstream |
 
 ### Upstream draft fix (do not file until our wave lands)
 

--- a/docs/superpowers/specs/2026-08-02-skill-discoverability-alignment.md
+++ b/docs/superpowers/specs/2026-08-02-skill-discoverability-alignment.md
@@ -1,0 +1,218 @@
+# Skill Discoverability Alignment — Addendum
+
+**Date:** 2026-08-02
+**Status:** Draft (ready for issue updates, then implementation)
+**Parent design:** [2026-07-17-project-scoped-skills-design.md](2026-07-17-project-scoped-skills-design.md) (issue #181)
+**Related ADRs:** [ADR-0007](../../architecture/adr/0007-agentskills-spec-compliance.md), [ADR-0008](../../architecture/adr/0008-three-layer-distribution.md)
+
+## Purpose
+
+Correct and unify how generated skills are **discovered** across:
+
+1. Host AI agents (Claude Code, Cursor, Copilot, etc.) via filesystem + `AGENTS.md`
+2. next-mcp `SkillRegistry` via `ANSIBLE_SKILL_SOURCES` (local / github)
+3. Cross-agent packaging via Lola (#149)
+
+This is an **addendum**, not a redesign of skill generation or layout.
+Output format remains agentskills.io-compliant nested collection grouping
+(ADR-0007 / closed #148).
+
+## Problem restatement
+
+Three discoverability gaps are often conflated:
+
+| Gap | Symptom | Fixed by |
+|-----|---------|----------|
+| **A. Wrong write location** | Skills land under `uvx` cache / `$HOME`, not the project | #181 env chain |
+| **B. Host agents don’t know where to look** | Generic `skills/` is not auto-loaded by most agents | #181 `AGENTS.md` managed section |
+| **C. next-mcp misses nested skills** | `_loadLocalSource` scans 1 level; module skills invisible | Upstream vscode-ansible patch (deferred) |
+
+#181 addresses **A** and **B** only. Claiming #181 “integrates with next-mcp”
+without **C** overstates Layer 1 readiness.
+
+## Discovery paths (corrected)
+
+```text
+ansible-know-mcp                         Consumers
+generate_* ──► SKILLS_DIR
+                 │
+                 ├─► know MCP: list_skills / get_skill / skills://*
+                 │
+                 ├─► Host agents: read AGENTS.md → open skills/**/SKILL.md
+                 │     (#181 — Layer 1 host discovery)
+                 │
+                 ├─► next-mcp SkillRegistry: type "local" url = same dir
+                 │     (today: collection-level only; nested needs upstream)
+                 │
+                 └─► Lola wrap (#149) → lola install / GitHub Lola source
+                       (Layer 2 distribution — packaging step)
+```
+
+### Layer classification (corrects ADR-0008 follow-up wording)
+
+| Mechanism | Layer | Role |
+|-----------|-------|------|
+| Shared project `skills/` + know MCP tools | Layer 1 | Generate + serve locally |
+| `AGENTS.md` managed section (#181) | Layer 1 | Host-agent pointer into project skills |
+| next-mcp `ANSIBLE_SKILL_SOURCES` local | Layer 1 | Registry/`skill_*` over same directory |
+| GitHub skill repo + next-mcp github source | Layer 2 | Team-shared consumption |
+| Lola module packaging (#149) | Layer 2 | Cross-agent install / marketplace |
+| Remote HTTP MCP (#71) | Layer 3 | On-demand generation service |
+
+**Correction:** Do **not** classify `AGENTS.md` as a Layer 2 consumption path.
+The #181 design follow-up item that said so is superseded by this addendum.
+
+**Correction:** next-mcp GitHub **Lola** loading does **not** consume our raw
+`skills/{collection}/{module}/SKILL.md` tree. Lola expects
+`{module}/skills/{skill}/SKILL.md` (or marketplace layout). Layer 2 via Lola
+requires #149 (or equivalent wrap). Vercel/generic GitHub loaders are also
+1-level and miss nested module skills without packaging or an upstream depth fix.
+
+## Dual-config contract (our side)
+
+When users run ansible-know-mcp **and** next-mcp against the same project,
+both must resolve to the **same skills directory**.
+
+### Env vars
+
+| Variable | Owner | Meaning |
+|----------|-------|---------|
+| `ANSIBLE_KNOW_SKILLS_DIR` | know-mcp | Explicit skills directory (wins) |
+| `ANSIBLE_KNOW_PROJECT_DIR` | know-mcp | Project root → `{root}/skills` |
+| `CLAUDE_PROJECT_DIR` | Claude Code → know-mcp | Auto-injected project root → `{root}/skills` |
+| `ANSIBLE_SKILL_SOURCES` | next-mcp | JSON array of `SkillSource`: `{id, type, url, trust}` |
+
+know-mcp never reads `ANSIBLE_SKILL_SOURCES`. next-mcp never reads
+`ANSIBLE_KNOW_*`. Alignment is **operator configuration**, documented by us.
+
+### Recommended VS Code wiring
+
+Prefer the extension setting for next-mcp sources when available
+(`ansibleEnvironments.skillSources`); for raw MCP `env`, use the same
+absolute/workspace path in both places:
+
+```json
+{
+  "servers": {
+    "ansible-know": {
+      "command": "uvx",
+      "args": ["ansible-know-mcp"],
+      "env": {
+        "ANSIBLE_KNOW_PROJECT_DIR": "${workspaceFolder}"
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "ansibleEnvironments.skillSources": [
+    {
+      "id": "know-generated",
+      "type": "local",
+      "url": "${workspaceFolder}/skills",
+      "trust": "community"
+    }
+  ]
+}
+```
+
+Notes:
+
+- next-mcp’s loader expects **`url`** (directory path), plus **`id`** and **`trust`**.
+  Docs/examples that use `path` or `repo` alone do not match the TypeScript
+  `SkillSource` interface — call that out in README; do not invent a parallel schema.
+- Until upstream expands local scan depth, next-mcp will index **collection-level**
+  `skills/{collection}/SKILL.md` and miss nested module/plugin/role skills.
+  Host agents following `AGENTS.md` can still open nested `SKILL.md` files.
+- Claude Code: `CLAUDE_PROJECT_DIR` makes know-mcp zero-config; next-mcp still
+  needs an explicit local source if `skill_*` tools should see generated skills.
+
+### What `AGENTS.md` must and must not claim
+
+Managed section (#181) **should**:
+
+- Point at the project-relative `skills/` tree
+- Give a concrete nested example path
+- List available collection directories when known
+
+Managed section **must not**:
+
+- Claim that next-mcp `SkillRegistry` reads `AGENTS.md` (it does not)
+- Claim that all nested skills appear in `skill_list` without the upstream fix
+- Write beside `ANSIBLE_KNOW_SKILLS_DIR` when that path is a shared non-project
+  directory (`get_project_root()` excludes that var — keep that rule)
+
+## Non-goals (this addendum / #181 wave)
+
+- Changing nested output layout to flat `skills/{name}/SKILL.md` for next-mcp
+- Implementing multi-path `list_skills` (#182) in the same change as #181
+- Automating Lola packaging (#149)
+- Patching vscode-ansible `_loadLocalSource` (upstream phase)
+- Loading `.agents/skills` or agent-specific skill dirs (rejected by next-mcp ADR-014 for registry; out of scope for us too)
+
+## Issue map and ownership
+
+| Issue | Action after this addendum | Phase |
+|-------|----------------------------|-------|
+| **#181** | Implement; body/comments: dual-config, A+B only, link this doc; harden `SKILLS_DIR` validation | Our side — now |
+| **#182** | Comment: blocked on #181; know-only multi-path; not next-mcp | Our side — after #181 |
+| **#149** | Comment: required for Layer 2 Lola/GitHub Lola; not a substitute for local scan depth | Our side — later |
+| **#196** | Checklist: Accept ADR-0007; revise ADR-0008 layers/`AGENTS.md`/Lola claims; fix July 31 skill tree example; clear stale project-strategy open items (#148 done) | Our side — with or right after #181 |
+| **Upstream scan depth** | Keep draft at `tmp/draft-issue-local-scan-depth.md`; **fix algorithm before filing** (see below) | Upstream — after our docs/issues agree |
+| Optional tracker | Open “Skill discoverability alignment” only if useful to link 181/182/149/196 + upstream | Optional |
+
+### Upstream draft fix (do not file until our wave lands)
+
+`tmp/draft-issue-local-scan-depth.md` must be corrected before posting:
+
+1. **Always** discover nested `{collection}/{skill}/SKILL.md` even when
+   `{collection}/SKILL.md` exists (collection-level skill is normal for us).
+2. Persist a relative content path (or `contentUrl`) so
+   `_fetchSkillContent` does not assume `join(url, skill.name, 'SKILL.md')`.
+3. Optionally mirror depth-2 for `_loadVercelSource` if raw GitHub trees
+   without Lola wrapping are in scope.
+
+Filing venue: `ansible/vscode-ansible` (next branch / SkillRegistry).
+
+## Implementation sequence (our side first)
+
+1. **Land this addendum** (this file) — source of truth for discoverability narrative.
+2. **Update issue bodies/comments** (#181, #182, #149, #196) to link here and drop superseded Layer-2/`AGENTS.md` wording.
+3. **Implement #181** per parent design + dual-config README/tool-description notes from this addendum; include `SKILLS_DIR` sensitive-prefix validation.
+4. **Docs/ADR catch-up** (#196 slice) in the same PR or an immediate follow-up.
+5. **#182** only if multi-path is still needed after #181.
+6. **#149** when Layer 2 / marketplace work starts.
+7. **Upstream phase:** fix draft → file vscode-ansible issue → link from ADR-0008.
+
+## Edits implied in sibling docs (for #196 / #181 PR)
+
+Do not rewrite the full skills-distribution strategy. Minimal corrections:
+
+| Doc | Change |
+|-----|--------|
+| #181 design follow-up #3 | Superseded: `AGENTS.md` is Layer 1 host discovery, not Layer 2 |
+| ADR-0008 | Add Layer 1 `AGENTS.md` path; fix “Lola works today” for raw output; link deferred upstream + this addendum |
+| ADR-0007 | Promote toward Accepted (#148 closed); keep consumer scan-depth caveat |
+| `docs/research/skills-distribution-strategy-2026-06-26.md` | Same Lola/Layer corrections in “Already works” / open items |
+| `docs/research/2026-07-31-know-vs-next-mcp-comparison.md` | Replace flat `skills/ansible.builtin.copy/` example with nested kebab layout |
+| `docs/architecture/project-strategy.md` | Mark #148 done; note scan-depth proposal deferred to upstream phase |
+
+## Success criteria
+
+- [ ] #181 ships: skills default into the project; `AGENTS.md` managed section works (create/append/replace).
+- [ ] README documents dual-config for VS Code / Claude Code without promising nested `skill_list` until upstream.
+- [ ] ADR-0007/0008 and strategy docs no longer claim Lola/GitHub consume raw nested trees.
+- [ ] Issues #181/#182/#149/#196 link this addendum and agree on sequencing.
+- [ ] Upstream issue remains unfiled until the draft algorithm is fixed and our side narrative is consistent.
+
+## References
+
+- Parent design: [2026-07-17-project-scoped-skills-design.md](2026-07-17-project-scoped-skills-design.md)
+- Plan: [../plans/2026-07-17-project-scoped-skills.md](../plans/2026-07-17-project-scoped-skills.md)
+- Distribution strategy: [../../research/skills-distribution-strategy-2026-06-26.md](../../research/skills-distribution-strategy-2026-06-26.md)
+- Know vs next comparison: [../../research/2026-07-31-know-vs-next-mcp-comparison.md](../../research/2026-07-31-know-vs-next-mcp-comparison.md)
+- Upstream draft (local): `tmp/draft-issue-local-scan-depth.md`
+- next-mcp `SkillRegistry`: `packages/services/src/SkillRegistry.ts` in ansible/vscode-ansible (`next`)
+- agentskills.io client guide (scan depth 4–6)

--- a/src/ansible_know/config.py
+++ b/src/ansible_know/config.py
@@ -35,12 +35,23 @@ except PackageNotFoundError:
     USER_AGENT = "ansible-know-mcp/unknown (+https://github.com/leogallego/ansible-know-mcp)"
 
 
+def get_project_root() -> Path | None:
+    """Return the project root from env vars, or cwd as fallback."""
+    for var in ("ANSIBLE_KNOW_PROJECT_DIR", "CLAUDE_PROJECT_DIR"):
+        value = os.environ.get(var, "").strip()
+        if value:
+            return Path(value)
+    return Path.cwd()
+
+
 def __getattr__(name: str):
     if name == "SKILLS_DIR":
-        value = Path(os.environ.get(
-            "ANSIBLE_KNOW_SKILLS_DIR",
-            Path.cwd() / "skills",
-        ))
+        explicit = os.environ.get("ANSIBLE_KNOW_SKILLS_DIR", "").strip()
+        if explicit:
+            value = Path(explicit)
+        else:
+            root = get_project_root()
+            value = root / "skills"
         globals()["SKILLS_DIR"] = value
         return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/ansible_know/config.py
+++ b/src/ansible_know/config.py
@@ -35,7 +35,7 @@ except PackageNotFoundError:
     USER_AGENT = "ansible-know-mcp/unknown (+https://github.com/leogallego/ansible-know-mcp)"
 
 
-def get_project_root() -> Path | None:
+def get_project_root() -> Path:
     """Return the project root from env vars, or cwd as fallback."""
     for var in ("ANSIBLE_KNOW_PROJECT_DIR", "CLAUDE_PROJECT_DIR"):
         value = os.environ.get(var, "").strip()

--- a/src/ansible_know/config.py
+++ b/src/ansible_know/config.py
@@ -46,12 +46,15 @@ def get_project_root() -> Path:
 
 def __getattr__(name: str):
     if name == "SKILLS_DIR":
+        # Lazy import: validation is Foundation and must not import config.
+        from ansible_know.validation import validate_install_path
+
         explicit = os.environ.get("ANSIBLE_KNOW_SKILLS_DIR", "").strip()
         if explicit:
-            value = Path(explicit)
+            value = validate_install_path(explicit)
         else:
             root = get_project_root()
-            value = root / "skills"
+            value = validate_install_path(str(root / "skills"))
         globals()["SKILLS_DIR"] = value
         return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1331,8 +1331,8 @@ async def generate_collection_skills(
             "manifest": manifest,
             "collection_skill": collection_namespace,
         }
-    except ValidationError:
-        raise
+    except ValidationError as exc:
+        return {"error": str(exc)}
     except Exception as exc:
         logger.warning("generate_collection_skills failed: %s", exc)
         return {"error": maybe_add_hint(sanitize_error(str(exc)), collection_namespace)}

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1293,6 +1293,15 @@ async def generate_collection_skills(
             metadata_list, installed_version, plugins_metadata,
         )
 
+        from ansible_know.config import get_project_root
+
+        project_root = get_project_root()
+        if project_root is not None and project_root.is_dir():
+            try:
+                await run_in_executor(skills.update_agents_md, project_root, base_dir)
+            except OSError as exc:
+                logger.warning("AGENTS.md update failed: %s", sanitize_error(str(exc)))
+
         if ctx:
             await ctx.report_progress(progress=total, total=total)
 

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -905,7 +905,8 @@ async def generate_skill(
     install_to: Annotated[
         str | None,
         "Optional absolute path to install the skill to. Defaults to the project "
-        "directory (via ANSIBLE_KNOW_PROJECT_DIR or CLAUDE_PROJECT_DIR env vars, then cwd).",
+        "skills/ directory (via ANSIBLE_KNOW_SKILLS_DIR, or "
+        "ANSIBLE_KNOW_PROJECT_DIR/CLAUDE_PROJECT_DIR/cwd + /skills).",
     ] = None,
     ctx: Context | None = None,
 ) -> str | ErrorResponse:
@@ -971,7 +972,8 @@ async def generate_role_skill(
     install_to: Annotated[
         str | None,
         "Optional absolute path to install the skill to. Defaults to the project "
-        "directory (via ANSIBLE_KNOW_PROJECT_DIR or CLAUDE_PROJECT_DIR env vars, then cwd).",
+        "skills/ directory (via ANSIBLE_KNOW_SKILLS_DIR, or "
+        "ANSIBLE_KNOW_PROJECT_DIR/CLAUDE_PROJECT_DIR/cwd + /skills).",
     ] = None,
     ctx: Context | None = None,
 ) -> str | ErrorResponse:
@@ -1042,7 +1044,8 @@ async def generate_plugin_skill(
     install_to: Annotated[
         str | None,
         "Optional absolute path to install the skill to. Defaults to the project "
-        "directory (via ANSIBLE_KNOW_PROJECT_DIR or CLAUDE_PROJECT_DIR env vars, then cwd).",
+        "skills/ directory (via ANSIBLE_KNOW_SKILLS_DIR, or "
+        "ANSIBLE_KNOW_PROJECT_DIR/CLAUDE_PROJECT_DIR/cwd + /skills).",
     ] = None,
     ctx: Context | None = None,
 ) -> str | ErrorResponse:
@@ -1109,7 +1112,8 @@ async def generate_collection_skills(
     install_to: Annotated[
         str | None,
         "Optional absolute path to install skills to. Defaults to the project "
-        "directory (via ANSIBLE_KNOW_PROJECT_DIR or CLAUDE_PROJECT_DIR env vars, then cwd).",
+        "skills/ directory (via ANSIBLE_KNOW_SKILLS_DIR, or "
+        "ANSIBLE_KNOW_PROJECT_DIR/CLAUDE_PROJECT_DIR/cwd + /skills).",
     ] = None,
     ctx: Context | None = None,
 ) -> GenerateCollectionSkillsResult | ErrorResponse:
@@ -1313,12 +1317,20 @@ async def generate_collection_skills(
 
         from ansible_know.config import get_project_root
 
+        # AGENTS.md is project-root discovery only. Skip when skills were written
+        # outside {project_root}/skills (explicit install_to or ANSIBLE_KNOW_SKILLS_DIR).
         project_root = get_project_root()
-        if project_root.is_dir():
+        project_skills = (project_root / "skills").resolve()
+        if project_root.is_dir() and base_dir.resolve() == project_skills:
             try:
                 await run_in_executor(skills.update_agents_md, project_root, base_dir)
-            except OSError as exc:
+            except (OSError, ValidationError) as exc:
                 logger.warning("AGENTS.md update failed: %s", sanitize_error(str(exc)))
+        elif project_root.is_dir():
+            logger.debug(
+                "Skipping AGENTS.md update: skills dir %s is not %s",
+                base_dir, project_skills,
+            )
 
         if ctx:
             await ctx.report_progress(progress=total, total=total)

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1314,7 +1314,7 @@ async def generate_collection_skills(
         from ansible_know.config import get_project_root
 
         project_root = get_project_root()
-        if project_root is not None and project_root.is_dir():
+        if project_root.is_dir():
             try:
                 await run_in_executor(skills.update_agents_md, project_root, base_dir)
             except OSError as exc:

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -902,7 +902,11 @@ async def get_skill(
 @mcp.tool(annotations=ToolAnnotations(idempotentHint=True))
 async def generate_skill(
     module_name: Annotated[str, "Fully-qualified module name (e.g. 'ansible.builtin.copy')"],
-    install_to: Annotated[str | None, "Optional absolute path to install the skill to"] = None,
+    install_to: Annotated[
+        str | None,
+        "Optional absolute path to install the skill to. Defaults to the project "
+        "directory (via ANSIBLE_KNOW_PROJECT_DIR or CLAUDE_PROJECT_DIR env vars, then cwd).",
+    ] = None,
     ctx: Context | None = None,
 ) -> str | ErrorResponse:
     """Generate a skill package for one module.
@@ -964,7 +968,11 @@ async def generate_skill(
 @mcp.tool(annotations=ToolAnnotations(idempotentHint=True))
 async def generate_role_skill(
     role_name: Annotated[str, "Fully-qualified role name (e.g. 'fedora.linux_system_roles.timesync')"],
-    install_to: Annotated[str | None, "Optional absolute path to install the skill to"] = None,
+    install_to: Annotated[
+        str | None,
+        "Optional absolute path to install the skill to. Defaults to the project "
+        "directory (via ANSIBLE_KNOW_PROJECT_DIR or CLAUDE_PROJECT_DIR env vars, then cwd).",
+    ] = None,
     ctx: Context | None = None,
 ) -> str | ErrorResponse:
     """Generate a skill package for one role.
@@ -1031,7 +1039,11 @@ async def generate_plugin_skill(
         "strategy, callback, inventory, cache, cliconf, httpapi, "
         "netconf, shell, or vars)",
     ],
-    install_to: Annotated[str | None, "Optional absolute path to install the skill to"] = None,
+    install_to: Annotated[
+        str | None,
+        "Optional absolute path to install the skill to. Defaults to the project "
+        "directory (via ANSIBLE_KNOW_PROJECT_DIR or CLAUDE_PROJECT_DIR env vars, then cwd).",
+    ] = None,
     ctx: Context | None = None,
 ) -> str | ErrorResponse:
     """Generate a skill package for one plugin.
@@ -1094,12 +1106,18 @@ async def generate_plugin_skill(
 @mcp.tool(annotations=ToolAnnotations(idempotentHint=True))
 async def generate_collection_skills(
     collection_namespace: Annotated[str, "Collection namespace (e.g. 'netbox.netbox')"],
-    install_to: Annotated[str | None, "Optional absolute path to install skills to"] = None,
+    install_to: Annotated[
+        str | None,
+        "Optional absolute path to install skills to. Defaults to the project "
+        "directory (via ANSIBLE_KNOW_PROJECT_DIR or CLAUDE_PROJECT_DIR env vars, then cwd).",
+    ] = None,
     ctx: Context | None = None,
 ) -> GenerateCollectionSkillsResult | ErrorResponse:
     """Batch generate skills for an entire collection.
 
     Generates/updates the collection MANIFEST.json as a byproduct.
+    Updates AGENTS.md in the project root with a managed section
+    listing available collections for cross-agent discovery.
     Returns {"succeeded": int, "failed": int, "total": int, "manifest": dict, "collection_skill": str},
     or {"error": str} on failure.
     """

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -338,6 +338,7 @@ def update_agents_md(project_root: Path, skills_dir: Path) -> None:
 
     collections = []
     example_path = ""
+    example_dir = ""
     if skills_dir.exists():
         for entry in sorted(skills_dir.iterdir()):
             try:

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -10,6 +10,7 @@ import functools
 import logging
 import re
 import stat
+import threading
 from collections import Counter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -19,6 +20,7 @@ from ansible_know.tagging import derive_tags
 from ansible_know.validation import (
     split_collection_fqcn,
     truncate_response,
+    validate_install_path,
     validate_path_containment,
 )
 
@@ -35,6 +37,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger("ansible_know")
 
 PLUGIN_SKILL_DIR_RE = re.compile(r"^([a-z]+)-(.+)$")
+_AGENTS_MD_START = "<!-- ansible-know:skills:start -->"
+_AGENTS_MD_END = "<!-- ansible-know:skills:end -->"
+_agents_md_lock = threading.Lock()
 
 __all__ = [
     "PLUGIN_SKILL_DIR_RE",
@@ -53,6 +58,7 @@ __all__ = [
     "render_role_skill",
     "render_skill",
     "role_skill_name",
+    "update_agents_md",
     "write_collection_skill_package",
     "write_module_skill_package",
     "write_plugin_skill_package",
@@ -324,6 +330,71 @@ def get_skill_sync(skills_dir: Path, skill_name: str) -> str:
             return truncate_response(skill_path.read_text())
 
     raise FileNotFoundError(f"Skill '{skill_name}' not found.")
+
+
+def update_agents_md(project_root: Path, skills_dir: Path) -> None:
+    """Write or update the managed AGENTS.md section listing generated skills."""
+    validate_install_path(str(project_root))
+
+    collections = []
+    example_path = ""
+    if skills_dir.exists():
+        for entry in sorted(skills_dir.iterdir()):
+            try:
+                if not entry.is_dir() or entry.is_symlink():
+                    continue
+                if (entry / "SKILL.md").exists():
+                    fqcn = skill_dir_to_collection_fqcn(entry.name)
+                    collections.append(fqcn)
+                    if not example_path:
+                        for sub in sorted(entry.iterdir()):
+                            if sub.is_dir() and not sub.is_symlink() and (sub / "SKILL.md").exists():
+                                example_path = f"{fqcn}.{skill_dir_to_short_fqcn(sub.name)}"
+                                example_dir = f"skills/{entry.name}/{sub.name}/SKILL.md"
+                                break
+            except OSError:
+                continue
+
+    example_line = ""
+    if example_path:
+        example_line = f"\n(e.g., `{example_path}` → `{example_dir}`)."
+    else:
+        example_line = "."
+
+    section = (
+        f"{_AGENTS_MD_START}\n"
+        f"## Ansible Module Skills\n"
+        f"\n"
+        f"Generated Ansible module documentation skills are in `skills/`.\n"
+        f"Before writing tasks for a module, check for a SKILL.md in the\n"
+        f"matching collection and module directory{example_line}\n"
+        f"\n"
+        f"Available collections: {', '.join(collections)}\n"
+        f"{_AGENTS_MD_END}\n"
+    )
+
+    agents_md_path = project_root / "AGENTS.md"
+
+    with _agents_md_lock:
+        if not agents_md_path.exists():
+            agents_md_path.write_text(section)
+            return
+
+        content = agents_md_path.read_text()
+
+        if _AGENTS_MD_START in content and _AGENTS_MD_END in content:
+            start_idx = content.index(_AGENTS_MD_START)
+            end_idx = content.index(_AGENTS_MD_END) + len(_AGENTS_MD_END)
+            if content[end_idx:end_idx + 1] == "\n":
+                end_idx += 1
+            content = content[:start_idx] + section + content[end_idx:]
+            agents_md_path.write_text(content)
+            return
+
+        if not content.endswith("\n"):
+            content += "\n"
+        content += "\n" + section
+        agents_md_path.write_text(content)
 
 
 def _build_example_args(params: list[ParamDict], examples_yaml: str = "") -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from ansible_know.config import DEFAULT_DOC_SOURCES, get_doc_sources
 
 
@@ -193,25 +195,34 @@ class TestSkillsDirResolution:
         monkeypatch.setenv("ANSIBLE_KNOW_PROJECT_DIR", str(tmp_path / "project"))
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path / "claude"))
         result = self._reload_skills_dir(monkeypatch)
-        assert result == tmp_path / "explicit"
+        assert result == (tmp_path / "explicit").resolve()
 
     def test_project_dir_adds_skills_suffix(self, monkeypatch, tmp_path):
         monkeypatch.delenv("ANSIBLE_KNOW_SKILLS_DIR", raising=False)
         monkeypatch.setenv("ANSIBLE_KNOW_PROJECT_DIR", str(tmp_path))
         monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
         result = self._reload_skills_dir(monkeypatch)
-        assert result == tmp_path / "skills"
+        assert result == (tmp_path / "skills").resolve()
 
     def test_claude_project_dir_adds_skills_suffix(self, monkeypatch, tmp_path):
         monkeypatch.delenv("ANSIBLE_KNOW_SKILLS_DIR", raising=False)
         monkeypatch.delenv("ANSIBLE_KNOW_PROJECT_DIR", raising=False)
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
         result = self._reload_skills_dir(monkeypatch)
-        assert result == tmp_path / "skills"
+        assert result == (tmp_path / "skills").resolve()
 
     def test_cwd_fallback(self, monkeypatch):
         monkeypatch.delenv("ANSIBLE_KNOW_SKILLS_DIR", raising=False)
         monkeypatch.delenv("ANSIBLE_KNOW_PROJECT_DIR", raising=False)
         monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
         result = self._reload_skills_dir(monkeypatch)
-        assert result == Path.cwd() / "skills"
+        assert result == (Path.cwd() / "skills").resolve()
+
+    def test_rejects_sensitive_skills_dir(self, monkeypatch):
+        from ansible_know.errors import ValidationError
+
+        monkeypatch.setenv("ANSIBLE_KNOW_SKILLS_DIR", "/etc/ansible-know-skills")
+        monkeypatch.delenv("ANSIBLE_KNOW_PROJECT_DIR", raising=False)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        with pytest.raises(ValidationError, match="system directories"):
+            self._reload_skills_dir(monkeypatch)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -145,3 +145,76 @@ class TestAapDocSources:
     def test_aap_file_paths_end_with_json(self):
         for ver in ("aap-2.5", "aap-2.6", "aap-2.7"):
             assert DEFAULT_DOC_SOURCES[ver]["file"].endswith(".json")
+
+
+class TestGetProjectRoot:
+    def test_ansible_know_project_dir_wins(self, monkeypatch, tmp_path):
+        from ansible_know.config import get_project_root
+
+        monkeypatch.setenv("ANSIBLE_KNOW_PROJECT_DIR", str(tmp_path))
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/should/not/win")
+        assert get_project_root() == tmp_path
+
+    def test_claude_project_dir_fallback(self, monkeypatch, tmp_path):
+        from ansible_know.config import get_project_root
+
+        monkeypatch.delenv("ANSIBLE_KNOW_PROJECT_DIR", raising=False)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        assert get_project_root() == tmp_path
+
+    def test_cwd_fallback(self, monkeypatch):
+        from pathlib import Path
+
+        from ansible_know.config import get_project_root
+
+        monkeypatch.delenv("ANSIBLE_KNOW_PROJECT_DIR", raising=False)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        assert get_project_root() == Path.cwd()
+
+    def test_empty_env_var_skipped(self, monkeypatch, tmp_path):
+        from ansible_know.config import get_project_root
+
+        monkeypatch.setenv("ANSIBLE_KNOW_PROJECT_DIR", "")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        assert get_project_root() == tmp_path
+
+
+class TestSkillsDirResolution:
+    def _reload_skills_dir(self, monkeypatch):
+        """Force SKILLS_DIR to re-resolve by clearing the cached value."""
+        import ansible_know.config as config_mod
+
+        monkeypatch.delattr(config_mod, "SKILLS_DIR", raising=False)
+        if "SKILLS_DIR" in config_mod.__dict__:
+            del config_mod.__dict__["SKILLS_DIR"]
+        return config_mod.SKILLS_DIR
+
+    def test_explicit_skills_dir_wins(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("ANSIBLE_KNOW_SKILLS_DIR", str(tmp_path / "explicit"))
+        monkeypatch.setenv("ANSIBLE_KNOW_PROJECT_DIR", str(tmp_path / "project"))
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path / "claude"))
+        result = self._reload_skills_dir(monkeypatch)
+        assert result == tmp_path / "explicit"
+
+    def test_project_dir_adds_skills_suffix(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ANSIBLE_KNOW_SKILLS_DIR", raising=False)
+        monkeypatch.setenv("ANSIBLE_KNOW_PROJECT_DIR", str(tmp_path))
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        result = self._reload_skills_dir(monkeypatch)
+        assert result == tmp_path / "skills"
+
+    def test_claude_project_dir_adds_skills_suffix(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ANSIBLE_KNOW_SKILLS_DIR", raising=False)
+        monkeypatch.delenv("ANSIBLE_KNOW_PROJECT_DIR", raising=False)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        result = self._reload_skills_dir(monkeypatch)
+        assert result == tmp_path / "skills"
+
+    def test_cwd_fallback(self, monkeypatch):
+        from pathlib import Path
+
+        monkeypatch.delenv("ANSIBLE_KNOW_SKILLS_DIR", raising=False)
+        monkeypatch.delenv("ANSIBLE_KNOW_PROJECT_DIR", raising=False)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        result = self._reload_skills_dir(monkeypatch)
+        assert result == Path.cwd() / "skills"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 """Tests for ansible_know.config."""
 
 import json
+from pathlib import Path
 
 from ansible_know.config import DEFAULT_DOC_SOURCES, get_doc_sources
 
@@ -163,8 +164,6 @@ class TestGetProjectRoot:
         assert get_project_root() == tmp_path
 
     def test_cwd_fallback(self, monkeypatch):
-        from pathlib import Path
-
         from ansible_know.config import get_project_root
 
         monkeypatch.delenv("ANSIBLE_KNOW_PROJECT_DIR", raising=False)
@@ -211,8 +210,6 @@ class TestSkillsDirResolution:
         assert result == tmp_path / "skills"
 
     def test_cwd_fallback(self, monkeypatch):
-        from pathlib import Path
-
         monkeypatch.delenv("ANSIBLE_KNOW_SKILLS_DIR", raising=False)
         monkeypatch.delenv("ANSIBLE_KNOW_PROJECT_DIR", raising=False)
         monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -280,6 +280,28 @@ class TestGenerateCollectionSkillsTool:
         assert result["succeeded"] == 1
         assert (tmp_path / "netbox-netbox" / "netbox-device" / "SKILL.md").exists()
 
+    @pytest.mark.asyncio
+    async def test_updates_agents_md(self, tmp_path, mock_ansible_doc, monkeypatch):
+        """generate_collection_skills calls update_agents_md after writing skills."""
+        responses = [
+            json.dumps(SAMPLE_MODULE_LIST),
+            json.dumps({}),
+        ]
+        responses.extend([json.dumps({})] * 14)
+        responses.extend([json.dumps(SAMPLE_MODULE_DOC)] * 4)
+
+        mock_ansible_doc.side_effect = responses
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+
+        mock_update = MagicMock()
+        with patch("ansible_know.skills.update_agents_md", mock_update), \
+             patch("ansible_know.config.get_project_root", return_value=tmp_path):
+            from ansible_know.server import generate_collection_skills
+            result = await generate_collection_skills("ansible.builtin", install_to=str(tmp_path))
+
+        assert result["succeeded"] + result["failed"] == result["total"]
+        mock_update.assert_called_once_with(tmp_path, tmp_path)
+
 
 class TestFQCNValidation:
     @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -291,16 +291,78 @@ class TestGenerateCollectionSkillsTool:
         responses.extend([json.dumps(SAMPLE_MODULE_DOC)] * 4)
 
         mock_ansible_doc.side_effect = responses
-        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", skills_dir)
 
         mock_update = MagicMock()
         with patch("ansible_know.skills.update_agents_md", mock_update), \
              patch("ansible_know.config.get_project_root", return_value=tmp_path):
             from ansible_know.server import generate_collection_skills
-            result = await generate_collection_skills("ansible.builtin", install_to=str(tmp_path))
+            result = await generate_collection_skills(
+                "ansible.builtin", install_to=str(skills_dir),
+            )
 
         assert result["succeeded"] + result["failed"] == result["total"]
-        mock_update.assert_called_once_with(tmp_path, tmp_path)
+        mock_update.assert_called_once_with(tmp_path, skills_dir)
+
+    @pytest.mark.asyncio
+    async def test_agents_md_validation_error_does_not_mask_success(
+        self, tmp_path, mock_ansible_doc, monkeypatch,
+    ):
+        """ValidationError from update_agents_md must not turn success into error."""
+        from ansible_know.errors import ValidationError
+
+        responses = [
+            json.dumps(SAMPLE_MODULE_LIST),
+            json.dumps({}),
+        ]
+        responses.extend([json.dumps({})] * 14)
+        responses.extend([json.dumps(SAMPLE_MODULE_DOC)] * 4)
+        mock_ansible_doc.side_effect = responses
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", skills_dir)
+
+        mock_update = MagicMock(side_effect=ValidationError("Install path not allowed"))
+        with patch("ansible_know.skills.update_agents_md", mock_update), \
+             patch("ansible_know.config.get_project_root", return_value=tmp_path):
+            from ansible_know.server import generate_collection_skills
+            result = await generate_collection_skills(
+                "ansible.builtin", install_to=str(skills_dir),
+            )
+
+        assert "error" not in result
+        assert result["succeeded"] + result["failed"] == result["total"]
+
+    @pytest.mark.asyncio
+    async def test_skips_agents_md_when_install_to_diverges(
+        self, tmp_path, mock_ansible_doc, monkeypatch,
+    ):
+        """Do not update AGENTS.md when skills land outside project skills/."""
+        responses = [
+            json.dumps(SAMPLE_MODULE_LIST),
+            json.dumps({}),
+        ]
+        responses.extend([json.dumps({})] * 14)
+        responses.extend([json.dumps(SAMPLE_MODULE_DOC)] * 4)
+        mock_ansible_doc.side_effect = responses
+
+        other_dir = tmp_path / "elsewhere"
+        other_dir.mkdir()
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path / "skills")
+
+        mock_update = MagicMock()
+        with patch("ansible_know.skills.update_agents_md", mock_update), \
+             patch("ansible_know.config.get_project_root", return_value=tmp_path):
+            from ansible_know.server import generate_collection_skills
+            result = await generate_collection_skills(
+                "ansible.builtin", install_to=str(other_dir),
+            )
+
+        assert "error" not in result
+        mock_update.assert_not_called()
 
 
 class TestFQCNValidation:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -17,6 +17,7 @@ from ansible_know.skills import (
     render_role_skill,
     render_skill,
     role_skill_name,
+    update_agents_md,
     write_collection_skill_package,
     write_module_skill_package,
     write_plugin_skill_package,
@@ -729,3 +730,111 @@ class TestCollectionSkillWithPlugins:
         }]
         result = render_collection_skill("netbox.netbox", metadata_list)
         assert "Available Plugins" not in result
+
+
+class TestUpdateAgentsMd:
+    def _make_collection_skill(self, skills_dir, name):
+        """Create a minimal collection skill directory with SKILL.md."""
+        coll_dir = skills_dir / name
+        coll_dir.mkdir(parents=True)
+        (coll_dir / "SKILL.md").write_text(
+            "---\nname: test\ndescription: test collection\n---\n"
+        )
+        # Add a module-level skill for example path generation
+        mod_dir = coll_dir / "some-module"
+        mod_dir.mkdir()
+        (mod_dir / "SKILL.md").write_text(
+            "---\nname: test-mod\ndescription: test module\n---\n"
+        )
+
+    def test_create_agents_md(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        self._make_collection_skill(skills_dir, "netbox-netbox")
+        update_agents_md(tmp_path, skills_dir)
+        agents_md = (tmp_path / "AGENTS.md").read_text()
+        assert "<!-- ansible-know:skills:start -->" in agents_md
+        assert "<!-- ansible-know:skills:end -->" in agents_md
+        assert "netbox.netbox" in agents_md
+
+    def test_append_to_existing(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        self._make_collection_skill(skills_dir, "netbox-netbox")
+        (tmp_path / "AGENTS.md").write_text("# My Project\n\nExisting content.\n")
+        update_agents_md(tmp_path, skills_dir)
+        agents_md = (tmp_path / "AGENTS.md").read_text()
+        assert agents_md.startswith("# My Project")
+        assert "Existing content." in agents_md
+        assert "<!-- ansible-know:skills:start -->" in agents_md
+        assert "netbox.netbox" in agents_md
+
+    def test_replace_between_sentinels(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        self._make_collection_skill(skills_dir, "ansible-controller")
+        existing = (
+            "# My Project\n\n"
+            "<!-- ansible-know:skills:start -->\n"
+            "## Old content\n"
+            "<!-- ansible-know:skills:end -->\n\n"
+            "## Other section\n"
+        )
+        (tmp_path / "AGENTS.md").write_text(existing)
+        update_agents_md(tmp_path, skills_dir)
+        agents_md = (tmp_path / "AGENTS.md").read_text()
+        assert "# My Project" in agents_md
+        assert "Old content" not in agents_md
+        assert "ansible.controller" in agents_md
+        assert "## Other section" in agents_md
+
+    def test_preserves_other_sentinels(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        self._make_collection_skill(skills_dir, "netbox-netbox")
+        existing = (
+            "<!-- BEGIN ANSIBLE-DEVCONTAINER -->\n"
+            "## Devcontainer stuff\n"
+            "<!-- END ANSIBLE-DEVCONTAINER -->\n"
+        )
+        (tmp_path / "AGENTS.md").write_text(existing)
+        update_agents_md(tmp_path, skills_dir)
+        agents_md = (tmp_path / "AGENTS.md").read_text()
+        assert "BEGIN ANSIBLE-DEVCONTAINER" in agents_md
+        assert "Devcontainer stuff" in agents_md
+        assert "ansible-know:skills:start" in agents_md
+
+    def test_missing_end_sentinel_appends(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        self._make_collection_skill(skills_dir, "netbox-netbox")
+        existing = "# Project\n\n<!-- ansible-know:skills:start -->\nBroken\n"
+        (tmp_path / "AGENTS.md").write_text(existing)
+        update_agents_md(tmp_path, skills_dir)
+        agents_md = (tmp_path / "AGENTS.md").read_text()
+        assert agents_md.count("ansible-know:skills:start") == 2
+        assert "ansible-know:skills:end" in agents_md
+
+    def test_sensitive_path_rejected(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        self._make_collection_skill(skills_dir, "netbox-netbox")
+        from pathlib import Path
+
+        import pytest
+
+        from ansible_know.validation import ValidationError
+        with pytest.raises(ValidationError):
+            update_agents_md(Path("/etc"), skills_dir)
+
+    def test_empty_skills_dir(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        update_agents_md(tmp_path, skills_dir)
+        agents_md = (tmp_path / "AGENTS.md").read_text()
+        assert "Available collections:" in agents_md
+
+    def test_skips_symlinks(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        self._make_collection_skill(skills_dir, "real-collection")
+        (skills_dir / "symlink-collection").symlink_to(skills_dir / "real-collection")
+        update_agents_md(tmp_path, skills_dir)
+        agents_md = (tmp_path / "AGENTS.md").read_text()
+        assert "real.collection" in agents_md
+        # Should appear once in collections list, not duplicated by symlink
+        assert "Available collections: real.collection" in agents_md
+        assert "symlink.collection" not in agents_md

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,5 +1,9 @@
 """Tests for ansible_know.skills."""
 
+from pathlib import Path
+
+import pytest
+
 from ansible_know.parser import extract_module_metadata
 from ansible_know.skills import (
     _build_example_args,
@@ -24,6 +28,7 @@ from ansible_know.skills import (
     write_role_skill_package,
     write_skill_package,
 )
+from ansible_know.validation import ValidationError
 
 
 class TestFqcnToSkillName:
@@ -813,11 +818,6 @@ class TestUpdateAgentsMd:
     def test_sensitive_path_rejected(self, tmp_path):
         skills_dir = tmp_path / "skills"
         self._make_collection_skill(skills_dir, "netbox-netbox")
-        from pathlib import Path
-
-        import pytest
-
-        from ansible_know.validation import ValidationError
         with pytest.raises(ValidationError):
             update_agents_md(Path("/etc"), skills_dir)
 


### PR DESCRIPTION
## Summary

- Add env var priority chain for `SKILLS_DIR`: `ANSIBLE_KNOW_SKILLS_DIR` → `ANSIBLE_KNOW_PROJECT_DIR/skills` → `CLAUDE_PROJECT_DIR/skills` → `cwd/skills` (validated via `validate_install_path`)
- Add `get_project_root() -> Path` and `update_agents_md()` (sentinel-managed AGENTS.md section)
- Wire AGENTS.md updates from `generate_collection_skills` only when skills land in `{project_root}/skills`; catch `(OSError, ValidationError)` so failures never mask successful generation
- Document dual-config with next-mcp (`ansibleEnvironments.skillSources` / `{id, type, url, trust}`) and 1-level scan caveat
- Revise **ADR-0008** for Layer 1 AGENTS.md host discovery; correct Lola/GitHub “works today” claims for raw nested trees

## Design

- Spec: `docs/superpowers/specs/2026-07-17-project-scoped-skills-design.md`
- Alignment: `docs/superpowers/specs/2026-08-02-skill-discoverability-alignment.md`
- next-mcp scan depth tracking: #200 (upstream later)

Closes #181

## Test plan

- [x] Unit tests for env resolution, SKILLS_DIR validation, AGENTS.md create/append/replace
- [x] Server tests: AGENTS.md called for project skills/; skipped for divergent `install_to`; ValidationError does not mask success
- [x] Focused suite green; full suite 889 passed + 1 pre-existing `#179` failure (`test_with_tags`)
- [x] `ruff check` clean on touched Python
- [ ] Backward compatible — explicit `install_to` and `ANSIBLE_KNOW_SKILLS_DIR` still work; AGENTS.md skipped when those diverge from project `skills/`

Assisted-by: Claude / Cursor