### PR TITLE
docs: refresh architecture docs after v0.7 (#196)

### DIFF
--- a/docs/architecture/adr/0003-module-level-state.md
+++ b/docs/architecture/adr/0003-module-level-state.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted (with known technical debt)
+Accepted (with known technical debt; largely mitigated by PR #87 SharedState / SessionManager)
 
 ## Date
 
@@ -77,32 +77,30 @@ Thread safety measures applied:
   `clear_cache()` calls between tests. Existing tests already do this,
   but it is fragile. (`BoundedCache.clear()` makes this cleaner than
   manual dict/lock manipulation.)
-- **Thread safety gap**: `server.py` `_missing_collections` relies on
-  CPython GIL atomicity, which is an implementation detail, not a
-  language guarantee. (The `docs.py` thread-safety gap was fixed in
-  PR #60 via `BoundedCache`.)
-- **No reset mechanism**: there is no way to reset the server's state
-  without restarting the process. This makes it impossible to run multiple
-  isolated test scenarios in the same process.
-- **State scattering**: mutable state is spread across 4 modules, making
-  it hard to reason about the full state of the server at any point in time.
-  (`BoundedCache` provides a consistent abstraction but state is still
-  scattered across modules.)
-- **Singleton coupling**: functions implicitly depend on module-level state,
-  making their signatures incomplete — the function's behavior depends on
-  hidden global state, not just its arguments.
+- ~~**Thread safety gap**: `server.py` `_missing_collections` relies on
+  CPython GIL atomicity.~~ **Mitigated in PR #87** — `missing_collections`
+  is per-session on `ServerState` (async-only within a session).
+- **No reset mechanism**: there is no way to fully reset process-wide
+  state without restarting. Per-session state is scoped by `SessionManager`
+  TTL eviction.
+- **State scattering**: mutable state remains across modules
+  (`BoundedCache` instances, Galaxy clients), though session/process
+  boundaries are clearer after PR #87.
+- **Singleton coupling**: some Domain/External helpers still read
+  module-level caches; Orchestration obtains session state via
+  `Context` / lifespan.
 
 ### Known Technical Debt
 
 1. ~~`docs.py` `_manifest_cache` needs an `asyncio.Lock`.~~ **Fixed in PR #60**
    — now uses `BoundedCache` with internal `threading.Lock`.
-2. `server.py` `_missing_collections` should use explicit synchronization.
-3. All module-level state should eventually be encapsulated in a
-   `ServerState` or `SessionContext` class that is:
-   - Created at lifespan start
-   - Passed through the lifespan context
-   - Accessible to tool handlers via `Context`
-   - Resettable for testing
+2. ~~`server.py` `_missing_collections` should use explicit synchronization.~~
+   **Mitigated in PR #87** — per-session `ServerState.missing_collections`.
+3. ~~Encapsulate module-level state in `ServerState` / session context.~~
+   **Largely done in PR #87** — `SharedState` (process-wide) +
+   `SessionManager` / `ServerState` (per-session) + `CollectionManager`.
+   Residual: some caches remain module-scoped by design (`galaxy.py`,
+   `docs.py` `BoundedCache`).
 
 ### Partial Mitigation: BoundedCache (PR #60)
 
@@ -147,3 +145,4 @@ to use module-level state remains unchanged.
 | 2026-06-19 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial decision |
 | 2026-06-19 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Updated with BoundedCache mitigation (PR #60) |
 | 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Added Implementation Notes, Related Decisions, Revision History |
+| 2026-08-03 | Leonardo Gallego (Assisted-by: Cursor) | Acknowledge PR #87 SharedState / SessionManager mitigation in Status and debt list |

--- a/docs/architecture/adr/0007-agentskills-spec-compliance.md
+++ b/docs/architecture/adr/0007-agentskills-spec-compliance.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -15,16 +15,17 @@ the emerging standard for AI agent skills, supported by 40+ coding agents
 including Claude Code, Cursor, GitHub Copilot, VS Code, Gemini CLI, OpenAI
 Codex, Junie (JetBrains), and others.
 
-Our generated SKILL.md packages do not comply with the spec:
+Before #148, generated SKILL.md packages did not comply with the spec:
 
-- `name` field uses Ansible FQCNs with dots and underscores
+- `name` field used Ansible FQCNs with dots and underscores
   (`netbox.netbox.netbox_device`) — the spec requires lowercase + hyphens only
-- Directory names don't match the `name` field
+- Directory names didn't match the `name` field
 - Missing metadata fields (`compatibility`, `metadata.fqcn`, etc.)
 
-Non-compliance blocks interoperability with the agent ecosystem and with
+That blocked interoperability with the agent ecosystem and with
 distribution tools like [Lola](https://github.com/LobsterTrap/lola) and
 the [vscode-ansible skill registry](https://github.com/ansible/vscode-ansible).
+#148 implemented the decisions below; this ADR is Accepted.
 
 The [client implementation guide](https://agentskills.io/client-implementation/adding-skills-support)
 recommends 4-6 levels of scan depth. Our nested output (collection/skill/SKILL.md
@@ -129,8 +130,9 @@ No special output mode needed.
   and load our skills.
 - **Lola distribution**: spec-compliant skills can be packaged into Lola
   modules for cross-agent installation.
-- **next-mcp registry**: skills work with GitHub sources (Lola format,
-  2-level scan) today, and with local sources once scan depth is expanded.
+- **next-mcp registry**: local dual-config works for collection-level skills;
+  nested module skills need scan-depth expansion (#200). GitHub Lola loading
+  requires Lola packaging (#149), not raw nested trees.
 - **Validation**: generated skills can be validated with `skills-ref validate`.
 - **One format**: no configuration, no layout modes, no confusion.
 
@@ -140,24 +142,23 @@ No special output mode needed.
   underscore directories. Regeneration required.
 - **Plugin type prefix verbosity**: `lookup-nb-lookup` is longer than
   `nb_lookup`. Trade-off for collision avoidance.
-- **Consumer limitations**: 1-level scanners miss module-level skills until
-  they expand their scan depth. Mitigated by the proposed next-mcp patch
-  and by the GitHub source path (which already scans 2 levels).
+- **Consumer limitations**: 1-level scanners (next-mcp local/Vercel) miss
+  module-level skills until scan depth expands (#200). Lola/GitHub Lola
+  paths need packaging (#149).
 
 ## Implementation Notes
 
 Issue [#148](https://github.com/leogallego/ansible-know-mcp/issues/148)
-tracks the implementation. Changes required:
+**closed** — implemented:
 
 - **Templates**: `SKILL.md.j2`, `PLUGIN_SKILL.md.j2`, `ROLE_SKILL.md.j2`,
-  `COLLECTION_SKILL.md.j2` — add `compatibility`, `metadata` block
+  `COLLECTION_SKILL.md.j2` — `compatibility`, `metadata` block
 - **Code**: `skills.py` — FQCN-to-kebab-case name generation, plugin type
   prefix logic, directory naming, metadata context building
 - **Validation**: frontmatter validation against spec constraints (name
   format, length, required fields)
-- **Tests**: update all skill generation tests for new naming/metadata
-- **Validator**: `pip install skills-ref`, CLI `agentskills validate` —
-  confirmed passing with proposed format
+- **Tests**: skill generation tests updated for naming/metadata
+- **Validator**: `skills-ref` / `agentskills validate` confirmed with the format
 
 ## Related Decisions
 
@@ -173,3 +174,4 @@ tracks the implementation. Changes required:
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial proposal |
+| 2026-08-03 | Leonardo Gallego (Assisted-by: Cursor) | Accepted after #148; consumer gaps point to #200 / #149 |

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -14,7 +14,7 @@ decision with its context, rationale, and consequences.
 | [0004](0004-galaxy-fallback-chain.md) | Galaxy Fallback Chain with Multi-Server Support | Accepted |
 | [0005](0005-jinja2-skill-generation.md) | Jinja2-Based Skill Package Generation | Accepted |
 | [0006](0006-upstream-first-integration.md) | Upstream-First Integration with @ansible/mcp-server (next) | Proposed |
-| [0007](0007-agentskills-spec-compliance.md) | agentskills.io Specification Compliance | Proposed |
+| [0007](0007-agentskills-spec-compliance.md) | agentskills.io Specification Compliance | Accepted |
 | [0008](0008-three-layer-distribution.md) | Three-Layer Skill Distribution Model | Proposed |
 
 ## Format

--- a/docs/architecture/project-strategy.md
+++ b/docs/architecture/project-strategy.md
@@ -1,6 +1,6 @@
 # ansible-know-mcp: Project Strategy and Evolution
 
-**Last updated:** 2026-06-26
+**Last updated:** 2026-08-03
 **Status:** Active
 
 ---
@@ -9,7 +9,7 @@
 
 **ansible-know-mcp** is a community MCP server for Ansible knowledge retrieval and AI skill generation.
 
-| Dimension | Current (v0.6.0) |
+| Dimension | Current (v0.7.0) |
 |---|---|
 | Language | Python (FastMCP) |
 | License | GPL-3.0-or-later |
@@ -17,8 +17,8 @@
 | Tools | 18 |
 | Resources | 6 |
 | Prompts | 5 |
-| Tests | 776 (unit + integration) |
-| Modules | 21 Python source modules |
+| Tests | 974 collected (unit + integration; integration skipped by default) |
+| Modules | 23 Python source modules |
 
 ### Core capabilities
 
@@ -89,8 +89,8 @@ All significant decisions are recorded in [docs/architecture/adr/](adr/). Decisi
 | ADR | Title | Status | Summary |
 |---|---|---|---|
 | [0006](adr/0006-upstream-first-integration.md) | Upstream-First Integration with @ansible/mcp-server (next) | Proposed | Contribute knowledge features upstream, keep skill generation |
-| [0007](adr/0007-agentskills-spec-compliance.md) | agentskills.io Specification Compliance | Proposed | One output format, spec-compliant; naming and metadata conventions |
-| [0008](adr/0008-three-layer-distribution.md) | Three-Layer Skill Distribution Model | Proposed | Local → Repository → Remote, additive layers |
+| [0007](adr/0007-agentskills-spec-compliance.md) | agentskills.io Specification Compliance | Accepted | One output format, spec-compliant; naming and metadata conventions (#148) |
+| [0008](adr/0008-three-layer-distribution.md) | Three-Layer Skill Distribution Model | Proposed | Local → Repository → Remote; Layer 1 AGENTS.md + dual-config (#181/#184) |
 
 Prior decisions:
 
@@ -114,8 +114,8 @@ The Ansible DevTools MCP server, bundled in the VS Code extension. Our primary i
 - **Repo:** `github.com/ansible/vscode-ansible`
 - **Version:** 0.0.1 (pre-release)
 - **Relationship:** We upstream knowledge features; they distribute skills via the SkillRegistry
-- **Integration point:** Shared skill directory (local) or GitHub source (Lola format, 2-level scan)
-- **Gap:** `_loadLocalSource` scans 1 level; spec recommends 4-6. Patch proposed.
+- **Integration point:** Shared project `skills/` directory (Layer 1 dual-config + `AGENTS.md`; see ADR-0008 / #181) or GitHub source after Lola packaging (#149)
+- **Gap:** `_loadLocalSource` scans 1 level; tracked in [#200](https://github.com/leogallego/ansible-know-mcp/issues/200) (upstream later)
 - **Pitch document:** [upstream-integration-proposal-2026-06-26.md](../research/upstream-integration-proposal-2026-06-26.md)
 
 ### aap-mcp-server
@@ -141,17 +141,18 @@ The standard specification for AI agent skills.
 
 - **Spec:** `agentskills.io/specification`
 - **Validator:** `github.com/agentskills/agentskills/tree/main/skills-ref`
-- **Our compliance:** Issue #148. Fixing name format, metadata fields, directory naming.
+- **Our compliance:** #148 closed; ADR-0007 Accepted. Nested kebab layout + metadata shipped.
 - **See:** [ADR-0007](adr/0007-agentskills-spec-compliance.md)
 
 ---
 
 ## Open Items
 
-1. **Finalize issue #148** — update body with all decisions from ADR-0007
-2. **Draft next-mcp scan depth proposal** — venue (issue/comment/PR) and wording
-3. **Update upstream integration proposal** — add agentskills.io findings and three-layer model
-4. **Validate with `skills-ref`** — generate sample skills with new format, run the validator
+1. ~~**Finalize issue #148**~~ — **Done** (closed; ADR-0007 Accepted)
+2. ~~**Draft next-mcp scan depth proposal**~~ — **Tracked** as [#200](https://github.com/leogallego/ansible-know-mcp/issues/200)
+3. **#182** — multi-path `list_skills` / `get_skill`
+4. **#149** — Lola packaging helper (Layer 2)
+5. **#189 / #125** — FastMCP 4 / MCP 2026-07-28 session migration (blocked on stable release)
 
 ---
 

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -57,9 +57,9 @@ decorated tool, resource, and prompt handler functions. FastMCP manages:
 
 | Element | File | Registration |
 |---------|------|--------------|
-| 12 tool handlers | `server.py` | `@mcp.tool(annotations=ToolAnnotations(...))` |
+| 18 tool handlers | `server.py` | `@mcp.tool(annotations=ToolAnnotations(...))` |
 | 6 resource handlers | `server.py` | `@mcp.resource(uri, ...)` |
-| 4 prompt handlers | `server.py` | `@mcp.prompt` |
+| 5 prompt handlers | `server.py` | `@mcp.prompt` |
 | Lifespan hook | `server.py` | `@lifespan` decorator on `app_lifespan()` |
 
 ### Types Crossing This Boundary
@@ -88,7 +88,7 @@ decorated tool, resource, and prompt handler functions. FastMCP manages:
 |----|----------|-------------|----------|
 | ~~V-T1~~ | ~~Warning~~ | ~~Lifespan context is an untyped `dict[str, Any]` accessed by string keys.~~ **Fixed in PR #87** — `LifespanContext` TypedDict with typed keys (`http_client`, `shared`, `sessions`). | ~~`server.py:103-108`~~ → `state.py` |
 | ~~V-T2~~ | ~~Warning~~ | ~~`_run_in_executor()` uses deprecated `asyncio.get_event_loop()`. Should use `asyncio.get_running_loop()` — the function is only called from async context.~~ **Fixed** — `async_utils.py` uses `asyncio.get_running_loop()`. `_run_in_executor` was moved from `server.py` to `async_utils.py` in PR #89. | ~~`server.py:126-129`~~ → `async_utils.py` |
-| ~~V-T3~~ | ~~Info~~ | ~~Tool return types are `dict[str, Any]` rather than typed dicts.~~ **Fixed in PR #105** — all 12 tool handlers now use specific TypedDicts (`GetModuleDocResult`, `GetRoleDocResult`, `CollectionSearchResult`, etc.) with `| ErrorResponse` unions. Safe because `from __future__ import annotations` makes annotations strings at runtime — FastMCP never sees the TypedDict classes. Note: PR #60 originally reverted TypedDict annotations to `dict[str, Any]` over FastMCP wrapping concerns, but that concern is moot with stringified annotations. | ~~All tool handlers~~ → `types.py`, `server.py` |
+| ~~V-T3~~ | ~~Info~~ | ~~Tool return types are `dict[str, Any]` rather than typed dicts.~~ **Fixed in PR #105** — all tool handlers (18 as of v0.7) use specific TypedDicts (`GetModuleDocResult`, `GetRoleDocResult`, `CollectionSearchResult`, etc.) with `| ErrorResponse` unions. Safe because `from __future__ import annotations` makes annotations strings at runtime — FastMCP never sees the TypedDict classes. Note: PR #60 originally reverted TypedDict annotations to `dict[str, Any]` over FastMCP wrapping concerns, but that concern is moot with stringified annotations. | ~~All tool handlers~~ → `types.py`, `server.py` |
 
 ---
 
@@ -144,7 +144,7 @@ business logic. Domain modules are imported lazily to avoid loading
 | ~~V-D3~~ | ~~Warning~~ | ~~`skills.py` does not define `__all__`.~~ **Fixed** — `skills.py` now defines `__all__`. | ~~`skills.py`~~ |
 | ~~V-D4~~ | ~~Warning~~ | ~~`collection_manifest.py` does not define `__all__`.~~ **Fixed** — `collection_manifest.py` now defines `__all__`. | ~~`collection_manifest.py`~~ |
 | ~~V-D5~~ | ~~Warning~~ | ~~`docs.py` does not define `__all__`.~~ **Fixed** — `docs.py` now defines `__all__`. | ~~`docs.py`~~ |
-| V-D6 | Info | Several Domain functions return `dict[str, Any]` where TypedDicts exist. Partially addressed in PR #60 (`EnsureCollectionResult` now typed on `collections.ensure_collection()`, plus `ErrorResponse`, `SkillEntry`, `CollectionSearchResult` TypedDicts added) but not all return sites use them yet. | `parser.py:214-223`, `server.py:195-240` |
+| ~~V-D6~~ | ~~Info~~ | ~~Several Domain functions return `dict[str, Any]` where TypedDicts exist.~~ **Resolved across PRs #60, #87, #104, #105, #106** — tool handlers and key Domain returns use TypedDicts (`ParamDict`, `EntryPointInfo`, `EnsureCollectionResult`, etc.). Residual untyped internals may remain; not tracked as an open contract violation. | ~~`parser.py`, `server.py`~~ → `types.py` |
 | ~~V-D7~~ | ~~Warning~~ | ~~`_resolve_module_doc()` and `_resolve_role_doc()` in `server.py` contain significant business logic (Galaxy fallback, missing-collection caching). This logic belongs in the Domain layer, not Orchestration. The Orchestration layer should delegate to a domain-level resolution function.~~ **Fixed in PR #66** — Resolution logic moved to `resolution.py`. | ~~`server.py:195-301`~~ |
 | ~~V-D8~~ | ~~Warning~~ | ~~`collection_manifest.generate_manifest()` writes to disk as a side effect.~~ **Fixed** — Split into `generate_manifest()` (pure computation) and `write_manifest()` (I/O). Callers in `server.py` call both, wrapping `write_manifest` in `run_in_executor`. | ~~`collection_manifest.py:113-117`~~ |
 


### PR DESCRIPTION
## Summary
- Refresh `service-contracts.md` tool/prompt counts (18 / 5) and mark V-D6 resolved (was contradicting remediation list)
- Bump `project-strategy.md` to v0.7.0 / 974 tests / current open items (#182/#149/#200/#189)
- Promote ADR-0007 to **Accepted**; ADR index + ADR-0003 PR #87 mitigation note
- ADR-0008 already correct on main from #184 — verified only

Note: `docs/research/` is gitignored locally; comparison/strategy wording updates stay on disk only and are not in this PR.

## Test plan
- [ ] Docs-only review (no code changes)
- [ ] Spot-check CLAUDE.md still matches 18 tools / 6 resources / 5 prompts

Closes #196

Made with [Cursor](https://cursor.com)