### PR TITLE
fix: wrap MCP resource I/O in run_in_executor (#193)

### DIFF
--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1395,13 +1395,13 @@ async def clear_cache(
 
 
 @mcp.resource("skills://list", name="Available Skills", description="List all generated skill packages")
-def resource_skills_list() -> str:
+async def resource_skills_list() -> str:
     import json
 
     from ansible_know.config import get_skills_dirs
     from ansible_know.skills import list_skills_sync
 
-    entries = list_skills_sync(get_skills_dirs(), collection=None)
+    entries = await run_in_executor(list_skills_sync, get_skills_dirs(), None)
     return json.dumps([e["name"] for e in entries], indent=2)
 
 
@@ -1410,7 +1410,7 @@ def resource_skills_list() -> str:
     name="Skill Content",
     description="Read a generated skill's SKILL.md by FQCN or collection namespace",
 )
-def resource_skill_content(skill_name: str) -> str:
+async def resource_skill_content(skill_name: str) -> str:
     from ansible_know.config import get_skills_dirs
     from ansible_know.skills import get_skill_sync
 
@@ -1420,7 +1420,7 @@ def resource_skill_content(skill_name: str) -> str:
         return str(exc)
 
     try:
-        return get_skill_sync(get_skills_dirs(), skill_name)
+        return await run_in_executor(get_skill_sync, get_skills_dirs(), skill_name)
     except FileNotFoundError as exc:
         return str(exc)
     except ValidationError as exc:
@@ -1467,10 +1467,14 @@ def resource_server_version() -> str:
         "Shows auth type (token/basic/none) for debugging; credentials are never exposed."
     ),
 )
-def resource_galaxy_servers() -> str:
+async def resource_galaxy_servers() -> str:
     from ansible_know.galaxy_config import load_galaxy_servers
 
-    servers = (_shared_state.galaxy_servers if _shared_state else None) or load_galaxy_servers()
+    # Prefer SharedState populated at lifespan; avoid re-parsing ansible.cfg
+    # on the event loop. Fall back via executor when state is unavailable.
+    servers = _shared_state.galaxy_servers if _shared_state else None
+    if not servers:
+        servers = await run_in_executor(load_galaxy_servers)
     return json.dumps([
         {
             "name": s.name,

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1401,8 +1401,13 @@ async def resource_skills_list() -> str:
     from ansible_know.config import get_skills_dirs
     from ansible_know.skills import list_skills_sync
 
-    entries = await run_in_executor(list_skills_sync, get_skills_dirs(), None)
-    return json.dumps([e["name"] for e in entries], indent=2)
+    # Include get_skills_dirs() in the executor: making this handler async
+    # disables FastMCP's sync-handler threadpool offload for static resources.
+    def _list_skill_names() -> list[str]:
+        return [e["name"] for e in list_skills_sync(get_skills_dirs(), None)]
+
+    names = await run_in_executor(_list_skill_names)
+    return json.dumps(names, indent=2)
 
 
 @mcp.resource(
@@ -1419,8 +1424,13 @@ async def resource_skill_content(skill_name: str) -> str:
     except ValidationError as exc:
         return str(exc)
 
+    # Path resolution (get_skills_dirs) + FS read must stay off the event loop.
+    # Templates do not auto-threadpool sync handlers the way static resources do.
+    def _read_skill() -> str:
+        return get_skill_sync(get_skills_dirs(), skill_name)
+
     try:
-        return await run_in_executor(get_skill_sync, get_skills_dirs(), skill_name)
+        return await run_in_executor(_read_skill)
     except FileNotFoundError as exc:
         return str(exc)
     except ValidationError as exc:

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1472,9 +1472,10 @@ async def resource_galaxy_servers() -> str:
 
     # Prefer SharedState populated at lifespan; avoid re-parsing ansible.cfg
     # on the event loop. Fall back via executor when state is unavailable.
-    servers = _shared_state.galaxy_servers if _shared_state else None
-    if not servers:
+    if _shared_state is None:
         servers = await run_in_executor(load_galaxy_servers)
+    else:
+        servers = _shared_state.galaxy_servers
     return json.dumps([
         {
             "name": s.name,

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -1175,7 +1175,7 @@ class TestSearchCollectionsEdgeCases:
             return {"download_count": 100, "highest_version": {"version": "1.0.0"}}
 
         with _mock_search_context(mock_api_get):
-            client = GalaxyClient()
+            client = _skip_discovery(GalaxyClient())
             result = await client.search_collections("test")
 
         assert result["count"] == 1
@@ -1207,7 +1207,7 @@ class TestSearchCollectionsEdgeCases:
             return {"download_count": 0, "highest_version": {"version": "1.0.0"}}
 
         with _mock_search_context(mock_api_get):
-            client = GalaxyClient()
+            client = _skip_discovery(GalaxyClient())
             result = await client.search_collections("test")
 
         assert result["collections"][0]["tags"] == ["valid"]

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -1175,7 +1175,7 @@ class TestSearchCollectionsEdgeCases:
             return {"download_count": 100, "highest_version": {"version": "1.0.0"}}
 
         with _mock_search_context(mock_api_get):
-            client = _skip_discovery(GalaxyClient())
+            client = GalaxyClient()
             result = await client.search_collections("test")
 
         assert result["count"] == 1
@@ -1207,7 +1207,7 @@ class TestSearchCollectionsEdgeCases:
             return {"download_count": 0, "highest_version": {"version": "1.0.0"}}
 
         with _mock_search_context(mock_api_get):
-            client = _skip_discovery(GalaxyClient())
+            client = GalaxyClient()
             result = await client.search_collections("test")
 
         assert result["collections"][0]["tags"] == ["valid"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -965,6 +965,37 @@ class TestResourceFunctions:
         assert "ansible.builtin" in result
 
     @pytest.mark.asyncio
+    async def test_resource_skills_list_resolves_dirs_via_executor(self, tmp_path, monkeypatch):
+        """get_skills_dirs() must not run on the event loop (async drops FastMCP offload)."""
+        import threading
+
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        import ansible_know.config as config
+        import ansible_know.server as srv
+
+        main_thread = threading.current_thread()
+        real_get_dirs = config.get_skills_dirs
+
+        def tracking_get_dirs():
+            assert threading.current_thread() is not main_thread, (
+                "get_skills_dirs ran on the event-loop thread"
+            )
+            return real_get_dirs()
+
+        with (
+            patch(
+                "ansible_know.server.run_in_executor",
+                wraps=srv.run_in_executor,
+            ) as mock_rie,
+            patch("ansible_know.config.get_skills_dirs", side_effect=tracking_get_dirs),
+        ):
+            result = json.loads(await srv.resource_skills_list())
+
+        mock_rie.assert_called_once()
+        assert mock_rie.call_args.args[0].__name__ == "_list_skill_names"
+        assert result == []
+
+    @pytest.mark.asyncio
     async def test_resource_skill_content_not_found(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
         from ansible_know.server import resource_skill_content

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -947,46 +947,52 @@ class TestGalaxyDocsFallback:
 
 
 class TestResourceFunctions:
-    def test_resource_skills_list_empty(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_resource_skills_list_empty(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
         from ansible_know.server import resource_skills_list
-        result = json.loads(resource_skills_list())
+        result = json.loads(await resource_skills_list())
         assert result == []
 
-    def test_resource_skills_list_with_skills(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_resource_skills_list_with_skills(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
         skill_dir = tmp_path / "ansible.builtin"
         skill_dir.mkdir()
         (skill_dir / "SKILL.md").write_text("# Codex skill")
         from ansible_know.server import resource_skills_list
-        result = json.loads(resource_skills_list())
+        result = json.loads(await resource_skills_list())
         assert "ansible.builtin" in result
 
-    def test_resource_skill_content_not_found(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_resource_skill_content_not_found(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
         from ansible_know.server import resource_skill_content
-        result = resource_skill_content("ansible.builtin.copy")
+        result = await resource_skill_content("ansible.builtin.copy")
         assert "not found" in result.lower()
 
-    def test_resource_skill_content_reads_nested(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_resource_skill_content_reads_nested(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
         nested = tmp_path / "ansible-builtin" / "copy"
         nested.mkdir(parents=True)
         (nested / "SKILL.md").write_text("nested content")
         from ansible_know.server import resource_skill_content
-        result = resource_skill_content("ansible.builtin.copy")
+        result = await resource_skill_content("ansible.builtin.copy")
         assert result == "nested content"
 
-    def test_resource_skill_content_reads_collection_skill(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_resource_skill_content_reads_collection_skill(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
         coll_dir = tmp_path / "netbox.netbox"
         coll_dir.mkdir()
         (coll_dir / "SKILL.md").write_text("collection skill content")
         from ansible_know.server import resource_skill_content
-        result = resource_skill_content("netbox.netbox")
+        result = await resource_skill_content("netbox.netbox")
         assert result == "collection skill content"
 
-    def test_resource_skills_list_with_nested_skills(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_resource_skills_list_with_nested_skills(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
         coll_dir = tmp_path / "netbox-netbox"
         coll_dir.mkdir()
@@ -995,11 +1001,12 @@ class TestResourceFunctions:
         mod_dir.mkdir()
         (mod_dir / "SKILL.md").write_text("# Device skill")
         from ansible_know.server import resource_skills_list
-        result = json.loads(resource_skills_list())
+        result = json.loads(await resource_skills_list())
         assert "netbox.netbox" in result
         assert "netbox.netbox.netbox_device" in result
 
-    def test_resource_skills_list_merges_skills_path(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_resource_skills_list_merges_skills_path(self, tmp_path, monkeypatch):
         project = tmp_path / "project"
         bundled = tmp_path / "bundled"
         for root, name in (
@@ -1015,11 +1022,12 @@ class TestResourceFunctions:
             f"{project}:{bundled}",
         )
         from ansible_know.server import resource_skills_list
-        result = json.loads(resource_skills_list())
+        result = json.loads(await resource_skills_list())
         assert result.count("netbox.netbox") == 1
         assert "ansible.builtin" in result
 
-    def test_resource_skill_content_skills_path_first_wins(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_resource_skill_content_skills_path_first_wins(self, tmp_path, monkeypatch):
         project = tmp_path / "project"
         bundled = tmp_path / "bundled"
         for root, content in ((project, "from project"), (bundled, "from bundled")):
@@ -1031,21 +1039,23 @@ class TestResourceFunctions:
             f"{project}:{bundled}",
         )
         from ansible_know.server import resource_skill_content
-        assert resource_skill_content("netbox.netbox.netbox_device") == "from project"
+        assert await resource_skill_content("netbox.netbox.netbox_device") == "from project"
 
-    def test_resource_skill_content_flat_fallback(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_resource_skill_content_flat_fallback(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
         flat = tmp_path / "ansible.builtin.copy"
         flat.mkdir(parents=True)
         (flat / "SKILL.md").write_text("flat content")
         from ansible_know.server import resource_skill_content
-        result = resource_skill_content("ansible.builtin.copy")
+        result = await resource_skill_content("ansible.builtin.copy")
         assert result == "flat content"
 
-    def test_resource_skill_content_invalid_fqcn(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_resource_skill_content_invalid_fqcn(self, tmp_path, monkeypatch):
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
         from ansible_know.server import resource_skill_content
-        result = resource_skill_content("../../etc/passwd")
+        result = await resource_skill_content("../../etc/passwd")
         assert "invalid" in result.lower() or "expected" in result.lower()
 
     def test_resource_installed_collections_empty(self):
@@ -1081,6 +1091,81 @@ class TestResourceFunctions:
         result = json.loads(resource_doc_sources())
         assert isinstance(result, dict)
         assert len(result) >= 1
+
+    @pytest.mark.asyncio
+    async def test_resource_galaxy_servers_uses_shared_state(self):
+        import ansible_know.server as srv
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.state import SharedState
+
+        servers = [
+            GalaxyServerConfig(name="ah", url="https://galaxy.example/api/", token="secret"),
+            GalaxyServerConfig(name="public_galaxy", url="https://galaxy.ansible.com"),
+        ]
+        shared = SharedState(galaxy_servers=servers)
+        old = srv._shared_state
+        try:
+            srv._shared_state = shared
+            with patch(
+                "ansible_know.galaxy_config.load_galaxy_servers",
+            ) as mock_load:
+                result = json.loads(await srv.resource_galaxy_servers())
+            mock_load.assert_not_called()
+        finally:
+            srv._shared_state = old
+
+        assert result == [
+            {
+                "name": "ah",
+                "url": "https://galaxy.example/api/",
+                "auth": "token",
+                "validate_certs": True,
+            },
+            {
+                "name": "public_galaxy",
+                "url": "https://galaxy.ansible.com",
+                "auth": "none",
+                "validate_certs": True,
+            },
+        ]
+        assert "secret" not in json.dumps(result)
+
+    @pytest.mark.asyncio
+    async def test_resource_galaxy_servers_loads_via_executor_when_unshared(self):
+        import ansible_know.server as srv
+        from ansible_know.galaxy_config import GalaxyServerConfig
+
+        fallback = [
+            GalaxyServerConfig(
+                name="galaxy",
+                url="https://galaxy.ansible.com",
+                username="u",
+                password="p",
+            ),
+        ]
+        old = srv._shared_state
+        try:
+            srv._shared_state = None
+            with patch(
+                "ansible_know.galaxy_config.load_galaxy_servers",
+                return_value=fallback,
+            ) as mock_load:
+                result = json.loads(await srv.resource_galaxy_servers())
+            mock_load.assert_called_once_with()
+        finally:
+            srv._shared_state = old
+
+        assert result == [
+            {
+                "name": "galaxy",
+                "url": "https://galaxy.ansible.com",
+                "auth": "basic",
+                "validate_certs": True,
+            },
+        ]
+        assert "username" not in result[0]
+        assert "password" not in result[0]
+        assert "token" not in result[0]
 
 
 class TestPromptFunctions:
@@ -2142,13 +2227,14 @@ class TestListPluginSkills:
 
 
 class TestResourceSkillsListPlugins:
-    def test_returns_fqcn_for_plugin_skills(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_returns_fqcn_for_plugin_skills(self, tmp_path):
         skill_dir = tmp_path / "netbox-netbox" / "lookup-nb-lookup"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("---\nname: test\n---\n")
         with patch("ansible_know.config.SKILLS_DIR", tmp_path):
             from ansible_know.server import resource_skills_list
-            result = json.loads(resource_skills_list())
+            result = json.loads(await resource_skills_list())
         assert "netbox.netbox.nb_lookup" in result
         assert "lookup-nb-lookup" not in result
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1106,11 +1106,16 @@ class TestResourceFunctions:
         old = srv._shared_state
         try:
             srv._shared_state = shared
-            with patch(
-                "ansible_know.galaxy_config.load_galaxy_servers",
-            ) as mock_load:
+            with (
+                patch(
+                    "ansible_know.server.run_in_executor",
+                    wraps=srv.run_in_executor,
+                ) as mock_rie,
+                patch("ansible_know.galaxy_config.load_galaxy_servers") as mock_load,
+            ):
                 result = json.loads(await srv.resource_galaxy_servers())
             mock_load.assert_not_called()
+            mock_rie.assert_not_called()
         finally:
             srv._shared_state = old
 
@@ -1146,11 +1151,19 @@ class TestResourceFunctions:
         old = srv._shared_state
         try:
             srv._shared_state = None
-            with patch(
-                "ansible_know.galaxy_config.load_galaxy_servers",
-                return_value=fallback,
-            ) as mock_load:
+            with (
+                patch(
+                    "ansible_know.server.run_in_executor",
+                    wraps=srv.run_in_executor,
+                ) as mock_rie,
+                patch(
+                    "ansible_know.galaxy_config.load_galaxy_servers",
+                    return_value=fallback,
+                ) as mock_load,
+            ):
                 result = json.loads(await srv.resource_galaxy_servers())
+            mock_rie.assert_called_once()
+            assert mock_rie.call_args.args[0] is mock_load
             mock_load.assert_called_once_with()
         finally:
             srv._shared_state = old


### PR DESCRIPTION
## Summary
- Make `skills://list`, `skills://{skill_name}`, and `galaxy://servers` resource handlers async and wrap blocking FS/config I/O with `run_in_executor` (same pattern as the skill tools).
- Prefer `SharedState.galaxy_servers` from lifespan for `galaxy://servers`; only call `load_galaxy_servers()` via the executor when shared state is unavailable.
- Leave `docs://sources` sync after audit: `get_doc_sources()` is env/in-memory only (no FS I/O). In-memory resources (`galaxy://installed`, `server://version`) unchanged.
- Update resource tests for async handlers and add coverage for the SharedState vs executor fallback paths.

## Test plan
- [x] `pytest tests/test_server.py -k 'resource or Resource' -q` (18 passed)
- [x] `pytest tests/test_skills.py -q` (93 passed)
- [x] `ruff check` on touched files
- [ ] Confirm MCP clients can still read `skills://list`, `skills://{name}`, and `galaxy://servers`

Closes #193

Assisted-by: Cursor (Grok 4.5)