### PR TITLE
fix: HTTP fallback when Red Hat Docs MCP rejects AAP URLs (#183)

### DIFF
--- a/src/ansible_know/redhat_docs.py
+++ b/src/ansible_know/redhat_docs.py
@@ -252,15 +252,26 @@ def _is_url_rejection_message(text: str) -> bool:
 
 
 def _is_soft_404_markdown(markdown: str) -> bool:
-    """Return True when markdown starts with a not-found H1 (not prose mentions)."""
-    return bool(_SOFT_404_TITLE_RE.match(markdown.lstrip()))
+    """Return True when the first markdown H1 is a not-found title.
+
+    Ignores leading non-heading noise (e.g. decorative image alt text that
+    RH soft-404 pages emit before ``# 404: Page not found``).
+    """
+    match = re.search(r"^#\s+.+$", markdown, re.MULTILINE)
+    if match is None:
+        return False
+    return bool(_SOFT_404_TITLE_RE.match(match.group(0)))
 
 
 def _html_looks_soft_404(html: str) -> bool:
-    """Cheap pre-convert check for RH SPA / soft not-found pages."""
+    """Cheap pre-convert check for RH SPA / soft not-found pages.
+
+    Title must *start* with ``Page not found`` (RH soft-404 shape), not merely
+    mention those words in a troubleshooting guide title.
+    """
     head = html[:50_000]
     title = _HTML_TITLE_RE.search(head)
-    if title and re.search(r"page\s+not\s+found", title.group(1), re.IGNORECASE):
+    if title and re.match(r"\s*page\s+not\s+found\b", title.group(1), re.IGNORECASE):
         return True
     return bool(_HTML_SOFT_404_H1_RE.search(head))
 
@@ -621,7 +632,8 @@ async def fetch_redhat_doc_http(
         markdown = html_to_markdown(resp.text)
         if not markdown.strip():
             raise AnsibleKnowError(f"No convertible documentation content found at {url}")
-        if _is_soft_404_markdown(markdown):
+        # Prefer HTML title/H1 check (survives leading img alts); markdown is backup.
+        if _html_looks_soft_404(resp.text) or _is_soft_404_markdown(markdown):
             raise AnsibleKnowError(
                 f"docs.redhat.com returned a not-found page for {url}"
             )

--- a/src/ansible_know/redhat_docs.py
+++ b/src/ansible_know/redhat_docs.py
@@ -3,14 +3,22 @@
 Uses JSON-RPC over Streamable HTTP to fetch docs.redhat.com pages as
 markdown via the ``redhat_docs_fetch`` tool. Sessions are initialized
 lazily and re-created on 404 (server-side session expiry).
+
+When the upstream MCP server rejects a URL as invalid (notably AAP 2.6/2.7
+modular guide slugs), ``fetch_redhat_doc`` falls back to a direct HTTP
+fetch of docs.redhat.com and converts the HTML article to markdown.
 """
 
 from __future__ import annotations
 
+import html
 import json
 import logging
+import re
 import uuid
+from html.parser import HTMLParser
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 
@@ -25,12 +33,28 @@ logger = logging.getLogger("ansible_know")
 __all__ = [
     "RedHatDocsClient",
     "fetch_redhat_doc",
+    "fetch_redhat_doc_http",
+    "html_to_markdown",
     "parse_mcp_sse",
 ]
 
 _MCP_PROTOCOL_VERSION = "2024-11-05"
 _MAX_RETRIES = 3
 _MAX_RESPONSE_SIZE = 2_000_000  # 2MB
+_MAX_DOC_FETCH_SIZE = 2_000_000  # 2MB — aligned with docs.fetch_doc_content
+_RH_DOC_HOST = "docs.redhat.com"
+
+# Narrow trigger for HTTP fallback: upstream URL validator rejections only.
+# Do not match generic transport/timeouts — MCP-down should surface as error.
+_MCP_URL_REJECTION_RE = re.compile(
+    r"not a valid\b.{0,80}\blink"
+    r"|invalid\s+(?:red\s+hat\s+)?(?:documentation\s+)?(?:url|link)",
+    re.IGNORECASE,
+)
+_HTML_SEGMENT_RE = re.compile(r"/(html(?:-single)?)/")
+_INDEX_SUFFIX_RE = re.compile(r"/index/?$")
+_ARTICLE_RE = re.compile(r"<article\b[^>]*>.*?</article>", re.IGNORECASE | re.DOTALL)
+_MAIN_RE = re.compile(r"<main\b[^>]*>.*?</main>", re.IGNORECASE | re.DOTALL)
 
 
 def parse_mcp_sse(body: str) -> dict[str, Any] | None:
@@ -155,12 +179,17 @@ class RedHatDocsClient:
             msg = parsed["error"].get("message", str(parsed["error"]))
             raise AnsibleKnowError(f"MCP tool {name} error: {sanitize_error(msg)}")
 
-        content_blocks = parsed.get("result", {}).get("content", [])
+        result = parsed.get("result", {})
+        content_blocks = result.get("content", [])
         raw = "".join(
             block.get("text", "")
             for block in content_blocks
             if block.get("type") == "text"
         )
+        if result.get("isError"):
+            raise AnsibleKnowError(
+                f"MCP tool {name} error: {sanitize_error(raw or 'unknown error')}"
+            )
         return _unwrap_mcp_result(raw)
 
     async def close(self) -> None:
@@ -197,25 +226,226 @@ def _estimate_tokens(text: str) -> int:
     return len(text) // 4
 
 
-async def fetch_redhat_doc(
-    url: str,
-    max_tokens: int | None = None,
-    client: RedHatDocsClient | None = None,
-) -> FetchDocResult:
-    """Fetch a docs.redhat.com page via the Red Hat Documentation MCP server.
+def _is_mcp_url_rejection(exc: BaseException) -> bool:
+    """Return True when *exc* is an upstream RH Docs MCP URL-validation error."""
+    if not isinstance(exc, AnsibleKnowError):
+        return False
+    return bool(_MCP_URL_REJECTION_RE.search(str(exc)))
 
-    The caller (Orchestration layer) owns the client lifecycle — created
-    at lifespan startup in SharedState, closed at shutdown.  This function
-    is a stateless transform: fetch raw content, detect landing pages,
-    clean markdown, estimate tokens.
+
+def _is_url_rejection_message(text: str) -> bool:
+    """Return True when MCP returned a short URL-rejection string as content."""
+    stripped = text.strip()
+    if not stripped or len(stripped) > 300:
+        return False
+    return bool(_MCP_URL_REJECTION_RE.search(stripped))
+
+
+def _alternate_redhat_doc_url(url: str) -> str | None:
+    """Return a rewritten docs.redhat.com URL without /html/ or /html-single/.
+
+    AAP 2.6/2.7 modular guides are served at ``/{version}/{slug}``. Manifest
+    entries often still include a ``/html/`` segment that 404s for 2.7 (2.6
+    usually redirects). Returns None when no rewrite applies.
     """
-    if client is None:
-        raise AnsibleKnowError("RedHatDocsClient is required — pass via SharedState")
-    raw = await client.fetch(url)
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != _RH_DOC_HOST:
+        return None
+    path = _HTML_SEGMENT_RE.sub("/", parsed.path, count=1)
+    path = _INDEX_SUFFIX_RE.sub("", path)
+    if path == parsed.path:
+        return None
+    return urlunparse(parsed._replace(path=path or "/"))
 
-    if raw.lstrip().startswith("{"):
+
+def _extract_content_html(raw_html: str) -> str:
+    """Prefer ``<article>`` (then ``<main>``) for conversion; else full document."""
+    match = _ARTICLE_RE.search(raw_html)
+    if match:
+        return match.group(0)
+    match = _MAIN_RE.search(raw_html)
+    if match:
+        return match.group(0)
+    return raw_html
+
+
+class _HtmlToMarkdownParser(HTMLParser):
+    """Minimal HTML→Markdown converter for Red Hat docs article markup."""
+
+    _SKIP_TAGS = frozenset({
+        "script", "style", "nav", "header", "footer", "aside",
+        "button", "svg", "noscript", "form", "rh-button", "rh-icon",
+        "rh-surface", "rh-breadcrumb", "pf-popover",
+    })
+    _BLOCK_TAGS = frozenset({
+        "p", "div", "section", "li", "tr", "blockquote", "pre",
+        "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "table",
+        "article", "main", "br", "hr",
+    })
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._parts: list[str] = []
+        self._skip_depth = 0
+        self._in_pre = False
+        self._list_stack: list[str] = []  # "ul" | "ol"
+        self._ol_index: list[int] = []
+        self._href: str | None = None
+        self._pending_href_text: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if self._skip_depth:
+            if tag in self._SKIP_TAGS:
+                self._skip_depth += 1
+            return
+        if tag in self._SKIP_TAGS:
+            self._skip_depth = 1
+            return
+
+        attr_map = {k.lower(): (v or "") for k, v in attrs}
+
+        if tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            self._ensure_blank_line()
+            self._parts.append("#" * int(tag[1]) + " ")
+        elif tag == "br":
+            self._parts.append("\n")
+        elif tag == "hr":
+            self._ensure_blank_line()
+            self._parts.append("---\n\n")
+        elif tag == "p":
+            self._ensure_blank_line()
+        elif tag in {"ul", "ol"}:
+            self._ensure_blank_line()
+            self._list_stack.append(tag)
+            self._ol_index.append(0)
+        elif tag == "li":
+            self._ensure_newline()
+            depth = max(len(self._list_stack) - 1, 0)
+            indent = "  " * depth
+            if self._list_stack and self._list_stack[-1] == "ol":
+                self._ol_index[-1] += 1
+                self._parts.append(f"{indent}{self._ol_index[-1]}. ")
+            else:
+                self._parts.append(f"{indent}- ")
+        elif tag == "pre":
+            self._ensure_blank_line()
+            self._parts.append("```\n")
+            self._in_pre = True
+        elif tag == "code" and not self._in_pre:
+            self._parts.append("`")
+        elif tag in {"strong", "b"}:
+            self._parts.append("**")
+        elif tag in {"em", "i"}:
+            self._parts.append("*")
+        elif tag == "a":
+            href = attr_map.get("href", "")
+            if href and not href.startswith("#"):
+                self._href = href
+                self._pending_href_text = []
+        elif tag == "img":
+            alt = attr_map.get("alt", "")
+            if alt:
+                self._parts.append(alt)
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if self._skip_depth:
+            if tag in self._SKIP_TAGS:
+                self._skip_depth -= 1
+            return
+
+        if tag in {"h1", "h2", "h3", "h4", "h5", "h6", "p"}:
+            self._parts.append("\n\n")
+        elif tag in {"ul", "ol"}:
+            if self._list_stack:
+                self._list_stack.pop()
+            if self._ol_index:
+                self._ol_index.pop()
+            self._parts.append("\n")
+        elif tag == "li":
+            self._parts.append("\n")
+        elif tag == "pre":
+            if not self._parts or not self._parts[-1].endswith("\n"):
+                self._parts.append("\n")
+            self._parts.append("```\n\n")
+            self._in_pre = False
+        elif tag == "code" and not self._in_pre:
+            self._parts.append("`")
+        elif tag in {"strong", "b"}:
+            self._parts.append("**")
+        elif tag in {"em", "i"}:
+            self._parts.append("*")
+        elif tag == "a" and self._href is not None:
+            label = "".join(self._pending_href_text).strip() or self._href
+            self._parts.append(f"[{label}]({self._href})")
+            self._href = None
+            self._pending_href_text = []
+        elif tag in self._BLOCK_TAGS:
+            self._ensure_newline()
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth:
+            return
+        if self._href is not None:
+            self._pending_href_text.append(data)
+            return
+        if self._in_pre:
+            self._parts.append(data)
+            return
+        # Collapse runs of whitespace outside pre/code blocks
+        if not data.strip():
+            if data and self._parts and not self._parts[-1].endswith(("\n", " ", "\t")):
+                self._parts.append(" ")
+            return
+        collapsed = re.sub(r"[ \t\r\n]+", " ", data)
+        self._parts.append(collapsed)
+
+    def _ensure_newline(self) -> None:
+        if self._parts and not self._parts[-1].endswith("\n"):
+            self._parts.append("\n")
+
+    def _ensure_blank_line(self) -> None:
+        if not self._parts:
+            return
+        text = "".join(self._parts)
+        if not text.endswith("\n\n"):
+            if text.endswith("\n"):
+                self._parts.append("\n")
+            else:
+                self._parts.append("\n\n")
+
+    def get_markdown(self) -> str:
+        return "".join(self._parts)
+
+
+def html_to_markdown(raw_html: str) -> str:
+    """Convert Red Hat docs HTML to markdown (stdlib HTMLParser, no extra deps)."""
+    if not raw_html:
+        return ""
+    fragment = _extract_content_html(raw_html)
+    parser = _HtmlToMarkdownParser()
+    try:
+        parser.feed(fragment)
+        parser.close()
+    except Exception:
+        # Best-effort: fall back to stripped text rather than failing the fetch.
+        logger.debug("HTML→markdown parse failed; using stripped text fallback", exc_info=True)
+        text = re.sub(r"(?is)<(script|style).*?>.*?</\1>", "", fragment)
+        text = re.sub(r"(?s)<[^>]+>", " ", text)
+        return html.unescape(re.sub(r"\s+", " ", text)).strip()
+    return parser.get_markdown()
+
+
+def _finalize_doc_result(
+    raw_markdown: str,
+    source_url: str,
+    max_tokens: int | None,
+) -> FetchDocResult:
+    """Clean markdown, gate tokens, and build FetchDocResult."""
+    if raw_markdown.lstrip().startswith("{"):
         try:
-            json.loads(raw)
+            json.loads(raw_markdown)
             raise AnsibleKnowError(
                 "URL appears to be a landing page, not a guide page. "
                 "Use search_docs to find specific guide URLs."
@@ -223,7 +453,7 @@ async def fetch_redhat_doc(
         except json.JSONDecodeError:
             pass
 
-    content, title = clean_redhat_markdown(raw)
+    content, title = clean_redhat_markdown(raw_markdown)
     content = truncate_response(content)
     tokens = _estimate_tokens(content)
 
@@ -237,8 +467,139 @@ async def fetch_redhat_doc(
         "content": content,
         "title": title,
         "tokens": tokens,
-        "source_url": url,
+        "source_url": source_url,
     }
+
+
+async def _http_get_redhat_doc(
+    client: httpx.AsyncClient,
+    url: str,
+) -> httpx.Response:
+    """GET a docs.redhat.com page, rewriting /html/ paths on 404 when needed."""
+    headers = {
+        "Accept": "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8",
+        "User-Agent": USER_AGENT,
+    }
+    resp = await client.get(url, headers=headers, follow_redirects=True, timeout=30.0)
+    if resp.url.host != _RH_DOC_HOST:
+        raise AnsibleKnowError(f"Redirect to unexpected domain: {resp.url.host}")
+
+    if resp.status_code == 404:
+        alternate = _alternate_redhat_doc_url(url)
+        if alternate and alternate != str(resp.url) and alternate != url:
+            logger.info(
+                "docs.redhat.com returned 404 for %s; retrying rewritten URL %s",
+                url, alternate,
+            )
+            resp = await client.get(
+                alternate, headers=headers, follow_redirects=True, timeout=30.0,
+            )
+            if resp.url.host != _RH_DOC_HOST:
+                raise AnsibleKnowError(f"Redirect to unexpected domain: {resp.url.host}")
+
+    return resp
+
+
+async def fetch_redhat_doc_http(
+    url: str,
+    max_tokens: int | None = None,
+    http_client: httpx.AsyncClient | None = None,
+) -> FetchDocResult:
+    """Fetch a docs.redhat.com page over HTTP and convert HTML to markdown.
+
+    Used as a workaround when the Red Hat Documentation MCP server rejects
+    a URL (AAP 2.6/2.7 modular slugs). Stays on docs.redhat.com only.
+    """
+    client = http_client
+    should_close = False
+    if client is None:
+        client = httpx.AsyncClient(timeout=httpx.Timeout(30.0))
+        should_close = True
+
+    try:
+        resp = await _http_get_redhat_doc(client, url)
+    finally:
+        if should_close:
+            await client.aclose()
+
+    if resp.url.host != _RH_DOC_HOST:
+        raise AnsibleKnowError(f"Redirect to unexpected domain: {resp.url.host}")
+
+    if len(resp.content) > _MAX_DOC_FETCH_SIZE:
+        raise AnsibleKnowError(
+            f"Response too large: {len(resp.content)} bytes (max {_MAX_DOC_FETCH_SIZE})"
+        )
+
+    try:
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        raise AnsibleKnowError(
+            f"docs.redhat.com returned HTTP {exc.response.status_code} for {url}"
+        ) from exc
+
+    content_type = resp.headers.get("content-type", "")
+    body_start = resp.text.lstrip()[:64].lower()
+    looks_like_html = body_start.startswith("<!doctype") or body_start.startswith("<html")
+    if (
+        "text/html" not in content_type
+        and "application/xhtml" not in content_type
+        and not looks_like_html
+    ):
+        raise AnsibleKnowError(
+            f"Expected HTML from docs.redhat.com but got {content_type!r} for {url}"
+        )
+
+    markdown = html_to_markdown(resp.text)
+    if not markdown.strip():
+        raise AnsibleKnowError(f"No convertible documentation content found at {url}")
+
+    return _finalize_doc_result(markdown, str(resp.url), max_tokens)
+
+
+async def fetch_redhat_doc(
+    url: str,
+    max_tokens: int | None = None,
+    client: RedHatDocsClient | None = None,
+    http_client: httpx.AsyncClient | None = None,
+) -> FetchDocResult:
+    """Fetch a docs.redhat.com page via MCP, with HTTP fallback on URL rejection.
+
+    Prefers the Red Hat Documentation MCP server (works for AAP 2.5 and other
+    traditional guide URLs). When MCP rejects the URL as invalid — the known
+    upstream failure for AAP 2.6/2.7 modular slugs — falls back to a direct
+    HTTP fetch + HTML→markdown conversion.
+
+    The caller (Orchestration layer) owns client lifecycles — MCP client via
+    SharedState, optional shared httpx.AsyncClient from lifespan.
+    """
+    if client is None:
+        raise AnsibleKnowError("RedHatDocsClient is required — pass via SharedState")
+
+    try:
+        raw = await client.fetch(url)
+    except AnsibleKnowError as exc:
+        if not _is_mcp_url_rejection(exc):
+            raise
+        logger.warning(
+            "Red Hat Docs MCP rejected URL (upstream URL validation); "
+            "falling back to direct HTTP fetch: %s",
+            url,
+        )
+        return await fetch_redhat_doc_http(
+            url, max_tokens=max_tokens, http_client=http_client,
+        )
+
+    if _is_url_rejection_message(raw):
+        logger.warning(
+            "Red Hat Docs MCP returned URL-rejection content; "
+            "falling back to direct HTTP fetch: %s",
+            url,
+        )
+        return await fetch_redhat_doc_http(
+            url, max_tokens=max_tokens, http_client=http_client,
+        )
+
+    return _finalize_doc_result(raw, url, max_tokens)
 
 
 def _unwrap_mcp_result(raw: str) -> str:

--- a/src/ansible_know/redhat_docs.py
+++ b/src/ansible_know/redhat_docs.py
@@ -47,15 +47,24 @@ _MAX_DOC_FETCH_SIZE = 5_000_000
 _RH_DOC_HOST = "docs.redhat.com"
 
 # Narrow trigger for HTTP fallback: upstream URL validator rejections only.
-# Do not match generic "Invalid URL" / transport errors — MCP-down must surface.
+# Do not match generic "Invalid URL" / unrelated "not a valid … link" text.
 _MCP_URL_REJECTION_RE = re.compile(
-    r"not a valid\b.{0,80}\blink\b"
+    r"not a valid(?:\s+red\s+hat)?\s+documentation\s+link\b"
     r"|invalid\s+(?:red\s+hat\s+)?documentation\s+(?:url|link)\b",
     re.IGNORECASE,
 )
 _HTML_SEGMENT_RE = re.compile(r"/(html(?:-single)?)/")
 _INDEX_SUFFIX_RE = re.compile(r"/index/?$")
-_SOFT_404_RE = re.compile(r"\b404\b.{0,20}\bpage not found\b", re.IGNORECASE)
+# Soft-404 title/H1 only — must not match troubleshooting prose mentioning 404.
+_SOFT_404_TITLE_RE = re.compile(
+    r"^#\s*404\b.{0,40}\bpage not found\b",
+    re.IGNORECASE,
+)
+_HTML_TITLE_RE = re.compile(r"<title[^>]*>([^<]+)</title>", re.IGNORECASE)
+_HTML_SOFT_404_H1_RE = re.compile(
+    r"<h1[^>]*>\s*404\b.{0,40}page\s+not\s+found",
+    re.IGNORECASE,
+)
 
 
 def parse_mcp_sse(body: str) -> dict[str, Any] | None:
@@ -242,6 +251,20 @@ def _is_url_rejection_message(text: str) -> bool:
     return bool(_MCP_URL_REJECTION_RE.search(stripped))
 
 
+def _is_soft_404_markdown(markdown: str) -> bool:
+    """Return True when markdown starts with a not-found H1 (not prose mentions)."""
+    return bool(_SOFT_404_TITLE_RE.match(markdown.lstrip()))
+
+
+def _html_looks_soft_404(html: str) -> bool:
+    """Cheap pre-convert check for RH SPA / soft not-found pages."""
+    head = html[:50_000]
+    title = _HTML_TITLE_RE.search(head)
+    if title and re.search(r"page\s+not\s+found", title.group(1), re.IGNORECASE):
+        return True
+    return bool(_HTML_SOFT_404_H1_RE.search(head))
+
+
 def _alternate_redhat_doc_url(url: str) -> str | None:
     """Return a rewritten docs.redhat.com URL without /html/ or /html-single/.
 
@@ -349,14 +372,14 @@ class _HtmlToMarkdownParser(HTMLParser):
                 self._parts.append(f"{indent}- ")
         elif tag == "pre":
             self._ensure_blank_line()
-            self._parts.append("```\n")
+            self._emit("```\n")
             self._in_pre = True
         elif tag == "code" and not self._in_pre:
-            self._parts.append("`")
+            self._emit("`")
         elif tag in {"strong", "b"}:
-            self._parts.append("**")
+            self._emit("**")
         elif tag in {"em", "i"}:
-            self._parts.append("*")
+            self._emit("*")
         elif tag == "a":
             href = attr_map.get("href", "")
             if href and not href.startswith("#"):
@@ -365,7 +388,7 @@ class _HtmlToMarkdownParser(HTMLParser):
         elif tag == "img":
             alt = attr_map.get("alt", "")
             if alt:
-                self._parts.append(alt)
+                self._emit(alt)
 
     def handle_endtag(self, tag: str) -> None:
         tag = tag.lower()
@@ -375,26 +398,29 @@ class _HtmlToMarkdownParser(HTMLParser):
             return
 
         if tag in {"h1", "h2", "h3", "h4", "h5", "h6", "p"}:
-            self._parts.append("\n\n")
+            self._emit("\n\n")
         elif tag in {"ul", "ol"}:
             if self._list_stack:
                 self._list_stack.pop()
             if self._ol_index:
                 self._ol_index.pop()
-            self._parts.append("\n")
+            self._emit("\n")
         elif tag == "li":
-            self._parts.append("\n")
+            self._emit("\n")
         elif tag == "pre":
-            if not self._parts or not self._parts[-1].endswith("\n"):
-                self._parts.append("\n")
-            self._parts.append("```\n\n")
+            if self._href is not None:
+                if not "".join(self._pending_href_text).endswith("\n"):
+                    self._emit("\n")
+            elif not self._parts or not self._parts[-1].endswith("\n"):
+                self._emit("\n")
+            self._emit("```\n\n")
             self._in_pre = False
         elif tag == "code" and not self._in_pre:
-            self._parts.append("`")
+            self._emit("`")
         elif tag in {"strong", "b"}:
-            self._parts.append("**")
+            self._emit("**")
         elif tag in {"em", "i"}:
-            self._parts.append("*")
+            self._emit("*")
         elif tag == "a" and self._href is not None:
             label = "".join(self._pending_href_text).strip() or self._href
             self._parts.append(f"[{label}]({self._href})")
@@ -406,19 +432,28 @@ class _HtmlToMarkdownParser(HTMLParser):
     def handle_data(self, data: str) -> None:
         if self._skip_depth:
             return
-        if self._href is not None:
-            self._pending_href_text.append(data)
-            return
         if self._in_pre:
-            self._parts.append(data)
+            self._emit(data)
             return
         # Collapse runs of whitespace outside pre/code blocks
         if not data.strip():
+            if self._href is not None:
+                pending = "".join(self._pending_href_text)
+                if data and pending and not pending.endswith(("\n", " ", "\t")):
+                    self._emit(" ")
+                return
             if data and self._parts and not self._parts[-1].endswith(("\n", " ", "\t")):
-                self._parts.append(" ")
+                self._emit(" ")
             return
         collapsed = re.sub(r"[ \t\r\n]+", " ", data)
-        self._parts.append(collapsed)
+        self._emit(collapsed)
+
+    def _emit(self, text: str) -> None:
+        """Append to link buffer while inside ``<a>``, else to output parts."""
+        if self._href is not None:
+            self._pending_href_text.append(text)
+        else:
+            self._parts.append(text)
 
     def _ensure_newline(self) -> None:
         if self._parts and not self._parts[-1].endswith("\n"):
@@ -492,59 +527,51 @@ def _finalize_doc_result(
     }
 
 
+def _assert_redhat_host(resp: httpx.Response) -> None:
+    if resp.url.host != _RH_DOC_HOST:
+        raise AnsibleKnowError(f"Redirect to unexpected domain: {resp.url.host}")
+
+
+async def _http_get_once(
+    client: httpx.AsyncClient,
+    url: str,
+    headers: dict[str, str],
+) -> httpx.Response:
+    resp = await client.get(url, headers=headers, follow_redirects=True, timeout=30.0)
+    _assert_redhat_host(resp)
+    return resp
+
+
 async def _http_get_redhat_doc(
     client: httpx.AsyncClient,
     url: str,
 ) -> httpx.Response:
-    """GET a docs.redhat.com page, rewriting /html/ paths on 404 when needed."""
+    """GET a docs.redhat.com page, rewriting /html/ on status or soft 404."""
     headers = {
         "Accept": "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8",
         "User-Agent": USER_AGENT,
     }
-    resp = await client.get(url, headers=headers, follow_redirects=True, timeout=30.0)
-    if resp.url.host != _RH_DOC_HOST:
-        raise AnsibleKnowError(f"Redirect to unexpected domain: {resp.url.host}")
+    resp = await _http_get_once(client, url, headers)
 
-    if resp.status_code == 404:
-        alternate = _alternate_redhat_doc_url(url)
-        if alternate and alternate != str(resp.url) and alternate != url:
-            logger.info(
-                "docs.redhat.com returned 404 for %s; retrying rewritten URL %s",
-                url, alternate,
-            )
-            resp = await client.get(
-                alternate, headers=headers, follow_redirects=True, timeout=30.0,
-            )
-            if resp.url.host != _RH_DOC_HOST:
-                raise AnsibleKnowError(f"Redirect to unexpected domain: {resp.url.host}")
+    needs_rewrite = resp.status_code == 404 or (
+        resp.status_code == 200 and _html_looks_soft_404(resp.text)
+    )
+    if not needs_rewrite:
+        return resp
 
-    return resp
+    alternate = _alternate_redhat_doc_url(url)
+    if not alternate or alternate == url or alternate == str(resp.url):
+        return resp
+
+    logger.info(
+        "docs.redhat.com returned not-found for %s; retrying rewritten URL %s",
+        url, alternate,
+    )
+    return await _http_get_once(client, alternate, headers)
 
 
-async def fetch_redhat_doc_http(
-    url: str,
-    max_tokens: int | None = None,
-    http_client: httpx.AsyncClient | None = None,
-) -> FetchDocResult:
-    """Fetch a docs.redhat.com page over HTTP and convert HTML to markdown.
-
-    Used as a workaround when the Red Hat Documentation MCP server rejects
-    a URL (AAP 2.6/2.7 modular slugs). Stays on docs.redhat.com only.
-    """
-    client = http_client
-    should_close = False
-    if client is None:
-        client = httpx.AsyncClient(timeout=httpx.Timeout(30.0))
-        should_close = True
-
-    try:
-        resp = await _http_get_redhat_doc(client, url)
-    finally:
-        if should_close:
-            await client.aclose()
-
-    if resp.url.host != _RH_DOC_HOST:
-        raise AnsibleKnowError(f"Redirect to unexpected domain: {resp.url.host}")
+def _validate_redhat_http_response(resp: httpx.Response, url: str) -> None:
+    _assert_redhat_host(resp)
 
     if len(resp.content) > _MAX_DOC_FETCH_SIZE:
         raise AnsibleKnowError(
@@ -570,15 +597,39 @@ async def fetch_redhat_doc_http(
             f"Expected HTML from docs.redhat.com but got {content_type!r} for {url}"
         )
 
-    markdown = html_to_markdown(resp.text)
-    if not markdown.strip():
-        raise AnsibleKnowError(f"No convertible documentation content found at {url}")
-    if _SOFT_404_RE.search(markdown[:500]):
-        raise AnsibleKnowError(
-            f"docs.redhat.com returned a not-found page for {url}"
-        )
 
-    return _finalize_doc_result(markdown, str(resp.url), max_tokens)
+async def fetch_redhat_doc_http(
+    url: str,
+    max_tokens: int | None = None,
+    http_client: httpx.AsyncClient | None = None,
+) -> FetchDocResult:
+    """Fetch a docs.redhat.com page over HTTP and convert HTML to markdown.
+
+    Used as a workaround when the Red Hat Documentation MCP server rejects
+    a URL (AAP 2.6/2.7 modular slugs). Stays on docs.redhat.com only.
+    """
+    client = http_client
+    should_close = False
+    if client is None:
+        client = httpx.AsyncClient(timeout=httpx.Timeout(30.0))
+        should_close = True
+
+    try:
+        resp = await _http_get_redhat_doc(client, url)
+        _validate_redhat_http_response(resp, url)
+
+        markdown = html_to_markdown(resp.text)
+        if not markdown.strip():
+            raise AnsibleKnowError(f"No convertible documentation content found at {url}")
+        if _is_soft_404_markdown(markdown):
+            raise AnsibleKnowError(
+                f"docs.redhat.com returned a not-found page for {url}"
+            )
+
+        return _finalize_doc_result(markdown, str(resp.url), max_tokens)
+    finally:
+        if should_close:
+            await client.aclose()
 
 
 async def fetch_redhat_doc(

--- a/src/ansible_know/redhat_docs.py
+++ b/src/ansible_know/redhat_docs.py
@@ -41,20 +41,21 @@ __all__ = [
 _MCP_PROTOCOL_VERSION = "2024-11-05"
 _MAX_RETRIES = 3
 _MAX_RESPONSE_SIZE = 2_000_000  # 2MB
-_MAX_DOC_FETCH_SIZE = 2_000_000  # 2MB — aligned with docs.fetch_doc_content
+# HTML pages are larger than Cloudflare markdown; modular AAP guides are ~1MB,
+# but some html-single books exceed 2MB. Cap below manifests (5MB).
+_MAX_DOC_FETCH_SIZE = 5_000_000
 _RH_DOC_HOST = "docs.redhat.com"
 
 # Narrow trigger for HTTP fallback: upstream URL validator rejections only.
-# Do not match generic transport/timeouts — MCP-down should surface as error.
+# Do not match generic "Invalid URL" / transport errors — MCP-down must surface.
 _MCP_URL_REJECTION_RE = re.compile(
-    r"not a valid\b.{0,80}\blink"
-    r"|invalid\s+(?:red\s+hat\s+)?(?:documentation\s+)?(?:url|link)",
+    r"not a valid\b.{0,80}\blink\b"
+    r"|invalid\s+(?:red\s+hat\s+)?documentation\s+(?:url|link)\b",
     re.IGNORECASE,
 )
 _HTML_SEGMENT_RE = re.compile(r"/(html(?:-single)?)/")
 _INDEX_SUFFIX_RE = re.compile(r"/index/?$")
-_ARTICLE_RE = re.compile(r"<article\b[^>]*>.*?</article>", re.IGNORECASE | re.DOTALL)
-_MAIN_RE = re.compile(r"<main\b[^>]*>.*?</main>", re.IGNORECASE | re.DOTALL)
+_SOFT_404_RE = re.compile(r"\b404\b.{0,20}\bpage not found\b", re.IGNORECASE)
 
 
 def parse_mcp_sse(body: str) -> dict[str, Any] | None:
@@ -258,15 +259,33 @@ def _alternate_redhat_doc_url(url: str) -> str | None:
     return urlunparse(parsed._replace(path=path or "/"))
 
 
+def _extract_tagged_region(raw_html: str, tag: str) -> str | None:
+    """Extract first ``<tag>...</tag>`` region without catastrophic backtracking."""
+    lower = raw_html.lower()
+    start_token = f"<{tag}"
+    close_token = f"</{tag}>"
+    search_from = 0
+    while True:
+        start = lower.find(start_token, search_from)
+        if start < 0:
+            return None
+        after = start + len(start_token)
+        if after < len(raw_html) and raw_html[after] not in " \t\r\n/>":
+            search_from = after
+            continue
+        end = lower.find(close_token, after)
+        if end < 0:
+            return None
+        return raw_html[start:end + len(close_token)]
+
+
 def _extract_content_html(raw_html: str) -> str:
     """Prefer ``<article>`` (then ``<main>``) for conversion; else full document."""
-    match = _ARTICLE_RE.search(raw_html)
-    if match:
-        return match.group(0)
-    match = _MAIN_RE.search(raw_html)
-    if match:
-        return match.group(0)
-    return raw_html
+    return (
+        _extract_tagged_region(raw_html, "article")
+        or _extract_tagged_region(raw_html, "main")
+        or raw_html
+    )
 
 
 class _HtmlToMarkdownParser(HTMLParser):
@@ -408,12 +427,14 @@ class _HtmlToMarkdownParser(HTMLParser):
     def _ensure_blank_line(self) -> None:
         if not self._parts:
             return
-        text = "".join(self._parts)
-        if not text.endswith("\n\n"):
-            if text.endswith("\n"):
-                self._parts.append("\n")
-            else:
-                self._parts.append("\n\n")
+        # Inspect a short suffix only — avoid O(n²) joins on large pages.
+        suffix = "".join(self._parts[-3:])
+        if suffix.endswith("\n\n"):
+            return
+        if suffix.endswith("\n"):
+            self._parts.append("\n")
+        else:
+            self._parts.append("\n\n")
 
     def get_markdown(self) -> str:
         return "".join(self._parts)
@@ -552,6 +573,10 @@ async def fetch_redhat_doc_http(
     markdown = html_to_markdown(resp.text)
     if not markdown.strip():
         raise AnsibleKnowError(f"No convertible documentation content found at {url}")
+    if _SOFT_404_RE.search(markdown[:500]):
+        raise AnsibleKnowError(
+            f"docs.redhat.com returned a not-found page for {url}"
+        )
 
     return _finalize_doc_result(markdown, str(resp.url), max_tokens)
 

--- a/src/ansible_know/redhat_docs.py
+++ b/src/ansible_know/redhat_docs.py
@@ -23,10 +23,10 @@ from urllib.parse import urlparse, urlunparse
 import httpx
 
 from ansible_know.config import REDHAT_DOCS_MCP_URL, USER_AGENT
-from ansible_know.errors import AnsibleKnowError
+from ansible_know.errors import AnsibleKnowError, ValidationError
 from ansible_know.text_utils import clean_redhat_markdown
 from ansible_know.types import FetchDocResult
-from ansible_know.validation import sanitize_error, truncate_response
+from ansible_know.validation import sanitize_error, truncate_response, validate_doc_url
 
 logger = logging.getLogger("ansible_know")
 
@@ -322,6 +322,30 @@ def _extract_content_html(raw_html: str) -> str:
     )
 
 
+def _format_markdown_link(label: str, href: str) -> str:
+    """Build a CommonMark link, escaping delimiters; drop unsafe schemes."""
+    href = href.strip()
+    label = label.strip() or href
+    if not href:
+        return label
+
+    parsed = urlparse(href)
+    scheme = (parsed.scheme or "").lower()
+    if scheme and scheme not in {"http", "https"}:
+        # javascript:/data:/mailto: etc. — keep visible text only
+        return label
+    if href.startswith("//"):
+        return label
+
+    safe_label = (
+        label.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
+    )
+    safe_href = href.replace("\\", "\\\\").replace(")", "\\)")
+    if re.search(r"\s", safe_href):
+        return f"[{safe_label}](<{safe_href}>)"
+    return f"[{safe_label}]({safe_href})"
+
+
 class _HtmlToMarkdownParser(HTMLParser):
     """Minimal HTML→Markdown converter for Red Hat docs article markup."""
 
@@ -434,7 +458,7 @@ class _HtmlToMarkdownParser(HTMLParser):
             self._emit("*")
         elif tag == "a" and self._href is not None:
             label = "".join(self._pending_href_text).strip() or self._href
-            self._parts.append(f"[{label}]({self._href})")
+            self._parts.append(_format_markdown_link(label, self._href))
             self._href = None
             self._pending_href_text = []
         elif tag in self._BLOCK_TAGS:
@@ -619,6 +643,15 @@ async def fetch_redhat_doc_http(
     Used as a workaround when the Red Hat Documentation MCP server rejects
     a URL (AAP 2.6/2.7 modular slugs). Stays on docs.redhat.com only.
     """
+    try:
+        validate_doc_url(url)
+    except ValidationError as exc:
+        raise AnsibleKnowError(str(exc)) from exc
+    if urlparse(url).netloc != _RH_DOC_HOST:
+        raise AnsibleKnowError(
+            "URL must start with https://docs.redhat.com/ for HTTP fallback"
+        )
+
     client = http_client
     should_close = False
     if client is None:

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -584,6 +584,7 @@ async def fetch_doc(
             return await fetch_redhat_doc(
                 url=url, max_tokens=max_tokens,
                 client=_get_shared(ctx).redhat_client,
+                http_client=_get_http_client(ctx),
             )
         else:
             from ansible_know import docs

--- a/tests/integration/test_redhat_docs_live.py
+++ b/tests/integration/test_redhat_docs_live.py
@@ -9,11 +9,13 @@ May require VPN access to docs-mcp.api.redhat.com.
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock
 
 import pytest
 
 from ansible_know.docs import search_docs
-from ansible_know.redhat_docs import RedHatDocsClient
+from ansible_know.errors import AnsibleKnowError
+from ansible_know.redhat_docs import RedHatDocsClient, fetch_redhat_doc
 
 pytestmark = pytest.mark.integration
 
@@ -62,3 +64,28 @@ class TestSearchDocsAapLive:
         results = await search_docs("install", source="aap-2.7")
         assert len(results) > 0
         assert all(r["source"] == "aap-2.7" for r in results)
+
+
+class TestFetchRedhatDocHttpFallbackLive:
+    """Live HTTP fallback for AAP 2.7 modular URLs rejected by RH Docs MCP."""
+
+    @pytest.mark.asyncio
+    async def test_aap27_modular_url_http_fallback(self):
+        """Simulate MCP URL rejection and fetch via docs.redhat.com HTTP."""
+        url = (
+            "https://docs.redhat.com/en/documentation/"
+            "red_hat_ansible_automation_platform/2.7/html/"
+            "install-proc_installing_containerized_aap"
+        )
+        mock_mcp = AsyncMock()
+        mock_mcp.fetch = AsyncMock(
+            side_effect=AnsibleKnowError(
+                "MCP tool redhat_docs_fetch error: "
+                "Not a valid Red Hat Documentation link"
+            )
+        )
+
+        result = await fetch_redhat_doc(url, client=mock_mcp)
+        assert result["title"]
+        assert len(result["content"]) > 100
+        assert "install" in result["content"].lower() or "install" in result["title"].lower()

--- a/tests/test_redhat_docs.py
+++ b/tests/test_redhat_docs.py
@@ -317,6 +317,18 @@ class TestHtmlToMarkdown:
         assert "Skip me" not in md
         assert "Copy link" not in md
 
+    def test_inline_tags_inside_anchor_stay_in_link_label(self):
+        html = (
+            '<article><p>See '
+            '<a href="https://docs.redhat.com/en/docs">'
+            'the <code>install</code> <strong>guide</strong>'
+            "</a>.</p></article>"
+        )
+        md = html_to_markdown(html)
+        assert "[the `install` **guide**](https://docs.redhat.com/en/docs)" in md
+        assert md.count("`") == 2
+        assert "`](" not in md
+
     def test_empty_input(self):
         assert html_to_markdown("") == ""
 
@@ -462,6 +474,22 @@ class TestFetchRedhatDocFallback:
         mock_http.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_unrelated_not_a_valid_link_does_not_fallback(self):
+        mock_client = AsyncMock()
+        mock_client.fetch = AsyncMock(
+            side_effect=AnsibleKnowError("not a valid temporary download link")
+        )
+
+        with patch(
+            "ansible_know.redhat_docs.fetch_redhat_doc_http",
+            new_callable=AsyncMock,
+        ) as mock_http:
+            with pytest.raises(AnsibleKnowError, match="temporary download"):
+                await fetch_redhat_doc(self.AAP27_URL, client=mock_client)
+
+        mock_http.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_http_fallback_rejects_redirect_off_docs_redhat(self):
         mock_http = AsyncMock(spec=httpx.AsyncClient)
         mock_http.get = AsyncMock(
@@ -477,18 +505,63 @@ class TestFetchRedhatDocFallback:
             await fetch_redhat_doc_http(self.AAP27_URL, http_client=mock_http)
 
     @pytest.mark.asyncio
-    async def test_http_fallback_rejects_soft_404_page(self):
+    async def test_http_fallback_soft_404_rewrites_html_segment(self):
+        """HTTP 200 soft-404 on /html/ must retry rewritten slug (AAP 2.7)."""
+        soft_404 = _html_response(
+            "<html><head><title>Page not found | Red Hat Documentation</title></head>"
+            "<main><h1>404: Page not found</h1></main></html>",
+            url=self.AAP27_URL + "/index",
+            status_code=200,
+        )
+        rewritten = (
+            "https://docs.redhat.com/en/documentation/"
+            "red_hat_ansible_automation_platform/2.7/"
+            "install-proc_installing_containerized_aap"
+        )
+        ok = _html_response(
+            "<article><h1>Install containerized AAP</h1>"
+            "<p>Prepared host steps.</p></article>",
+            url=rewritten,
+            status_code=200,
+        )
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(side_effect=[soft_404, ok])
+
+        result = await fetch_redhat_doc_http(self.AAP27_URL, http_client=mock_http)
+
+        assert result["title"] == "Install containerized AAP"
+        assert "Prepared host steps" in result["content"]
+        assert mock_http.get.await_count == 2
+        assert "/html/" not in mock_http.get.await_args_list[1].args[0]
+
+    @pytest.mark.asyncio
+    async def test_http_fallback_rejects_soft_404_without_alternate(self):
+        url = (
+            "https://docs.redhat.com/en/documentation/"
+            "red_hat_ansible_automation_platform/2.7/"
+            "install-proc_installing_containerized_aap"
+        )
         mock_http = AsyncMock(spec=httpx.AsyncClient)
         mock_http.get = AsyncMock(
             return_value=_html_response(
-                "<html><main><h1>404: Page not found</h1><p>missing</p></main></html>",
-                url=self.AAP27_URL,
+                "<html><head><title>Page not found | Red Hat Documentation</title></head>"
+                "<main><h1>404: Page not found</h1></main></html>",
+                url=url,
                 status_code=200,
             )
         )
 
         with pytest.raises(AnsibleKnowError, match="not-found page"):
-            await fetch_redhat_doc_http(self.AAP27_URL, http_client=mock_http)
+            await fetch_redhat_doc_http(url, http_client=mock_http)
+        assert mock_http.get.await_count == 1
+
+    def test_soft_404_detector_ignores_troubleshooting_titles(self):
+        from ansible_know.redhat_docs import _is_soft_404_markdown
+
+        assert _is_soft_404_markdown("# 404: Page not found\n\nMissing.")
+        assert not _is_soft_404_markdown(
+            "# Troubleshooting HTTP 404 page not found errors\n\nDetails."
+        )
 
     @pytest.mark.asyncio
     async def test_http_fallback_rewrites_html_segment_on_404(self):

--- a/tests/test_redhat_docs.py
+++ b/tests/test_redhat_docs.py
@@ -4,13 +4,19 @@ from __future__ import annotations
 
 import json
 import uuid
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 
 from ansible_know.errors import AnsibleKnowError
-from ansible_know.redhat_docs import RedHatDocsClient, parse_mcp_sse
+from ansible_know.redhat_docs import (
+    RedHatDocsClient,
+    fetch_redhat_doc,
+    fetch_redhat_doc_http,
+    html_to_markdown,
+    parse_mcp_sse,
+)
 from ansible_know.text_utils import clean_redhat_markdown
 
 
@@ -276,3 +282,253 @@ class TestCleanRedhatMarkdown:
         content, title = clean_redhat_markdown(raw)
         assert title == ""
         assert "Some content" in content
+
+
+class TestHtmlToMarkdown:
+    """Tests for stdlib HTML→markdown conversion used by HTTP fallback."""
+
+    def test_converts_article_headings_lists_and_code(self):
+        html = """
+        <html><body>
+        <nav>Skip me</nav>
+        <article>
+          <h1>Install containerized AAP</h1>
+          <p>Run the <code>install</code> playbook.</p>
+          <h2>Procedure</h2>
+          <ol>
+            <li>Go to the install directory</li>
+            <li>Run:
+              <pre><code>ansible-playbook -i inventory install</code></pre>
+            </li>
+          </ol>
+          <p>See <a href="https://docs.redhat.com/en/docs">more docs</a>.</p>
+          <button>Copy link</button>
+        </article>
+        </body></html>
+        """
+        md = html_to_markdown(html)
+        assert "# Install containerized AAP" in md
+        assert "## Procedure" in md
+        assert "`install`" in md
+        assert "1. Go to the install directory" in md
+        assert "```" in md
+        assert "ansible-playbook -i inventory install" in md
+        assert "[more docs](https://docs.redhat.com/en/docs)" in md
+        assert "Skip me" not in md
+        assert "Copy link" not in md
+
+    def test_empty_input(self):
+        assert html_to_markdown("") == ""
+
+
+def _html_response(
+    body: str,
+    url: str = "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/install-proc_installing_containerized_aap",
+    status_code: int = 200,
+) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        text=body,
+        headers={"content-type": "text/html;charset=utf-8"},
+        request=httpx.Request("GET", url),
+    )
+
+
+class TestFetchRedhatDocFallback:
+    """MCP-first fetch with narrow HTTP fallback on URL validation rejection."""
+
+    AAP25_URL = (
+        "https://docs.redhat.com/en/documentation/"
+        "red_hat_ansible_automation_platform/2.5/html-single/release_notes"
+    )
+    AAP27_URL = (
+        "https://docs.redhat.com/en/documentation/"
+        "red_hat_ansible_automation_platform/2.7/html/"
+        "install-proc_installing_containerized_aap"
+    )
+
+    @pytest.mark.asyncio
+    async def test_mcp_success_does_not_invoke_http_fallback(self):
+        """AAP 2.5-style URLs that MCP accepts must not hit HTTP fallback."""
+        markdown = "# Release notes\n\nAAP 2.5 content."
+        mock_client = AsyncMock()
+        mock_client.fetch = AsyncMock(return_value=markdown)
+
+        with patch(
+            "ansible_know.redhat_docs.fetch_redhat_doc_http",
+            new_callable=AsyncMock,
+        ) as mock_http:
+            result = await fetch_redhat_doc(self.AAP25_URL, client=mock_client)
+
+        assert result["title"] == "Release notes"
+        assert "AAP 2.5 content" in result["content"]
+        mock_client.fetch.assert_awaited_once_with(self.AAP25_URL)
+        mock_http.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_mcp_url_rejection_falls_back_to_http(self):
+        """Modular AAP 2.7 URL rejected by MCP should use HTTP→markdown path."""
+        mock_client = AsyncMock()
+        mock_client.fetch = AsyncMock(
+            side_effect=AnsibleKnowError(
+                "MCP tool redhat_docs_fetch error: "
+                "Not a valid Red Hat Documentation link"
+            )
+        )
+        article_html = """
+        <article>
+          <h1>Install containerized Ansible Automation Platform</h1>
+          <p>Run the install playbook after preparing the host.</p>
+          <h2>Legal Notice</h2>
+          <p>Copyright boilerplate.</p>
+          <h2>Procedure</h2>
+          <p>Real steps here.</p>
+        </article>
+        """
+        rewritten = (
+            "https://docs.redhat.com/en/documentation/"
+            "red_hat_ansible_automation_platform/2.7/"
+            "install-proc_installing_containerized_aap"
+        )
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_html_response(article_html, url=rewritten),
+        )
+
+        result = await fetch_redhat_doc(
+            self.AAP27_URL, client=mock_client, http_client=mock_http,
+        )
+
+        assert result["title"] == "Install containerized Ansible Automation Platform"
+        assert "Real steps here" in result["content"]
+        assert "Legal Notice" not in result["content"]
+        assert "Copyright boilerplate" not in result["content"]
+        mock_client.fetch.assert_awaited_once_with(self.AAP27_URL)
+        mock_http.get.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_mcp_rejection_content_also_triggers_fallback(self):
+        """URL rejection returned as tool text (not JSON-RPC error) still falls back."""
+        mock_client = AsyncMock()
+        mock_client.fetch = AsyncMock(
+            return_value="Not a valid Red Hat Documentation link"
+        )
+        fallback_result = {
+            "content": "# Guide\n\nBody.",
+            "title": "Guide",
+            "tokens": 3,
+            "source_url": self.AAP27_URL,
+        }
+        with patch(
+            "ansible_know.redhat_docs.fetch_redhat_doc_http",
+            new_callable=AsyncMock,
+            return_value=fallback_result,
+        ) as mock_http:
+            result = await fetch_redhat_doc(self.AAP27_URL, client=mock_client)
+
+        assert result == fallback_result
+        mock_http.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_url_mcp_errors_do_not_fallback(self):
+        """Transport / generic MCP failures must not silently fall back to HTTP."""
+        mock_client = AsyncMock()
+        mock_client.fetch = AsyncMock(
+            side_effect=AnsibleKnowError("MCP fetch failed after 3 retries")
+        )
+
+        with patch(
+            "ansible_know.redhat_docs.fetch_redhat_doc_http",
+            new_callable=AsyncMock,
+        ) as mock_http:
+            with pytest.raises(AnsibleKnowError, match="MCP fetch failed"):
+                await fetch_redhat_doc(self.AAP27_URL, client=mock_client)
+
+        mock_http.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_http_fallback_rejects_redirect_off_docs_redhat(self):
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                text="<html><article><h1>Nope</h1></article></html>",
+                headers={"content-type": "text/html"},
+                request=httpx.Request("GET", "https://evil.example/doc"),
+            )
+        )
+
+        with pytest.raises(AnsibleKnowError, match="unexpected domain"):
+            await fetch_redhat_doc_http(self.AAP27_URL, http_client=mock_http)
+
+    @pytest.mark.asyncio
+    async def test_http_fallback_rewrites_html_segment_on_404(self):
+        """Manifest /html/ URLs that 404 should retry without the segment."""
+        article_html = (
+            "<article><h1>Install containerized AAP</h1>"
+            "<p>Prepared host steps.</p></article>"
+        )
+        rewritten = (
+            "https://docs.redhat.com/en/documentation/"
+            "red_hat_ansible_automation_platform/2.7/"
+            "install-proc_installing_containerized_aap"
+        )
+        not_found = _html_response(
+            "<html><h1>404: Page not found</h1></html>",
+            url=self.AAP27_URL + "/index",
+            status_code=404,
+        )
+        ok = _html_response(article_html, url=rewritten, status_code=200)
+
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(side_effect=[not_found, ok])
+
+        result = await fetch_redhat_doc_http(self.AAP27_URL, http_client=mock_http)
+
+        assert result["title"] == "Install containerized AAP"
+        assert "Prepared host steps" in result["content"]
+        assert mock_http.get.await_count == 2
+        second_url = mock_http.get.await_args_list[1].args[0]
+        assert "/html/" not in second_url
+        assert "install-proc_installing_containerized_aap" in second_url
+
+
+class TestCallToolIsError:
+    """MCP tool isError responses should raise AnsibleKnowError."""
+
+    @pytest.mark.asyncio
+    async def test_is_error_raises(self):
+        error_result = {
+            "jsonrpc": "2.0",
+            "id": str(uuid.uuid4()),
+            "result": {
+                "isError": True,
+                "content": [
+                    {"type": "text", "text": "Not a valid Red Hat Documentation link"},
+                ],
+            },
+        }
+        sse = httpx.Response(
+            200,
+            text=f"data: {json.dumps(error_result)}\n\n",
+            headers={"content-type": "text/event-stream", "mcp-session-id": "s"},
+            request=httpx.Request("POST", "https://docs-mcp.api.redhat.com/mcp"),
+        )
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post = AsyncMock(side_effect=[
+            _make_init_response(),
+            _make_notification_response(),
+            sse,
+        ])
+        mock_client.aclose = AsyncMock()
+
+        client = RedHatDocsClient()
+        client._client = mock_client
+
+        with pytest.raises(AnsibleKnowError, match="Not a valid Red Hat Documentation link"):
+            await client.fetch(
+                "https://docs.redhat.com/en/documentation/"
+                "red_hat_ansible_automation_platform/2.7/html/"
+                "install-proc_installing_containerized_aap"
+            )
+        await client.close()

--- a/tests/test_redhat_docs.py
+++ b/tests/test_redhat_docs.py
@@ -12,6 +12,7 @@ import pytest
 from ansible_know.errors import AnsibleKnowError
 from ansible_know.redhat_docs import (
     RedHatDocsClient,
+    _format_markdown_link,
     fetch_redhat_doc,
     fetch_redhat_doc_http,
     html_to_markdown,
@@ -329,6 +330,29 @@ class TestHtmlToMarkdown:
         assert md.count("`") == 2
         assert "`](" not in md
 
+    def test_escapes_parens_in_href_and_brackets_in_label(self):
+        html = (
+            '<article><a href="https://docs.redhat.com/path_(copy)">'
+            "see [notes]</a></article>"
+        )
+        md = html_to_markdown(html)
+        assert r"[see \[notes\]](https://docs.redhat.com/path_(copy\))" in md
+
+    def test_drops_javascript_href_keeps_label(self):
+        html = '<article><a href="javascript:alert(1)">click</a></article>'
+        md = html_to_markdown(html)
+        assert "javascript:" not in md
+        assert "click" in md
+        assert "](" not in md
+
+    def test_keeps_relative_https_style_paths(self):
+        assert _format_markdown_link("Guide", "/en/documentation/foo") == (
+            "[Guide](/en/documentation/foo)"
+        )
+        assert _format_markdown_link("Guide", "https://docs.redhat.com/x") == (
+            "[Guide](https://docs.redhat.com/x)"
+        )
+
     def test_empty_input(self):
         assert html_to_markdown("") == ""
 
@@ -503,6 +527,29 @@ class TestFetchRedhatDocFallback:
 
         with pytest.raises(AnsibleKnowError, match="unexpected domain"):
             await fetch_redhat_doc_http(self.AAP27_URL, http_client=mock_http)
+
+    @pytest.mark.asyncio
+    async def test_http_fallback_revalidates_url_before_get(self):
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock()
+
+        with pytest.raises(AnsibleKnowError, match="docs.redhat.com|docs.ansible.com"):
+            await fetch_redhat_doc_http(
+                "https://evil.example/doc", http_client=mock_http,
+            )
+        mock_http.get.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_http_fallback_rejects_ansible_com_url(self):
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock()
+
+        with pytest.raises(AnsibleKnowError, match="docs.redhat.com"):
+            await fetch_redhat_doc_http(
+                "https://docs.ansible.com/projects/ansible/latest/",
+                http_client=mock_http,
+            )
+        mock_http.get.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_http_fallback_soft_404_rewrites_html_segment(self):

--- a/tests/test_redhat_docs.py
+++ b/tests/test_redhat_docs.py
@@ -559,9 +559,33 @@ class TestFetchRedhatDocFallback:
         from ansible_know.redhat_docs import _is_soft_404_markdown
 
         assert _is_soft_404_markdown("# 404: Page not found\n\nMissing.")
+        assert _is_soft_404_markdown(
+            "Cloud Image\n\n# 404: Page not found\n\nMissing."
+        )
         assert not _is_soft_404_markdown(
             "# Troubleshooting HTTP 404 page not found errors\n\nDetails."
         )
+
+    @pytest.mark.asyncio
+    async def test_http_fallback_rejects_soft_404_with_leading_img_alt(self):
+        """RH soft-404 pages often emit img alt text before the 404 H1."""
+        url = (
+            "https://docs.redhat.com/en/documentation/"
+            "red_hat_ansible_automation_platform/2.7/"
+            "install-proc_installing_containerized_aap"
+        )
+        html = (
+            "<html><head><title>Page not found | Red Hat Documentation</title></head>"
+            '<body><img alt="Cloud Image">'
+            "<main><h1>404: Page not found</h1><p>missing</p></main></body></html>"
+        )
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_html_response(html, url=url, status_code=200)
+        )
+
+        with pytest.raises(AnsibleKnowError, match="not-found page"):
+            await fetch_redhat_doc_http(url, http_client=mock_http)
 
     @pytest.mark.asyncio
     async def test_http_fallback_rewrites_html_segment_on_404(self):

--- a/tests/test_redhat_docs.py
+++ b/tests/test_redhat_docs.py
@@ -447,6 +447,21 @@ class TestFetchRedhatDocFallback:
         mock_http.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_generic_invalid_url_error_does_not_fallback(self):
+        """Bare 'Invalid URL' must not trigger HTTP fallback (too broad)."""
+        mock_client = AsyncMock()
+        mock_client.fetch = AsyncMock(side_effect=AnsibleKnowError("Invalid URL"))
+
+        with patch(
+            "ansible_know.redhat_docs.fetch_redhat_doc_http",
+            new_callable=AsyncMock,
+        ) as mock_http:
+            with pytest.raises(AnsibleKnowError, match="Invalid URL"):
+                await fetch_redhat_doc(self.AAP27_URL, client=mock_client)
+
+        mock_http.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_http_fallback_rejects_redirect_off_docs_redhat(self):
         mock_http = AsyncMock(spec=httpx.AsyncClient)
         mock_http.get = AsyncMock(
@@ -459,6 +474,20 @@ class TestFetchRedhatDocFallback:
         )
 
         with pytest.raises(AnsibleKnowError, match="unexpected domain"):
+            await fetch_redhat_doc_http(self.AAP27_URL, http_client=mock_http)
+
+    @pytest.mark.asyncio
+    async def test_http_fallback_rejects_soft_404_page(self):
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_html_response(
+                "<html><main><h1>404: Page not found</h1><p>missing</p></main></html>",
+                url=self.AAP27_URL,
+                status_code=200,
+            )
+        )
+
+        with pytest.raises(AnsibleKnowError, match="not-found page"):
             await fetch_redhat_doc_http(self.AAP27_URL, http_client=mock_http)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **Workaround for upstream RH Docs MCP URL validation** — `docs-mcp.api.redhat.com` `redhat_docs_fetch` still rejects AAP 2.6/2.7 modular guide slugs (`Not a valid Red Hat Documentation link`). This PR does **not** fix upstream.
- Prefer MCP first (AAP 2.5 / working URLs unchanged). On narrow URL-validation rejections only, fall back to direct `docs.redhat.com` HTTP fetch + stdlib HTML→markdown, then `clean_redhat_markdown`.
- On HTTP 404 for manifest `/html/` or `/html-single/` paths, retry the rewritten `/{version}/{slug}` URL (needed for AAP 2.7). Reject redirects off `docs.redhat.com`; reuse lifespan httpx client when available.

## Test plan
- [x] `pytest tests/test_redhat_docs.py tests/test_server.py -k 'fetch_doc or redhat or RedHat' -q` (33 passed)
- [x] `ruff check` on touched files
- [ ] Optional live: `pytest tests/integration/test_redhat_docs_live.py --run-integration`
- [ ] Manual: `search_docs(source="aap-2.7")` then `fetch_doc` on a modular guide URL → markdown via fallback
- [ ] Manual: AAP 2.5 URL still uses MCP only when MCP succeeds

Closes #183

Assisted-by: Cursor (Grok 4.5)