### PR TITLE
fix: align test_with_tags with multi-server Galaxy search (#179)

### DIFF
--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -1264,7 +1264,11 @@ class TestUnicodeQueries:
     @pytest.mark.asyncio
     async def test_unicode_search_collections(self):
         mock_result = {"query": "réseau", "count": 0, "collections": []}
-        with patch("ansible_know.galaxy.GalaxyClient.search_collections", return_value=mock_result):
+        with patch(
+            "ansible_know.resolution.search_galaxy_collections",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
             from ansible_know.server import search_collections as search_collections_tool
             result = await search_collections_tool("réseau")
         assert result["count"] == 0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1363,6 +1363,12 @@ class TestServerVersionResource:
 
 
 class TestSearchCollectionsTool:
+    """Tool-level tests mock resolution.search_galaxy_collections.
+
+    Default config has multiple Galaxy servers, so a class-level
+    GalaxyClient.search_collections mock fires once per server.
+    """
+
     @pytest.mark.asyncio
     async def test_returns_results(self):
         mock_result = {
@@ -1381,7 +1387,11 @@ class TestSearchCollectionsTool:
                 }
             ],
         }
-        with patch("ansible_know.galaxy.GalaxyClient.search_collections", return_value=mock_result):
+        with patch(
+            "ansible_know.resolution.search_galaxy_collections",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
             from ansible_know.server import search_collections
             result = await search_collections("netbox")
         assert result["count"] == 1
@@ -1389,9 +1399,6 @@ class TestSearchCollectionsTool:
 
     @pytest.mark.asyncio
     async def test_with_tags(self):
-        # Patch at the resolution boundary: search_galaxy_collections queries
-        # every configured Galaxy server (default config has 2), so a class-level
-        # GalaxyClient.search_collections mock fires once per server.
         mock_result = {"query": "network", "count": 0, "collections": []}
         with patch(
             "ansible_know.resolution.search_galaxy_collections",
@@ -1436,7 +1443,11 @@ class TestSearchCollectionsTool:
     @pytest.mark.asyncio
     async def test_handles_galaxy_error(self):
         from ansible_know.errors import GalaxyError
-        with patch("ansible_know.galaxy.GalaxyClient.search_collections", side_effect=GalaxyError("timeout")):
+        with patch(
+            "ansible_know.resolution.search_galaxy_collections",
+            new_callable=AsyncMock,
+            side_effect=GalaxyError("timeout"),
+        ):
             from ansible_know.server import search_collections
             result = await search_collections("netbox")
         assert "error" in result
@@ -1757,7 +1768,11 @@ class TestGetCollectionManifestWithRoles:
                 }
             ],
         }
-        with patch("ansible_know.galaxy.GalaxyClient.search_collections", return_value=mock_result):
+        with patch(
+            "ansible_know.resolution.search_galaxy_collections",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
             from ansible_know.server import search_collections
             result = await search_collections("linux")
         assert result["collections"][0]["role_count"] == 43

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -1389,11 +1389,24 @@ class TestSearchCollectionsTool:
 
     @pytest.mark.asyncio
     async def test_with_tags(self):
+        # Patch at the resolution boundary: search_galaxy_collections queries
+        # every configured Galaxy server (default config has 2), so a class-level
+        # GalaxyClient.search_collections mock fires once per server.
         mock_result = {"query": "network", "count": 0, "collections": []}
-        with patch("ansible_know.galaxy.GalaxyClient.search_collections", return_value=mock_result) as mock_search:
+        with patch(
+            "ansible_know.resolution.search_galaxy_collections",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ) as mock_search:
             from ansible_know.server import search_collections
             result = await search_collections("network", tags="networking,cloud")
-        mock_search.assert_called_once_with("network", tags="networking,cloud")
+        mock_search.assert_called_once_with(
+            "network",
+            tags="networking,cloud",
+            http_client=ANY,
+            galaxy_servers=ANY,
+            client_factory=ANY,
+        )
         assert result["count"] == 0
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fix `TestSearchCollectionsTool::test_with_tags` by mocking `resolution.search_galaxy_collections` instead of `GalaxyClient.search_collections`.
- Assert query/tags are forwarded once at the tool→resolution boundary, matching default multi-server Galaxy search (N client calls).
- Test-only change; no production multi-server behavior changes.

## Test plan
- [x] `pytest tests/test_server.py::TestSearchCollectionsTool -q` (7 passed)
- [x] Confirm `test_with_tags` passes under default multi-server config

Closes #179

Assisted-by: Cursor (Grok 4.5)