### PR TITLE
feat: multi-path skill search via ANSIBLE_KNOW_SKILLS_PATH (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Multi-path skill search via `ANSIBLE_KNOW_SKILLS_PATH` (colon-separated) for `list_skills`, `get_skill`, and `skills://*` — first path wins; writes still use single `SKILLS_DIR` (#182)
+
 ## [0.7.0] - 2026-06-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ url = https://galaxy.ansible.com/api/
 | Environment Variable | Description | Default |
 |---------------------|-------------|---------|
 | `ANSIBLE_KNOW_SKILLS_DIR` | Explicit skills directory for writes / single-path reads (wins over project-dir chain) | *(not set)* |
-| `ANSIBLE_KNOW_SKILLS_PATH` | Colon-separated skills dirs for `list_skills` / `get_skill` / `skills://*` (like `$PATH`; first match wins). When set, replaces the single-dir search | *(not set)* |
+| `ANSIBLE_KNOW_SKILLS_PATH` | Colon-separated skills dirs for `list_skills` / `get_skill` / `skills://*` (like `$PATH`; first match wins). When set, replaces the single-dir search. Include the write directory (project `skills/` or `ANSIBLE_KNOW_SKILLS_DIR`) in this list if generated skills should remain discoverable | *(not set)* |
 | `ANSIBLE_KNOW_PROJECT_DIR` | Project root; skills go to `{root}/skills` | *(not set)* |
 | `CLAUDE_PROJECT_DIR` | Same as project dir when set by Claude Code | *(not set)* |
 | *(skills fallback)* | If none of the above are set | `cwd/skills/` |

--- a/README.md
+++ b/README.md
@@ -314,7 +314,8 @@ url = https://galaxy.ansible.com/api/
 
 | Environment Variable | Description | Default |
 |---------------------|-------------|---------|
-| `ANSIBLE_KNOW_SKILLS_DIR` | Explicit skills directory (wins over project-dir chain) | *(not set)* |
+| `ANSIBLE_KNOW_SKILLS_DIR` | Explicit skills directory for writes / single-path reads (wins over project-dir chain) | *(not set)* |
+| `ANSIBLE_KNOW_SKILLS_PATH` | Colon-separated skills dirs for `list_skills` / `get_skill` / `skills://*` (like `$PATH`; first match wins). When set, replaces the single-dir search | *(not set)* |
 | `ANSIBLE_KNOW_PROJECT_DIR` | Project root; skills go to `{root}/skills` | *(not set)* |
 | `CLAUDE_PROJECT_DIR` | Same as project dir when set by Claude Code | *(not set)* |
 | *(skills fallback)* | If none of the above are set | `cwd/skills/` |

--- a/docs/architecture/adr/0008-three-layer-distribution.md
+++ b/docs/architecture/adr/0008-three-layer-distribution.md
@@ -37,6 +37,9 @@ endpoints (locally installed, private Automation Hub, public Galaxy).
 - Skills land under the project by default via the `SKILLS_DIR` env chain
   (`ANSIBLE_KNOW_SKILLS_DIR` → `ANSIBLE_KNOW_PROJECT_DIR/skills` →
   `CLAUDE_PROJECT_DIR/skills` → `cwd/skills`) — see issue #181
+- **Multi-path reads (optional):** `ANSIBLE_KNOW_SKILLS_PATH` (colon-separated)
+  lets `list_skills` / `get_skill` / `skills://*` search multiple trees
+  (e.g. project + bundled). Writes still use single `SKILLS_DIR` — see #182
 - **Host-agent discovery:** `generate_collection_skills` updates a managed
   section in project-root `AGENTS.md` pointing agents at `skills/`.
   This is Layer 1 host discovery, not repository distribution.
@@ -149,3 +152,4 @@ would break. Spec compliance makes the layers possible.
 |------|--------|--------|
 | 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial proposal |
 | 2026-08-03 | Leonardo Gallego (Assisted-by: Cursor) | Layer 1: project-scoped skills + AGENTS.md host discovery; correct Lola/GitHub claims; dual-config; scan-depth tracking |
+| 2026-08-03 | Leonardo Gallego (Assisted-by: Cursor) | Layer 1: optional `ANSIBLE_KNOW_SKILLS_PATH` multi-path reads (#182) |

--- a/docs/architecture/project-strategy.md
+++ b/docs/architecture/project-strategy.md
@@ -150,7 +150,7 @@ The standard specification for AI agent skills.
 
 1. ~~**Finalize issue #148**~~ — **Done** (closed; ADR-0007 Accepted)
 2. ~~**Draft next-mcp scan depth proposal**~~ — **Tracked** as [#200](https://github.com/leogallego/ansible-know-mcp/issues/200)
-3. **#182** — multi-path `list_skills` / `get_skill`
+3. ~~**#182** — multi-path `list_skills` / `get_skill`~~ (done: `ANSIBLE_KNOW_SKILLS_PATH`)
 4. **#149** — Lola packaging helper (Layer 2)
 5. **#189 / #125** — FastMCP 4 / MCP 2026-07-28 session migration (blocked on stable release)
 

--- a/docs/superpowers/specs/2026-07-17-project-scoped-skills-design.md
+++ b/docs/superpowers/specs/2026-07-17-project-scoped-skills-design.md
@@ -213,7 +213,7 @@ discovery, not Layer 2) and defines dual-config with `ANSIBLE_SKILL_SOURCES`.
 
 ## Follow-Up Issues
 
-1. **Multi-path search for `list_skills`/`get_skill`** (#182): search both project-local and a secondary path (e.g., pre-baked devcontainer skills). Enables shared + project-specific skill coexistence. Blocked on this design landing first.
+1. ~~**Multi-path search for `list_skills`/`get_skill`** (#182)~~ — Implemented: `ANSIBLE_KNOW_SKILLS_PATH` (colon-separated); `list_skills` / `get_skill` / `skills://*` merge/search in order (first wins). Writes still use single `SKILLS_DIR`.
 2. **AGENTS.md from single-module generators** (intentional non-goal of #181): only `generate_collection_skills` updates AGENTS.md. Per-module/role/plugin generators do not — avoids noisy rewrites when called in a loop. Revisit only if operators commonly generate one-off skills without the collection batch tool. No GitHub issue yet; not required for this design.
 3. ~~**Update ADR-0008**~~ — **Done in #181 / PR #184**: ADR-0008 revised for Layer 1 AGENTS.md + dual-config; Lola/GitHub claims corrected.
 4. ~~**Validate `SKILLS_DIR` against sensitive prefixes**~~ — **Done in #181 / PR #184**: `SKILLS_DIR` resolution runs through `validate_install_path()`.

--- a/docs/superpowers/specs/2026-08-02-skill-discoverability-alignment.md
+++ b/docs/superpowers/specs/2026-08-02-skill-discoverability-alignment.md
@@ -157,7 +157,7 @@ Managed section **must not**:
 | Issue | Action after this addendum | Phase |
 |-------|----------------------------|-------|
 | **#181** | Implement; body/comments: dual-config, A+B only, link this doc; harden `SKILLS_DIR` validation | Our side — now |
-| **#182** | Comment: blocked on #181; know-only multi-path; not next-mcp | Our side — after #181 |
+| **#182** | Done: `ANSIBLE_KNOW_SKILLS_PATH` for know-mcp `list_skills` / `get_skill` / `skills://*` | Our side — shipped |
 | **#149** | Comment: required for Layer 2 Lola/GitHub Lola; not a substitute for local scan depth | Our side — later |
 | **#196** | Remaining v0.7 docs drift only (service-contracts counts, ADR-0003, ADR-0007 Accepted, July 31 comparison, strategy table). ADR-0008 / discoverability owned by #181 | After #181 |
 | **#200** | next-mcp local scan depth tracking; draft at `tmp/draft-issue-local-scan-depth.md` (fix algorithm before filing upstream) | After #181; then upstream |

--- a/src/ansible_know/config.py
+++ b/src/ansible_know/config.py
@@ -44,17 +44,53 @@ def get_project_root() -> Path:
     return Path.cwd()
 
 
+def _resolve_skills_dir() -> Path:
+    """Resolve the single default skills directory (write target / PATH fallback)."""
+    # Lazy import: validation is Foundation and must not import config at module load.
+    from ansible_know.validation import validate_install_path
+
+    explicit = os.environ.get("ANSIBLE_KNOW_SKILLS_DIR", "").strip()
+    if explicit:
+        return validate_install_path(explicit)
+    root = get_project_root()
+    return validate_install_path(str(root / "skills"))
+
+
+def get_skills_dirs() -> list[Path]:
+    """Return skill search directories for list_skills / get_skill.
+
+    Resolution:
+    1. ``ANSIBLE_KNOW_SKILLS_PATH`` — colon-separated list (like ``$PATH``)
+    2. Else ``SKILLS_DIR`` — single path from the existing env chain
+
+    Each path is validated via ``validate_install_path``. Empty segments are
+    skipped; duplicates are dropped (first occurrence wins).
+    """
+    from ansible_know.validation import validate_install_path
+
+    raw = os.environ.get("ANSIBLE_KNOW_SKILLS_PATH", "").strip()
+    if raw:
+        dirs: list[Path] = []
+        seen: set[Path] = set()
+        for part in raw.split(":"):
+            part = part.strip()
+            if not part:
+                continue
+            path = validate_install_path(part)
+            if path not in seen:
+                seen.add(path)
+                dirs.append(path)
+        if dirs:
+            return dirs
+
+    if "SKILLS_DIR" in globals():
+        return [globals()["SKILLS_DIR"]]
+    return [_resolve_skills_dir()]
+
+
 def __getattr__(name: str):
     if name == "SKILLS_DIR":
-        # Lazy import: validation is Foundation and must not import config.
-        from ansible_know.validation import validate_install_path
-
-        explicit = os.environ.get("ANSIBLE_KNOW_SKILLS_DIR", "").strip()
-        if explicit:
-            value = validate_install_path(explicit)
-        else:
-            root = get_project_root()
-            value = validate_install_path(str(root / "skills"))
+        value = _resolve_skills_dir()
         globals()["SKILLS_DIR"] = value
         return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -848,6 +848,9 @@ async def list_skills(
 ) -> list[SkillEntry] | ErrorResponse:
     """List all available generated skills. Returns name, description, path for each.
 
+    Searches ``ANSIBLE_KNOW_SKILLS_PATH`` (colon-separated) when set, otherwise
+    the single ``SKILLS_DIR``. Duplicate names keep the first path's entry.
+
     Returns: [{"name": str, "description": str, "path": str}, ...] or {"error": str} on failure.
     """
     logger.info("list_skills collection=%r", collection)
@@ -858,10 +861,10 @@ async def list_skills(
             return {"error": str(exc)}
 
     try:
-        from ansible_know.config import SKILLS_DIR
+        from ansible_know.config import get_skills_dirs
         from ansible_know.skills import list_skills_sync
 
-        return await run_in_executor(list_skills_sync, SKILLS_DIR, collection)
+        return await run_in_executor(list_skills_sync, get_skills_dirs(), collection)
     except Exception as exc:
         logger.warning("list_skills failed: %s", exc)
         return {"error": sanitize_error(str(exc))}
@@ -877,6 +880,9 @@ async def get_skill(
 ) -> str | ErrorResponse:
     """Read a specific skill's SKILL.md content by name.
 
+    Searches ``ANSIBLE_KNOW_SKILLS_PATH`` (colon-separated) when set, otherwise
+    the single ``SKILLS_DIR``. First match wins.
+
     Returns: SKILL.md content as str, or {"error": str} on failure/not found.
     """
     logger.info("get_skill name=%r", skill_name)
@@ -886,10 +892,10 @@ async def get_skill(
         return {"error": str(exc)}
 
     try:
-        from ansible_know.config import SKILLS_DIR
+        from ansible_know.config import get_skills_dirs
         from ansible_know.skills import get_skill_sync
 
-        return await run_in_executor(get_skill_sync, SKILLS_DIR, skill_name)
+        return await run_in_executor(get_skill_sync, get_skills_dirs(), skill_name)
     except FileNotFoundError as exc:
         return {"error": str(exc)}
     except ValidationError as exc:
@@ -1392,10 +1398,10 @@ async def clear_cache(
 def resource_skills_list() -> str:
     import json
 
-    from ansible_know.config import SKILLS_DIR
+    from ansible_know.config import get_skills_dirs
     from ansible_know.skills import list_skills_sync
 
-    entries = list_skills_sync(SKILLS_DIR, collection=None)
+    entries = list_skills_sync(get_skills_dirs(), collection=None)
     return json.dumps([e["name"] for e in entries], indent=2)
 
 
@@ -1405,7 +1411,7 @@ def resource_skills_list() -> str:
     description="Read a generated skill's SKILL.md by FQCN or collection namespace",
 )
 def resource_skill_content(skill_name: str) -> str:
-    from ansible_know.config import SKILLS_DIR
+    from ansible_know.config import get_skills_dirs
     from ansible_know.skills import get_skill_sync
 
     try:
@@ -1414,7 +1420,7 @@ def resource_skill_content(skill_name: str) -> str:
         return str(exc)
 
     try:
-        return get_skill_sync(SKILLS_DIR, skill_name)
+        return get_skill_sync(get_skills_dirs(), skill_name)
     except FileNotFoundError as exc:
         return str(exc)
     except ValidationError as exc:

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -252,6 +252,7 @@ def _list_nested_skills(
 
 
 def _normalize_skills_dirs(skills_dirs: Path | Sequence[Path]) -> list[Path]:
+    """Normalize a single Path or a sequence of Paths to a list."""
     if isinstance(skills_dirs, Path):
         return [skills_dirs]
     return list(skills_dirs)
@@ -262,7 +263,7 @@ def _list_skills_one_dir(
 ) -> list[SkillEntry]:
     """List skills from a single directory (no multi-path merge)."""
     results: list[SkillEntry] = []
-    if not skills_dir.exists():
+    if not skills_dir.is_dir():
         return results
 
     if collection:

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -12,6 +12,7 @@ import re
 import stat
 import threading
 from collections import Counter
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -250,15 +251,16 @@ def _list_nested_skills(
     return results
 
 
-def list_skills_sync(
+def _normalize_skills_dirs(skills_dirs: Path | Sequence[Path]) -> list[Path]:
+    if isinstance(skills_dirs, Path):
+        return [skills_dirs]
+    return list(skills_dirs)
+
+
+def _list_skills_one_dir(
     skills_dir: Path, collection: str | None,
 ) -> list[SkillEntry]:
-    """List generated skills from *skills_dir*.
-
-    When *collection* is given, returns module/role/plugin skills within that
-    collection directory.  Otherwise returns all skills: collection-level
-    entries followed by their nested module/role/plugin skills.
-    """
+    """List skills from a single directory (no multi-path merge)."""
     results: list[SkillEntry] = []
     if not skills_dir.exists():
         return results
@@ -290,16 +292,33 @@ def list_skills_sync(
     return results
 
 
-def get_skill_sync(skills_dir: Path, skill_name: str) -> str:
-    """Read a skill's SKILL.md content from disk.
+def list_skills_sync(
+    skills_dirs: Path | Sequence[Path],
+    collection: str | None,
+) -> list[SkillEntry]:
+    """List generated skills from one or more skills directories.
 
-    Callers MUST validate *skill_name* with ``validate_skill_name()`` first.
+    When *collection* is given, returns module/role/plugin skills within that
+    collection directory.  Otherwise returns all skills: collection-level
+    entries followed by their nested module/role/plugin skills.
 
-    Raises:
-        FileNotFoundError: If no matching SKILL.md exists.
-        ValidationError: If a resolved path escapes *skills_dir*.
-        OSError: On permission or I/O errors reading the file.
+    With multiple directories, results are merged in path order and deduplicated
+    by skill name (first path wins).
     """
+    merged: list[SkillEntry] = []
+    seen: set[str] = set()
+    for skills_dir in _normalize_skills_dirs(skills_dirs):
+        for entry in _list_skills_one_dir(skills_dir, collection):
+            name = entry["name"]
+            if name in seen:
+                continue
+            seen.add(name)
+            merged.append(entry)
+    return merged
+
+
+def _get_skill_one_dir(skills_dir: Path, skill_name: str) -> str | None:
+    """Read a skill from *skills_dir*, or return None if missing."""
     parts = skill_name.split(".")
     if len(parts) >= 3:
         namespace = ".".join(parts[:2])
@@ -314,7 +333,9 @@ def get_skill_sync(skills_dir: Path, skill_name: str) -> str:
 
         from ansible_know.config import PLUGIN_TYPES
         for ptype in PLUGIN_TYPES:
-            plugin_path = (skills_dir / collection_dir_name / f"{ptype}-{kebab_short}" / "SKILL.md").resolve()
+            plugin_path = (
+                skills_dir / collection_dir_name / f"{ptype}-{kebab_short}" / "SKILL.md"
+            ).resolve()
             validate_path_containment(plugin_path, skills_dir)
             if plugin_path.exists():
                 return truncate_response(plugin_path.read_text())
@@ -328,6 +349,26 @@ def get_skill_sync(skills_dir: Path, skill_name: str) -> str:
         validate_path_containment(skill_path, skills_dir)
         if skill_path.exists():
             return truncate_response(skill_path.read_text())
+
+    return None
+
+
+def get_skill_sync(skills_dirs: Path | Sequence[Path], skill_name: str) -> str:
+    """Read a skill's SKILL.md content from disk.
+
+    Callers MUST validate *skill_name* with ``validate_skill_name()`` first.
+
+    With multiple directories, searches in order and returns the first match.
+
+    Raises:
+        FileNotFoundError: If no matching SKILL.md exists in any directory.
+        ValidationError: If a resolved path escapes its skills directory.
+        OSError: On permission or I/O errors reading the file.
+    """
+    for skills_dir in _normalize_skills_dirs(skills_dirs):
+        content = _get_skill_one_dir(skills_dir, skill_name)
+        if content is not None:
+            return content
 
     raise FileNotFoundError(f"Skill '{skill_name}' not found.")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -226,3 +226,57 @@ class TestSkillsDirResolution:
         monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
         with pytest.raises(ValidationError, match="system directories"):
             self._reload_skills_dir(monkeypatch)
+
+
+class TestGetSkillsDirs:
+    def _clear_skills_dir_cache(self, monkeypatch):
+        import ansible_know.config as config_mod
+
+        monkeypatch.delattr(config_mod, "SKILLS_DIR", raising=False)
+        if "SKILLS_DIR" in config_mod.__dict__:
+            del config_mod.__dict__["SKILLS_DIR"]
+
+    def test_falls_back_to_skills_dir(self, monkeypatch, tmp_path):
+        from ansible_know.config import get_skills_dirs
+
+        monkeypatch.delenv("ANSIBLE_KNOW_SKILLS_PATH", raising=False)
+        monkeypatch.setenv("ANSIBLE_KNOW_SKILLS_DIR", str(tmp_path / "skills"))
+        self._clear_skills_dir_cache(monkeypatch)
+        assert get_skills_dirs() == [(tmp_path / "skills").resolve()]
+
+    def test_path_env_returns_colon_separated_dirs(self, monkeypatch, tmp_path):
+        from ansible_know.config import get_skills_dirs
+
+        first = tmp_path / "project-skills"
+        second = tmp_path / "bundled"
+        monkeypatch.setenv(
+            "ANSIBLE_KNOW_SKILLS_PATH",
+            f"{first}:{second}",
+        )
+        assert get_skills_dirs() == [first.resolve(), second.resolve()]
+
+    def test_path_skips_empty_segments_and_dedupes(self, monkeypatch, tmp_path):
+        from ansible_know.config import get_skills_dirs
+
+        only = tmp_path / "skills"
+        monkeypatch.setenv(
+            "ANSIBLE_KNOW_SKILLS_PATH",
+            f":{only}::{only}:",
+        )
+        assert get_skills_dirs() == [only.resolve()]
+
+    def test_empty_path_falls_back_to_skills_dir(self, monkeypatch, tmp_path):
+        from ansible_know.config import get_skills_dirs
+
+        monkeypatch.setenv("ANSIBLE_KNOW_SKILLS_PATH", ":::")
+        monkeypatch.setenv("ANSIBLE_KNOW_SKILLS_DIR", str(tmp_path / "fallback"))
+        self._clear_skills_dir_cache(monkeypatch)
+        assert get_skills_dirs() == [(tmp_path / "fallback").resolve()]
+
+    def test_path_rejects_sensitive_prefix(self, monkeypatch):
+        from ansible_know.config import get_skills_dirs
+        from ansible_know.errors import ValidationError
+
+        monkeypatch.setenv("ANSIBLE_KNOW_SKILLS_PATH", "/etc/skills")
+        with pytest.raises(ValidationError, match="system directories"):
+            get_skills_dirs()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,6 +192,37 @@ class TestListSkillsTool:
         assert by_name["netbox.netbox"] == "project"
         assert by_name["ansible.builtin"] == "builtin"
 
+    @pytest.mark.asyncio
+    async def test_merges_skills_path_with_collection_filter(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        bundled = tmp_path / "bundled"
+        for root, module, desc in (
+            (project, "netbox-device", "project device"),
+            (bundled, "netbox-device", "bundled device"),
+            (bundled, "netbox-site", "bundled site"),
+        ):
+            d = root / "netbox-netbox" / module
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: x\ndescription: {desc}\n---\n"
+            )
+        other = bundled / "ansible-builtin" / "copy"
+        other.mkdir(parents=True)
+        (other / "SKILL.md").write_text(
+            "---\nname: x\ndescription: copy\n---\n"
+        )
+        monkeypatch.setenv(
+            "ANSIBLE_KNOW_SKILLS_PATH",
+            f"{project}:{bundled}",
+        )
+        from ansible_know.server import list_skills
+        result = await list_skills(collection="netbox.netbox")
+        assert isinstance(result, list)
+        by_name = {e["name"]: e["description"] for e in result}
+        assert by_name["netbox.netbox.netbox_device"] == "project device"
+        assert by_name["netbox.netbox.netbox_site"] == "bundled site"
+        assert "ansible.builtin.copy" not in by_name
+
 
 class TestGetSkillTool:
     @pytest.mark.asyncio
@@ -247,6 +278,28 @@ class TestGetSkillTool:
         from ansible_know.server import get_skill
         result = await get_skill("netbox.netbox")
         assert result == "from project"
+
+    @pytest.mark.asyncio
+    async def test_skills_path_nested_first_match_wins(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        bundled = tmp_path / "bundled"
+        for root, content in (
+            (project, "from project nested"),
+            (bundled, "from bundled nested"),
+        ):
+            d = root / "netbox-netbox" / "netbox-device"
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(content)
+        only = bundled / "netbox-netbox" / "netbox-site"
+        only.mkdir(parents=True)
+        (only / "SKILL.md").write_text("bundled only nested")
+        monkeypatch.setenv(
+            "ANSIBLE_KNOW_SKILLS_PATH",
+            f"{project}:{bundled}",
+        )
+        from ansible_know.server import get_skill
+        assert await get_skill("netbox.netbox.netbox_device") == "from project nested"
+        assert await get_skill("netbox.netbox.netbox_site") == "bundled only nested"
 
 
 class TestGenerateSkillTool:
@@ -945,6 +998,40 @@ class TestResourceFunctions:
         result = json.loads(resource_skills_list())
         assert "netbox.netbox" in result
         assert "netbox.netbox.netbox_device" in result
+
+    def test_resource_skills_list_merges_skills_path(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        bundled = tmp_path / "bundled"
+        for root, name in (
+            (project, "netbox.netbox"),
+            (bundled, "netbox.netbox"),
+            (bundled, "ansible.builtin"),
+        ):
+            d = root / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(f"# {name}")
+        monkeypatch.setenv(
+            "ANSIBLE_KNOW_SKILLS_PATH",
+            f"{project}:{bundled}",
+        )
+        from ansible_know.server import resource_skills_list
+        result = json.loads(resource_skills_list())
+        assert result.count("netbox.netbox") == 1
+        assert "ansible.builtin" in result
+
+    def test_resource_skill_content_skills_path_first_wins(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        bundled = tmp_path / "bundled"
+        for root, content in ((project, "from project"), (bundled, "from bundled")):
+            d = root / "netbox-netbox" / "netbox-device"
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(content)
+        monkeypatch.setenv(
+            "ANSIBLE_KNOW_SKILLS_PATH",
+            f"{project}:{bundled}",
+        )
+        from ansible_know.server import resource_skill_content
+        assert resource_skill_content("netbox.netbox.netbox_device") == "from project"
 
     def test_resource_skill_content_flat_fallback(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,6 +15,12 @@ from tests.conftest import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_ansible_know_skills_path(monkeypatch):
+    """Keep SKILLS_DIR monkeypatches effective; PATH would override them."""
+    monkeypatch.delenv("ANSIBLE_KNOW_SKILLS_PATH", raising=False)
+
+
 def _make_mock_ctx(state, shared, http_client=None):
     """Build a mock FastMCP Context with session-based state."""
     mock_ctx = MagicMock()
@@ -116,10 +122,6 @@ class TestGetCollectionManifestTool:
 
 
 class TestListSkillsTool:
-    @pytest.fixture(autouse=True)
-    def _clear_skills_path(self, monkeypatch):
-        monkeypatch.delenv("ANSIBLE_KNOW_SKILLS_PATH", raising=False)
-
     @pytest.mark.asyncio
     async def test_returns_empty_when_no_skills(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
@@ -192,10 +194,6 @@ class TestListSkillsTool:
 
 
 class TestGetSkillTool:
-    @pytest.fixture(autouse=True)
-    def _clear_skills_path(self, monkeypatch):
-        monkeypatch.delenv("ANSIBLE_KNOW_SKILLS_PATH", raising=False)
-
     @pytest.mark.asyncio
     async def test_returns_not_found(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -116,6 +116,10 @@ class TestGetCollectionManifestTool:
 
 
 class TestListSkillsTool:
+    @pytest.fixture(autouse=True)
+    def _clear_skills_path(self, monkeypatch):
+        monkeypatch.delenv("ANSIBLE_KNOW_SKILLS_PATH", raising=False)
+
     @pytest.mark.asyncio
     async def test_returns_empty_when_no_skills(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
@@ -161,8 +165,37 @@ class TestListSkillsTool:
         result = await list_skills(collection="bad!")
         assert "error" in result
 
+    @pytest.mark.asyncio
+    async def test_merges_skills_path_dirs(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        bundled = tmp_path / "bundled"
+        for root, name, desc in (
+            (project, "netbox.netbox", "project"),
+            (bundled, "netbox.netbox", "bundled"),
+            (bundled, "ansible.builtin", "builtin"),
+        ):
+            d = root / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n"
+            )
+        monkeypatch.setenv(
+            "ANSIBLE_KNOW_SKILLS_PATH",
+            f"{project}:{bundled}",
+        )
+        from ansible_know.server import list_skills
+        result = await list_skills()
+        assert isinstance(result, list)
+        by_name = {e["name"]: e["description"] for e in result}
+        assert by_name["netbox.netbox"] == "project"
+        assert by_name["ansible.builtin"] == "builtin"
+
 
 class TestGetSkillTool:
+    @pytest.fixture(autouse=True)
+    def _clear_skills_path(self, monkeypatch):
+        monkeypatch.delenv("ANSIBLE_KNOW_SKILLS_PATH", raising=False)
+
     @pytest.mark.asyncio
     async def test_returns_not_found(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
@@ -200,6 +233,22 @@ class TestGetSkillTool:
         from ansible_know.server import get_skill
         result = await get_skill("ansible.builtin.copy")
         assert result == "flat skill content"
+
+    @pytest.mark.asyncio
+    async def test_skills_path_first_match_wins(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        bundled = tmp_path / "bundled"
+        for root, content in ((project, "from project"), (bundled, "from bundled")):
+            d = root / "netbox.netbox"
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(content)
+        monkeypatch.setenv(
+            "ANSIBLE_KNOW_SKILLS_PATH",
+            f"{project}:{bundled}",
+        )
+        from ansible_know.server import get_skill
+        result = await get_skill("netbox.netbox")
+        assert result == "from project"
 
 
 class TestGenerateSkillTool:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -885,3 +885,12 @@ class TestMultiPathSkills:
         results = list_skills_sync(tmp_path, collection=None)
         assert len(results) == 1
         assert get_skill_sync(tmp_path, "netbox.netbox").startswith("---")
+
+    def test_skips_nondirectory_path_entries(self, tmp_path):
+        not_a_dir = tmp_path / "file"
+        not_a_dir.write_text("x")
+        good = tmp_path / "bundled"
+        self._write_collection_skill(good, "ansible.builtin", "ok")
+        results = list_skills_sync([not_a_dir, good], collection=None)
+        assert len(results) == 1
+        assert results[0]["name"] == "ansible.builtin"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -13,6 +13,8 @@ from ansible_know.skills import (
     _role_template_context,
     collection_skill_name,
     fqcn_to_skill_name,
+    get_skill_sync,
+    list_skills_sync,
     module_to_skill_name,
     plugin_skill_name,
     render_collection_skill,
@@ -838,3 +840,48 @@ class TestUpdateAgentsMd:
         # Should appear once in collections list, not duplicated by symlink
         assert "Available collections: real.collection" in agents_md
         assert "symlink.collection" not in agents_md
+
+
+class TestMultiPathSkills:
+    def _write_collection_skill(self, root: Path, dir_name: str, description: str) -> None:
+        skill_dir = root / dir_name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {dir_name}\ndescription: {description}\n---\n"
+        )
+
+    def test_list_merges_and_dedupes_first_wins(self, tmp_path):
+        project = tmp_path / "project"
+        bundled = tmp_path / "bundled"
+        self._write_collection_skill(project, "netbox.netbox", "project netbox")
+        self._write_collection_skill(bundled, "netbox.netbox", "bundled netbox")
+        self._write_collection_skill(bundled, "ansible.builtin", "bundled builtin")
+
+        results = list_skills_sync([project, bundled], collection=None)
+        by_name = {e["name"]: e for e in results}
+        assert by_name["netbox.netbox"]["description"] == "project netbox"
+        assert by_name["ansible.builtin"]["description"] == "bundled builtin"
+        assert len(results) == 2
+
+    def test_get_searches_in_order(self, tmp_path):
+        project = tmp_path / "project"
+        bundled = tmp_path / "bundled"
+        self._write_collection_skill(project, "netbox.netbox", "from project")
+        self._write_collection_skill(bundled, "netbox.netbox", "from bundled")
+        self._write_collection_skill(bundled, "ansible.builtin", "bundled only")
+
+        project_hit = get_skill_sync([project, bundled], "netbox.netbox")
+        assert "from project" in project_hit
+
+        bundled_only = get_skill_sync([project, bundled], "ansible.builtin")
+        assert "bundled only" in bundled_only
+
+    def test_get_not_found_across_all_dirs(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="not found"):
+            get_skill_sync([tmp_path / "a", tmp_path / "b"], "missing.collection")
+
+    def test_single_path_still_accepted(self, tmp_path):
+        self._write_collection_skill(tmp_path, "netbox.netbox", "solo")
+        results = list_skills_sync(tmp_path, collection=None)
+        assert len(results) == 1
+        assert get_skill_sync(tmp_path, "netbox.netbox").startswith("---")

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -894,3 +894,68 @@ class TestMultiPathSkills:
         results = list_skills_sync([not_a_dir, good], collection=None)
         assert len(results) == 1
         assert results[0]["name"] == "ansible.builtin"
+
+    def _write_nested_module_skill(
+        self, root: Path, collection_kebab: str, module_kebab: str, body: str,
+    ) -> None:
+        nested = root / collection_kebab / module_kebab
+        nested.mkdir(parents=True)
+        (nested / "SKILL.md").write_text(body)
+
+    def test_list_collection_filter_merges_dirs(self, tmp_path):
+        project = tmp_path / "project"
+        bundled = tmp_path / "bundled"
+        self._write_nested_module_skill(
+            project, "netbox-netbox", "netbox-device",
+            "---\nname: netbox.netbox.netbox_device\ndescription: project device\n---\n",
+        )
+        self._write_nested_module_skill(
+            bundled, "netbox-netbox", "netbox-device",
+            "---\nname: netbox.netbox.netbox_device\ndescription: bundled device\n---\n",
+        )
+        self._write_nested_module_skill(
+            bundled, "netbox-netbox", "netbox-site",
+            "---\nname: netbox.netbox.netbox_site\ndescription: bundled site\n---\n",
+        )
+        # Unrelated collection should be ignored by the filter.
+        self._write_nested_module_skill(
+            bundled, "ansible-builtin", "copy",
+            "---\nname: ansible.builtin.copy\ndescription: copy\n---\n",
+        )
+
+        results = list_skills_sync([project, bundled], collection="netbox.netbox")
+        by_name = {e["name"]: e["description"] for e in results}
+        assert by_name["netbox.netbox.netbox_device"] == "project device"
+        assert by_name["netbox.netbox.netbox_site"] == "bundled site"
+        assert "ansible.builtin.copy" not in by_name
+        assert len(results) == 2
+
+    def test_nested_skill_shadows_across_dirs(self, tmp_path):
+        project = tmp_path / "project"
+        bundled = tmp_path / "bundled"
+        self._write_nested_module_skill(
+            project, "netbox-netbox", "netbox-device", "from project nested",
+        )
+        self._write_nested_module_skill(
+            bundled, "netbox-netbox", "netbox-device", "from bundled nested",
+        )
+        self._write_nested_module_skill(
+            bundled, "netbox-netbox", "netbox-site", "bundled only nested",
+        )
+
+        assert get_skill_sync(
+            [project, bundled], "netbox.netbox.netbox_device",
+        ) == "from project nested"
+        assert get_skill_sync(
+            [project, bundled], "netbox.netbox.netbox_site",
+        ) == "bundled only nested"
+
+        listed = list_skills_sync([project, bundled], collection=None)
+        by_name = {e["name"]: e["description"] for e in listed}
+        # Nested list uses frontmatter description when present; bodies above
+        # have no frontmatter so description may be empty — assert first-wins
+        # via path instead.
+        device = next(e for e in listed if e["name"] == "netbox.netbox.netbox_device")
+        assert str(project) in device["path"]
+        assert str(bundled) not in device["path"]
+        assert "netbox.netbox.netbox_site" in by_name


### PR DESCRIPTION
## Summary
- Add `ANSIBLE_KNOW_SKILLS_PATH` (colon-separated) so `list_skills`, `get_skill`, and `skills://*` can search multiple skill trees (first match wins).
- Keep writes on single `SKILLS_DIR` / `install_to` — multi-path is read-only discovery for standalone know-mcp / devcontainer bundled + project skills.
- Document env var; cover path parse, merge/dedupe, and shadowing in unit tests.

Closes #182

## Test plan
- [x] `pytest tests/test_config.py::TestGetSkillsDirs tests/test_skills.py::TestMultiPathSkills tests/test_server.py::TestListSkillsTool tests/test_server.py::TestGetSkillTool`
- [x] Broader skill-related suite (154 passed)
- [ ] CI green on PR
- [ ] Manual smoke: set `ANSIBLE_KNOW_SKILLS_PATH=/tmp/a:/tmp/b`, put a skill only in `b`, confirm `list_skills` / `get_skill` find it; put same name in both and confirm `a` shadows `b`


Made with [Cursor](https://cursor.com)