### PR TITLE
fix: partition Galaxy caches by server base URL (#190)

### DIFF
--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -40,14 +40,16 @@ _SAFE_V3_PATH_RE = re.compile(r"^[a-zA-Z0-9/_-]+/?$")
 # Keys include server identity (normalized base URL + server name) so private
 # Hub and public Galaxy never collide for the same FQCN, and so two configs
 # that share a URL but differ by name/auth stay partitioned.
-# Filename bump (v3) retires pre-#190 and interim v2 on-disk entries.
+# Version cache persists to disk (tiny). Blob cache is memory-only (#194
+# workaround): docs-blobs are large and rewriting a full JSON file on every
+# put was too expensive; a proper deferred/coalesced disk strategy is TBD.
+# Filename bump (v3) retires pre-#190 and interim v2 version-cache entries.
 _version_cache: BoundedCache[tuple[str, str, str, str], str] = BoundedCache(
     max_size=500, ttl=CACHE_TTL_SECONDS,
     path=CACHE_DIR / "galaxy-versions-v3.json",
 )
 _blob_cache: BoundedCache[tuple[str, str, str, str, str], dict[str, Any]] = BoundedCache(
     max_size=50, ttl=CACHE_TTL_SECONDS,
-    path=CACHE_DIR / "galaxy-blobs-v3.json",
 )
 
 _LEGACY_CACHE_FILES = (
@@ -55,6 +57,7 @@ _LEGACY_CACHE_FILES = (
     CACHE_DIR / "galaxy-blobs.json",
     CACHE_DIR / "galaxy-versions-v2.json",
     CACHE_DIR / "galaxy-blobs-v2.json",
+    CACHE_DIR / "galaxy-blobs-v3.json",
 )
 
 _legacy_retired = False

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import threading
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -36,26 +37,32 @@ MAX_DISCOVERY_RESPONSE_SIZE = 100_000  # 100KB — discovery payloads are tiny
 _SAFE_V3_PATH_RE = re.compile(r"^[a-zA-Z0-9/_-]+/?$")
 
 # Module-level caches shared across all GalaxyClient instances.
-# Keys include server identity (base URL) so private Hub and public Galaxy
-# never collide for the same FQCN. Thread-safe via BoundedCache.
-# Filename bump (v2) retires pre-server-keyed on-disk entries from #190.
-_version_cache: BoundedCache[tuple[str, str, str], str] = BoundedCache(
+# Keys include server identity (normalized base URL + server name) so private
+# Hub and public Galaxy never collide for the same FQCN, and so two configs
+# that share a URL but differ by name/auth stay partitioned.
+# Filename bump (v3) retires pre-#190 and interim v2 on-disk entries.
+_version_cache: BoundedCache[tuple[str, str, str, str], str] = BoundedCache(
     max_size=500, ttl=CACHE_TTL_SECONDS,
-    path=CACHE_DIR / "galaxy-versions-v2.json",
+    path=CACHE_DIR / "galaxy-versions-v3.json",
 )
-_blob_cache: BoundedCache[tuple[str, str, str, str], dict[str, Any]] = BoundedCache(
+_blob_cache: BoundedCache[tuple[str, str, str, str, str], dict[str, Any]] = BoundedCache(
     max_size=50, ttl=CACHE_TTL_SECONDS,
-    path=CACHE_DIR / "galaxy-blobs-v2.json",
+    path=CACHE_DIR / "galaxy-blobs-v3.json",
 )
 
 _LEGACY_CACHE_FILES = (
     CACHE_DIR / "galaxy-versions.json",
     CACHE_DIR / "galaxy-blobs.json",
+    CACHE_DIR / "galaxy-versions-v2.json",
+    CACHE_DIR / "galaxy-blobs-v2.json",
 )
+
+_legacy_retired = False
+_legacy_retire_lock = threading.Lock()
 
 
 def _retire_legacy_cache_files() -> None:
-    """Remove pre-v2 Galaxy disk caches that omit server identity."""
+    """Remove Galaxy disk caches that omit full server identity."""
     for path in _LEGACY_CACHE_FILES:
         try:
             path.unlink(missing_ok=True)
@@ -63,11 +70,34 @@ def _retire_legacy_cache_files() -> None:
             logger.debug("Could not remove legacy Galaxy cache file %s", path)
 
 
-_retire_legacy_cache_files()
+def _ensure_legacy_caches_retired() -> None:
+    """Lazily delete legacy on-disk caches on first cache use."""
+    global _legacy_retired
+    if _legacy_retired:
+        return
+    with _legacy_retire_lock:
+        if _legacy_retired:
+            return
+        _retire_legacy_cache_files()
+        _legacy_retired = True
+
+
+def _normalize_cache_base_url(url: str) -> str:
+    """Normalize a Galaxy/Hub URL for cache partitioning.
+
+    Trailing slashes and a trailing ``/api`` suffix are stripped so
+    ``https://hub.example/api`` and ``https://hub.example`` share a
+    partition without changing the request base URL.
+    """
+    base = url.rstrip("/")
+    if base.endswith("/api"):
+        base = base[: -len("/api")].rstrip("/")
+    return base
 
 
 def clear_cache() -> None:
     """Clear Galaxy caches (useful for testing)."""
+    _ensure_legacy_caches_retired()
     _version_cache.clear()
     _blob_cache.clear()
 
@@ -119,10 +149,13 @@ class GalaxyClient:
         self._discovery_lock = asyncio.Lock()
         self._discovery_failed: bool = False
 
-    @property
-    def _cache_server_id(self) -> str:
-        """Stable cache partition key: normalized Galaxy/Hub base URL."""
-        return self._base
+    def _cache_identity(self) -> tuple[str, str]:
+        """Stable cache partition: normalized base URL + server name.
+
+        Server name distinguishes configs that share a URL but use
+        different credentials (typical ansible.cfg ``galaxy_server.*``).
+        """
+        return (_normalize_cache_base_url(self._base), self.server_name or "")
 
     def _build_provenance(
         self,
@@ -436,7 +469,8 @@ class GalaxyClient:
         Raises:
             GalaxyError: If the collection is not found or the API fails.
         """
-        cache_key = (self._cache_server_id, namespace, name)
+        _ensure_legacy_caches_retired()
+        cache_key = (*self._cache_identity(), namespace, name)
         cached = _version_cache.get(cache_key)
         if cached is not None:
             return cached
@@ -542,7 +576,8 @@ class GalaxyClient:
     async def _fetch_docs_blob(
         self, namespace: str, name: str, version: str,
     ) -> dict[str, Any]:
-        cache_key = (self._cache_server_id, namespace, name, version)
+        _ensure_legacy_caches_retired()
+        cache_key = (*self._cache_identity(), namespace, name, version)
         cached = _blob_cache.get(cache_key)
         if cached is not None:
             return cached

--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -36,16 +36,34 @@ MAX_DISCOVERY_RESPONSE_SIZE = 100_000  # 100KB — discovery payloads are tiny
 _SAFE_V3_PATH_RE = re.compile(r"^[a-zA-Z0-9/_-]+/?$")
 
 # Module-level caches shared across all GalaxyClient instances.
-# Keys include enough context (namespace, name, version) to avoid
-# cross-instance collisions. Thread-safe via BoundedCache.
-_version_cache: BoundedCache[tuple[str, str], str] = BoundedCache(
+# Keys include server identity (base URL) so private Hub and public Galaxy
+# never collide for the same FQCN. Thread-safe via BoundedCache.
+# Filename bump (v2) retires pre-server-keyed on-disk entries from #190.
+_version_cache: BoundedCache[tuple[str, str, str], str] = BoundedCache(
     max_size=500, ttl=CACHE_TTL_SECONDS,
-    path=CACHE_DIR / "galaxy-versions.json",
+    path=CACHE_DIR / "galaxy-versions-v2.json",
 )
-_blob_cache: BoundedCache[tuple[str, str, str], dict[str, Any]] = BoundedCache(
+_blob_cache: BoundedCache[tuple[str, str, str, str], dict[str, Any]] = BoundedCache(
     max_size=50, ttl=CACHE_TTL_SECONDS,
-    path=CACHE_DIR / "galaxy-blobs.json",
+    path=CACHE_DIR / "galaxy-blobs-v2.json",
 )
+
+_LEGACY_CACHE_FILES = (
+    CACHE_DIR / "galaxy-versions.json",
+    CACHE_DIR / "galaxy-blobs.json",
+)
+
+
+def _retire_legacy_cache_files() -> None:
+    """Remove pre-v2 Galaxy disk caches that omit server identity."""
+    for path in _LEGACY_CACHE_FILES:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            logger.debug("Could not remove legacy Galaxy cache file %s", path)
+
+
+_retire_legacy_cache_files()
 
 
 def clear_cache() -> None:
@@ -100,6 +118,11 @@ class GalaxyClient:
         self._v3_path: str | None = None
         self._discovery_lock = asyncio.Lock()
         self._discovery_failed: bool = False
+
+    @property
+    def _cache_server_id(self) -> str:
+        """Stable cache partition key: normalized Galaxy/Hub base URL."""
+        return self._base
 
     def _build_provenance(
         self,
@@ -413,7 +436,7 @@ class GalaxyClient:
         Raises:
             GalaxyError: If the collection is not found or the API fails.
         """
-        cache_key = (namespace, name)
+        cache_key = (self._cache_server_id, namespace, name)
         cached = _version_cache.get(cache_key)
         if cached is not None:
             return cached
@@ -519,7 +542,7 @@ class GalaxyClient:
     async def _fetch_docs_blob(
         self, namespace: str, name: str, version: str,
     ) -> dict[str, Any]:
-        cache_key = (namespace, name, version)
+        cache_key = (self._cache_server_id, namespace, name, version)
         cached = _blob_cache.get(cache_key)
         if cached is not None:
             return cached

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -8,6 +8,7 @@ from unittest.mock import patch as stdlib_patch
 import httpx
 import pytest
 
+from ansible_know.config import GALAXY_BASE_URL
 from ansible_know.errors import GalaxyError
 from ansible_know.galaxy import (
     CACHE_TTL_SECONDS,
@@ -22,6 +23,8 @@ from ansible_know.galaxy import (
 )
 from tests.conftest import SAMPLE_DOCS_BLOB_WITH_ROLES
 
+DEFAULT_CACHE_SERVER = GALAXY_BASE_URL.rstrip("/")
+
 
 @pytest.fixture(autouse=True)
 def reset_galaxy_cache():
@@ -29,6 +32,23 @@ def reset_galaxy_cache():
     clear_cache()
     yield
     clear_cache()
+
+
+def _vkey(
+    namespace: str, name: str, server: str = DEFAULT_CACHE_SERVER,
+) -> tuple[str, str, str]:
+    """Build a version-cache key including server identity."""
+    return (server, namespace, name)
+
+
+def _bkey(
+    namespace: str,
+    name: str,
+    version: str,
+    server: str = DEFAULT_CACHE_SERVER,
+) -> tuple[str, str, str, str]:
+    """Build a blob-cache key including server identity."""
+    return (server, namespace, name, version)
 
 
 def _skip_discovery(gc: GalaxyClient, base: str = "https://galaxy.ansible.com/api") -> GalaxyClient:
@@ -792,23 +812,23 @@ class TestCacheEviction:
     def test_version_cache_evicts_oldest(self):
         max_size = _version_cache.max_size
         for i in range(max_size + 5):
-            _version_cache.put(("ns", f"col{i}"), f"1.0.{i}")
-        assert _version_cache.get(("ns", "col0")) is None
-        assert _version_cache.get(("ns", "col1")) is None
-        assert _version_cache.get(("ns", f"col{max_size + 4}")) == f"1.0.{max_size + 4}"
+            _version_cache.put(_vkey("ns", f"col{i}"), f"1.0.{i}")
+        assert _version_cache.get(_vkey("ns", "col0")) is None
+        assert _version_cache.get(_vkey("ns", "col1")) is None
+        assert _version_cache.get(_vkey("ns", f"col{max_size + 4}")) == f"1.0.{max_size + 4}"
 
     def test_blob_cache_evicts_oldest(self):
         max_size = _blob_cache.max_size
         for i in range(max_size + 5):
-            _blob_cache.put(("ns", f"col{i}", "1.0.0"), {"idx": i})
-        assert _blob_cache.get(("ns", "col0", "1.0.0")) is None
-        assert _blob_cache.get(("ns", "col1", "1.0.0")) is None
-        assert _blob_cache.get(("ns", f"col{max_size + 4}", "1.0.0")) == {"idx": max_size + 4}
+            _blob_cache.put(_bkey("ns", f"col{i}", "1.0.0"), {"idx": i})
+        assert _blob_cache.get(_bkey("ns", "col0", "1.0.0")) is None
+        assert _blob_cache.get(_bkey("ns", "col1", "1.0.0")) is None
+        assert _blob_cache.get(_bkey("ns", f"col{max_size + 4}", "1.0.0")) == {"idx": max_size + 4}
 
     def test_version_cache_stays_at_max_size(self):
         max_size = _version_cache.max_size
         for i in range(max_size + 10):
-            _version_cache.put(("ns", f"c{i}"), f"v{i}")
+            _version_cache.put(_vkey("ns", f"c{i}"), f"v{i}")
         assert len(_version_cache) <= max_size
 
 
@@ -861,7 +881,7 @@ class TestNetworkErrors:
 class TestCacheHitPaths:
     @pytest.mark.asyncio
     async def test_version_cache_hit_skips_api(self):
-        _version_cache.put(("netbox", "netbox"), "3.23.0")
+        _version_cache.put(_vkey("netbox", "netbox"), "3.23.0")
         mock_client = _mock_client_get({})
         with patch("ansible_know.galaxy.httpx.AsyncClient", return_value=mock_client):
             client = GalaxyClient()
@@ -871,8 +891,10 @@ class TestCacheHitPaths:
 
     @pytest.mark.asyncio
     async def test_blob_cache_hit_skips_api(self):
-        _version_cache.put(("netbox", "netbox"), "3.23.0")
-        _blob_cache.put(("netbox", "netbox", "3.23.0"), SAMPLE_DOCS_BLOB["docs_blob"])
+        _version_cache.put(_vkey("netbox", "netbox"), "3.23.0")
+        _blob_cache.put(
+            _bkey("netbox", "netbox", "3.23.0"), SAMPLE_DOCS_BLOB["docs_blob"],
+        )
 
         with patch.object(GalaxyClient, "_api_get", side_effect=AssertionError("should not call API")):
             client = GalaxyClient()
@@ -880,6 +902,101 @@ class TestCacheHitPaths:
 
         assert "netbox.netbox.netbox_device" in doc
         assert meta["doc_source"] == "galaxy"
+
+
+class TestMultiServerCacheIsolation:
+    """Regression for #190: same FQCN must not collide across Galaxy servers."""
+
+    @pytest.mark.asyncio
+    async def test_version_cache_partitioned_by_server(self):
+        public = _skip_discovery(
+            GalaxyClient(base_url="https://galaxy.ansible.com", server_name="galaxy"),
+        )
+        private = _skip_discovery(
+            GalaxyClient(
+                base_url="https://hub.example.internal", server_name="private_hub",
+            ),
+            base="https://hub.example.internal/api",
+        )
+
+        public_versions = {
+            "data": [{"version": "1.0.0"}],
+        }
+        private_versions = {
+            "data": [{"version": "9.9.9"}],
+        }
+
+        with patch.object(
+            GalaxyClient, "_safe_api_get", new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = public_versions
+            assert await public.latest_version("acme", "widgets") == "1.0.0"
+            assert mock_get.await_count == 1
+
+            # Public cache must not satisfy a different server for the same FQCN.
+            mock_get.return_value = private_versions
+            assert await private.latest_version("acme", "widgets") == "9.9.9"
+            assert mock_get.await_count == 2
+
+            mock_get.reset_mock()
+            assert await private.latest_version("acme", "widgets") == "9.9.9"
+            mock_get.assert_not_called()
+
+        assert _version_cache.get(
+            _vkey("acme", "widgets", "https://galaxy.ansible.com"),
+        ) == "1.0.0"
+        assert _version_cache.get(
+            _vkey("acme", "widgets", "https://hub.example.internal"),
+        ) == "9.9.9"
+
+    @pytest.mark.asyncio
+    async def test_blob_cache_partitioned_by_server(self):
+        public_blob = {
+            "contents": [{
+                "content_type": "module",
+                "content_name": "m",
+                "doc_strings": {"doc": {"short_description": "public"}},
+            }],
+        }
+        private_blob = {
+            "contents": [{
+                "content_type": "module",
+                "content_name": "m",
+                "doc_strings": {"doc": {"short_description": "private"}},
+            }],
+        }
+
+        public = _skip_discovery(
+            GalaxyClient(base_url="https://galaxy.ansible.com", server_name="galaxy"),
+        )
+        private = _skip_discovery(
+            GalaxyClient(
+                base_url="https://hub.example.internal", server_name="private_hub",
+            ),
+            base="https://hub.example.internal/api",
+        )
+
+        with patch.object(
+            GalaxyClient, "_safe_api_get", new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = {"docs_blob": public_blob}
+            assert await public._fetch_docs_blob("acme", "widgets", "1.0.0") == public_blob
+            assert mock_get.await_count == 1
+
+            mock_get.return_value = {"docs_blob": private_blob}
+            assert await private._fetch_docs_blob("acme", "widgets", "1.0.0") == private_blob
+            assert mock_get.await_count == 2
+
+            mock_get.reset_mock()
+            assert await private._fetch_docs_blob("acme", "widgets", "1.0.0") == private_blob
+            mock_get.assert_not_called()
+
+        assert _blob_cache.get(
+            _bkey("acme", "widgets", "1.0.0", "https://galaxy.ansible.com"),
+        ) == public_blob
+        assert _blob_cache.get(
+            _bkey("acme", "widgets", "1.0.0", "https://hub.example.internal"),
+        ) == private_blob
 
 
 class TestSearchCollectionsEdgeCases:
@@ -1016,30 +1133,30 @@ class TestUnicodeQueries:
 
 class TestCacheTTL:
     def test_version_cache_returns_none_after_ttl(self):
-        _version_cache.put(("ns", "col"), "1.0.0")
-        assert _version_cache.get(("ns", "col")) == "1.0.0"
+        _version_cache.put(_vkey("ns", "col"), "1.0.0")
+        assert _version_cache.get(_vkey("ns", "col")) == "1.0.0"
         with stdlib_patch("ansible_know.cache.time") as mock_time:
             mock_time.monotonic.return_value = time.monotonic() + CACHE_TTL_SECONDS + 1
-            assert _version_cache.get(("ns", "col")) is None
+            assert _version_cache.get(_vkey("ns", "col")) is None
 
     def test_blob_cache_returns_none_after_ttl(self):
-        _blob_cache.put(("ns", "col", "1.0.0"), {"data": "test"})
-        assert _blob_cache.get(("ns", "col", "1.0.0")) == {"data": "test"}
+        _blob_cache.put(_bkey("ns", "col", "1.0.0"), {"data": "test"})
+        assert _blob_cache.get(_bkey("ns", "col", "1.0.0")) == {"data": "test"}
         with stdlib_patch("ansible_know.cache.time") as mock_time:
             mock_time.monotonic.return_value = time.monotonic() + CACHE_TTL_SECONDS + 1
-            assert _blob_cache.get(("ns", "col", "1.0.0")) is None
+            assert _blob_cache.get(_bkey("ns", "col", "1.0.0")) is None
 
     def test_version_cache_returns_value_before_ttl(self):
-        _version_cache.put(("ns", "col"), "2.0.0")
+        _version_cache.put(_vkey("ns", "col"), "2.0.0")
         with stdlib_patch("ansible_know.cache.time") as mock_time:
             mock_time.monotonic.return_value = time.monotonic() + CACHE_TTL_SECONDS - 10
-            assert _version_cache.get(("ns", "col")) == "2.0.0"
+            assert _version_cache.get(_vkey("ns", "col")) == "2.0.0"
 
     def test_blob_cache_returns_value_before_ttl(self):
-        _blob_cache.put(("ns", "col", "1.0.0"), {"data": "fresh"})
+        _blob_cache.put(_bkey("ns", "col", "1.0.0"), {"data": "fresh"})
         with stdlib_patch("ansible_know.cache.time") as mock_time:
             mock_time.monotonic.return_value = time.monotonic() + CACHE_TTL_SECONDS - 10
-            assert _blob_cache.get(("ns", "col", "1.0.0")) == {"data": "fresh"}
+            assert _blob_cache.get(_bkey("ns", "col", "1.0.0")) == {"data": "fresh"}
 
 
 class TestConcurrentCacheAccess:
@@ -1051,8 +1168,8 @@ class TestConcurrentCacheAccess:
         def write_batch(start):
             try:
                 for i in range(100):
-                    _version_cache.put(("ns", f"col_{start}_{i}"), f"v{i}")
-                    _version_cache.get(("ns", f"col_{start}_{i}"))
+                    _version_cache.put(_vkey("ns", f"col_{start}_{i}"), f"v{i}")
+                    _version_cache.get(_vkey("ns", f"col_{start}_{i}"))
             except Exception as e:
                 errors.append(e)
 
@@ -1072,8 +1189,8 @@ class TestConcurrentCacheAccess:
         def write_batch(start):
             try:
                 for i in range(50):
-                    _blob_cache.put(("ns", f"col_{start}_{i}", "1.0"), {"v": i})
-                    _blob_cache.get(("ns", f"col_{start}_{i}", "1.0"))
+                    _blob_cache.put(_bkey("ns", f"col_{start}_{i}", "1.0"), {"v": i})
+                    _blob_cache.get(_bkey("ns", f"col_{start}_{i}", "1.0"))
             except Exception as e:
                 errors.append(e)
 
@@ -1118,7 +1235,7 @@ class TestTimeoutPassthrough:
 
     @pytest.mark.asyncio
     async def test_fetch_docs_blob_uses_slow_timeout(self):
-        _version_cache.put(("netbox", "netbox"), "3.23.0")
+        _version_cache.put(_vkey("netbox", "netbox"), "3.23.0")
         mock_client = _mock_client_get(SAMPLE_DOCS_BLOB)
         with patch("ansible_know.galaxy.httpx.AsyncClient", return_value=mock_client):
             client = _skip_discovery(GalaxyClient())

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -1104,12 +1104,17 @@ class TestMultiServerCacheIsolation:
 
 
 class TestLegacyCacheRetirement:
+    def test_blob_cache_is_memory_only(self):
+        """#194 workaround: large docs-blobs must not persist to disk."""
+        assert _blob_cache._path is None
+
     def test_retire_legacy_cache_files_deletes_old_filenames(self, tmp_path, monkeypatch):
         legacy = [
             tmp_path / "galaxy-versions.json",
             tmp_path / "galaxy-blobs.json",
             tmp_path / "galaxy-versions-v2.json",
             tmp_path / "galaxy-blobs-v2.json",
+            tmp_path / "galaxy-blobs-v3.json",
         ]
         for path in legacy:
             path.write_text("{}", encoding="utf-8")

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -8,6 +8,7 @@ from unittest.mock import patch as stdlib_patch
 import httpx
 import pytest
 
+from ansible_know import galaxy as galaxy_mod
 from ansible_know.config import GALAXY_BASE_URL
 from ansible_know.errors import GalaxyError
 from ansible_know.galaxy import (
@@ -18,12 +19,16 @@ from ansible_know.galaxy import (
     TIMEOUT_SLOW,
     GalaxyClient,
     _blob_cache,
+    _ensure_legacy_caches_retired,
+    _normalize_cache_base_url,
+    _retire_legacy_cache_files,
     _version_cache,
     clear_cache,
 )
 from tests.conftest import SAMPLE_DOCS_BLOB_WITH_ROLES
 
-DEFAULT_CACHE_SERVER = GALAXY_BASE_URL.rstrip("/")
+DEFAULT_CACHE_SERVER = _normalize_cache_base_url(GALAXY_BASE_URL)
+DEFAULT_CACHE_NAME = ""
 
 
 @pytest.fixture(autouse=True)
@@ -35,10 +40,13 @@ def reset_galaxy_cache():
 
 
 def _vkey(
-    namespace: str, name: str, server: str = DEFAULT_CACHE_SERVER,
-) -> tuple[str, str, str]:
+    namespace: str,
+    name: str,
+    server: str = DEFAULT_CACHE_SERVER,
+    server_name: str = DEFAULT_CACHE_NAME,
+) -> tuple[str, str, str, str]:
     """Build a version-cache key including server identity."""
-    return (server, namespace, name)
+    return (_normalize_cache_base_url(server), server_name, namespace, name)
 
 
 def _bkey(
@@ -46,9 +54,22 @@ def _bkey(
     name: str,
     version: str,
     server: str = DEFAULT_CACHE_SERVER,
-) -> tuple[str, str, str, str]:
+    server_name: str = DEFAULT_CACHE_NAME,
+) -> tuple[str, str, str, str, str]:
     """Build a blob-cache key including server identity."""
-    return (server, namespace, name, version)
+    return (
+        _normalize_cache_base_url(server), server_name, namespace, name, version,
+    )
+
+
+def _identity_vkey(client: GalaxyClient, namespace: str, name: str) -> tuple[str, str, str, str]:
+    return (*client._cache_identity(), namespace, name)
+
+
+def _identity_bkey(
+    client: GalaxyClient, namespace: str, name: str, version: str,
+) -> tuple[str, str, str, str, str]:
+    return (*client._cache_identity(), namespace, name, version)
 
 
 def _skip_discovery(gc: GalaxyClient, base: str = "https://galaxy.ansible.com/api") -> GalaxyClient:
@@ -919,12 +940,8 @@ class TestMultiServerCacheIsolation:
             base="https://hub.example.internal/api",
         )
 
-        public_versions = {
-            "data": [{"version": "1.0.0"}],
-        }
-        private_versions = {
-            "data": [{"version": "9.9.9"}],
-        }
+        public_versions = {"data": [{"version": "1.0.0"}]}
+        private_versions = {"data": [{"version": "9.9.9"}]}
 
         with patch.object(
             GalaxyClient, "_safe_api_get", new_callable=AsyncMock,
@@ -933,7 +950,6 @@ class TestMultiServerCacheIsolation:
             assert await public.latest_version("acme", "widgets") == "1.0.0"
             assert mock_get.await_count == 1
 
-            # Public cache must not satisfy a different server for the same FQCN.
             mock_get.return_value = private_versions
             assert await private.latest_version("acme", "widgets") == "9.9.9"
             assert mock_get.await_count == 2
@@ -942,12 +958,13 @@ class TestMultiServerCacheIsolation:
             assert await private.latest_version("acme", "widgets") == "9.9.9"
             mock_get.assert_not_called()
 
-        assert _version_cache.get(
-            _vkey("acme", "widgets", "https://galaxy.ansible.com"),
-        ) == "1.0.0"
-        assert _version_cache.get(
-            _vkey("acme", "widgets", "https://hub.example.internal"),
-        ) == "9.9.9"
+            # Symmetric: public re-fetch must also hit its own partition.
+            mock_get.reset_mock()
+            assert await public.latest_version("acme", "widgets") == "1.0.0"
+            mock_get.assert_not_called()
+
+        assert _version_cache.get(_identity_vkey(public, "acme", "widgets")) == "1.0.0"
+        assert _version_cache.get(_identity_vkey(private, "acme", "widgets")) == "9.9.9"
 
     @pytest.mark.asyncio
     async def test_blob_cache_partitioned_by_server(self):
@@ -991,12 +1008,136 @@ class TestMultiServerCacheIsolation:
             assert await private._fetch_docs_blob("acme", "widgets", "1.0.0") == private_blob
             mock_get.assert_not_called()
 
+            mock_get.reset_mock()
+            assert await public._fetch_docs_blob("acme", "widgets", "1.0.0") == public_blob
+            mock_get.assert_not_called()
+
         assert _blob_cache.get(
-            _bkey("acme", "widgets", "1.0.0", "https://galaxy.ansible.com"),
+            _identity_bkey(public, "acme", "widgets", "1.0.0"),
         ) == public_blob
         assert _blob_cache.get(
-            _bkey("acme", "widgets", "1.0.0", "https://hub.example.internal"),
+            _identity_bkey(private, "acme", "widgets", "1.0.0"),
         ) == private_blob
+
+    @pytest.mark.asyncio
+    async def test_trailing_slash_and_api_suffix_share_partition(self):
+        with_slash = _skip_discovery(
+            GalaxyClient(
+                base_url="https://hub.example.internal/", server_name="hub",
+            ),
+            base="https://hub.example.internal/api",
+        )
+        with_api = _skip_discovery(
+            GalaxyClient(
+                base_url="https://hub.example.internal/api", server_name="hub",
+            ),
+            base="https://hub.example.internal/api",
+        )
+        assert with_slash._cache_identity() == with_api._cache_identity()
+
+        with patch.object(
+            GalaxyClient, "_safe_api_get", new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = {"data": [{"version": "2.0.0"}]}
+            assert await with_slash.latest_version("acme", "widgets") == "2.0.0"
+            assert mock_get.await_count == 1
+
+            mock_get.reset_mock()
+            assert await with_api.latest_version("acme", "widgets") == "2.0.0"
+            mock_get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_same_server_name_different_urls_stay_isolated(self):
+        """Guards against regressing to server_name-only cache keys."""
+        hub_a = _skip_discovery(
+            GalaxyClient(base_url="https://hub-a.example", server_name="hub"),
+            base="https://hub-a.example/api",
+        )
+        hub_b = _skip_discovery(
+            GalaxyClient(base_url="https://hub-b.example", server_name="hub"),
+            base="https://hub-b.example/api",
+        )
+
+        with patch.object(
+            GalaxyClient, "_safe_api_get", new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = {"data": [{"version": "1.0.0"}]}
+            assert await hub_a.latest_version("acme", "widgets") == "1.0.0"
+
+            mock_get.return_value = {"data": [{"version": "2.0.0"}]}
+            assert await hub_b.latest_version("acme", "widgets") == "2.0.0"
+            assert mock_get.await_count == 2
+
+        assert _version_cache.get(_identity_vkey(hub_a, "acme", "widgets")) == "1.0.0"
+        assert _version_cache.get(_identity_vkey(hub_b, "acme", "widgets")) == "2.0.0"
+
+    @pytest.mark.asyncio
+    async def test_same_url_different_server_names_stay_isolated(self):
+        """Same endpoint with different ansible.cfg names/auth must not share."""
+        token_a = _skip_discovery(
+            GalaxyClient(
+                base_url="https://hub.example.internal",
+                server_name="hub_readonly",
+                token="token-a",
+            ),
+            base="https://hub.example.internal/api",
+        )
+        token_b = _skip_discovery(
+            GalaxyClient(
+                base_url="https://hub.example.internal",
+                server_name="hub_admin",
+                token="token-b",
+            ),
+            base="https://hub.example.internal/api",
+        )
+        assert token_a._cache_identity() != token_b._cache_identity()
+
+        with patch.object(
+            GalaxyClient, "_safe_api_get", new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = {"data": [{"version": "1.0.0"}]}
+            assert await token_a.latest_version("acme", "widgets") == "1.0.0"
+
+            mock_get.return_value = {"data": [{"version": "9.0.0"}]}
+            assert await token_b.latest_version("acme", "widgets") == "9.0.0"
+            assert mock_get.await_count == 2
+
+
+class TestLegacyCacheRetirement:
+    def test_retire_legacy_cache_files_deletes_old_filenames(self, tmp_path, monkeypatch):
+        legacy = [
+            tmp_path / "galaxy-versions.json",
+            tmp_path / "galaxy-blobs.json",
+            tmp_path / "galaxy-versions-v2.json",
+            tmp_path / "galaxy-blobs-v2.json",
+        ]
+        for path in legacy:
+            path.write_text("{}", encoding="utf-8")
+
+        monkeypatch.setattr(galaxy_mod, "_LEGACY_CACHE_FILES", tuple(legacy))
+        _retire_legacy_cache_files()
+        assert all(not path.exists() for path in legacy)
+
+    def test_ensure_legacy_retired_is_lazy_and_once(self, tmp_path, monkeypatch):
+        legacy = tmp_path / "galaxy-versions.json"
+        legacy.write_text("{}", encoding="utf-8")
+        monkeypatch.setattr(galaxy_mod, "_LEGACY_CACHE_FILES", (legacy,))
+        monkeypatch.setattr(galaxy_mod, "_legacy_retired", False)
+
+        assert legacy.exists()
+        _ensure_legacy_caches_retired()
+        assert not legacy.exists()
+        assert galaxy_mod._legacy_retired is True
+
+        # Second call must be a no-op even if a file reappears.
+        legacy.write_text("{}", encoding="utf-8")
+        _ensure_legacy_caches_retired()
+        assert legacy.exists()
+
+    def test_normalize_cache_base_url(self):
+        assert _normalize_cache_base_url("https://hub.example/") == "https://hub.example"
+        assert _normalize_cache_base_url("https://hub.example/api") == "https://hub.example"
+        assert _normalize_cache_base_url("https://hub.example/api/") == "https://hub.example"
 
 
 class TestSearchCollectionsEdgeCases:


### PR DESCRIPTION
## Summary
- Include Galaxy/Hub base URL in version and docs-blob cache keys so the same FQCN cannot collide across servers
- Bump on-disk cache filenames to `*-v2.json` and remove legacy files that omitted server identity
- Add multi-server regression tests covering version and blob cache isolation

Fixes #190

## Test plan
- [x] `pytest tests/test_galaxy.py::TestMultiServerCacheIsolation` (and related cache suites) pass
- [ ] CI unit tests pass
- [ ] Manual: with private Hub + public Galaxy configured for the same FQCN, confirm versions/docs do not cross-serve


Made with [Cursor](https://cursor.com)