### PR TITLE
fix: keep skill tool path resolve off event loop (#208)

### DIFF
--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -865,7 +865,12 @@ async def list_skills(
         from ansible_know.config import get_skills_dirs
         from ansible_know.skills import list_skills_sync
 
-        return await run_in_executor(list_skills_sync, get_skills_dirs(), collection)
+        # Include get_skills_dirs() in the executor: async tools always run on
+        # the event loop (FastMCP run_in_thread applies to sync tools only).
+        def _list_skills() -> list[SkillEntry]:
+            return list_skills_sync(get_skills_dirs(), collection)
+
+        return await run_in_executor(_list_skills)
     except Exception as exc:
         logger.warning("list_skills failed: %s", exc)
         return {"error": sanitize_error(str(exc))}
@@ -896,7 +901,11 @@ async def get_skill(
         from ansible_know.config import get_skills_dirs
         from ansible_know.skills import get_skill_sync
 
-        return await run_in_executor(get_skill_sync, get_skills_dirs(), skill_name)
+        # Path resolution (get_skills_dirs) + FS read must stay off the event loop.
+        def _read_skill() -> str:
+            return get_skill_sync(get_skills_dirs(), skill_name)
+
+        return await run_in_executor(_read_skill)
     except FileNotFoundError as exc:
         return {"error": str(exc)}
     except ValidationError as exc:

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -1175,7 +1175,7 @@ class TestSearchCollectionsEdgeCases:
             return {"download_count": 100, "highest_version": {"version": "1.0.0"}}
 
         with _mock_search_context(mock_api_get):
-            client = GalaxyClient()
+            client = _skip_discovery(GalaxyClient())
             result = await client.search_collections("test")
 
         assert result["count"] == 1
@@ -1207,7 +1207,7 @@ class TestSearchCollectionsEdgeCases:
             return {"download_count": 0, "highest_version": {"version": "1.0.0"}}
 
         with _mock_search_context(mock_api_get):
-            client = GalaxyClient()
+            client = _skip_discovery(GalaxyClient())
             result = await client.search_collections("test")
 
         assert result["collections"][0]["tags"] == ["valid"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -574,6 +574,70 @@ class TestSkillNameValidation:
         assert "error" in result
 
 
+class TestSkillToolsExecutorAffinity:
+    """Async tools are not FastMCP-threadpooled; path resolve must stay in executor."""
+
+    @pytest.mark.asyncio
+    async def test_list_skills_resolves_dirs_via_executor(self, tmp_path, monkeypatch):
+        import threading
+
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        import ansible_know.config as config
+        import ansible_know.server as srv
+
+        main_thread = threading.current_thread()
+        real_get_dirs = config.get_skills_dirs
+
+        def tracking_get_dirs():
+            assert threading.current_thread() is not main_thread, (
+                "get_skills_dirs ran on the event-loop thread"
+            )
+            return real_get_dirs()
+
+        with (
+            patch(
+                "ansible_know.server.run_in_executor",
+                wraps=srv.run_in_executor,
+            ) as mock_rie,
+            patch("ansible_know.config.get_skills_dirs", side_effect=tracking_get_dirs),
+        ):
+            result = await srv.list_skills()
+
+        mock_rie.assert_called_once()
+        assert mock_rie.call_args.args[0].__name__ == "_list_skills"
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_skill_resolves_dirs_via_executor(self, tmp_path, monkeypatch):
+        import threading
+
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        import ansible_know.config as config
+        import ansible_know.server as srv
+
+        main_thread = threading.current_thread()
+        real_get_dirs = config.get_skills_dirs
+
+        def tracking_get_dirs():
+            assert threading.current_thread() is not main_thread, (
+                "get_skills_dirs ran on the event-loop thread"
+            )
+            return real_get_dirs()
+
+        with (
+            patch(
+                "ansible_know.server.run_in_executor",
+                wraps=srv.run_in_executor,
+            ) as mock_rie,
+            patch("ansible_know.config.get_skills_dirs", side_effect=tracking_get_dirs),
+        ):
+            result = await srv.get_skill("ansible.builtin.copy")
+
+        mock_rie.assert_called_once()
+        assert mock_rie.call_args.args[0].__name__ == "_read_skill"
+        assert "error" in result
+
+
 class TestGetSkillSync:
     def test_returns_content_for_namespace_skill(self, tmp_path):
         from ansible_know.skills import get_skill_sync
@@ -994,6 +1058,37 @@ class TestResourceFunctions:
         mock_rie.assert_called_once()
         assert mock_rie.call_args.args[0].__name__ == "_list_skill_names"
         assert result == []
+
+    @pytest.mark.asyncio
+    async def test_resource_skill_content_resolves_dirs_via_executor(self, tmp_path, monkeypatch):
+        """get_skills_dirs() must not run on the event loop (async drops FastMCP offload)."""
+        import threading
+
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+        import ansible_know.config as config
+        import ansible_know.server as srv
+
+        main_thread = threading.current_thread()
+        real_get_dirs = config.get_skills_dirs
+
+        def tracking_get_dirs():
+            assert threading.current_thread() is not main_thread, (
+                "get_skills_dirs ran on the event-loop thread"
+            )
+            return real_get_dirs()
+
+        with (
+            patch(
+                "ansible_know.server.run_in_executor",
+                wraps=srv.run_in_executor,
+            ) as mock_rie,
+            patch("ansible_know.config.get_skills_dirs", side_effect=tracking_get_dirs),
+        ):
+            result = await srv.resource_skill_content("ansible.builtin.copy")
+
+        mock_rie.assert_called_once()
+        assert mock_rie.call_args.args[0].__name__ == "_read_skill"
+        assert "not found" in result.lower()
 
     @pytest.mark.asyncio
     async def test_resource_skill_content_not_found(self, tmp_path, monkeypatch):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -579,6 +579,7 @@ class TestSkillToolsExecutorAffinity:
 
     @pytest.mark.asyncio
     async def test_list_skills_resolves_dirs_via_executor(self, tmp_path, monkeypatch):
+        """get_skills_dirs() must not run on the event loop (async tools skip FastMCP offload)."""
         import threading
 
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
@@ -609,6 +610,7 @@ class TestSkillToolsExecutorAffinity:
 
     @pytest.mark.asyncio
     async def test_get_skill_resolves_dirs_via_executor(self, tmp_path, monkeypatch):
+        """get_skills_dirs() must not run on the event loop (async tools skip FastMCP offload)."""
         import threading
 
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)


### PR DESCRIPTION
## Summary

- Move `get_skills_dirs()` into `run_in_executor` closures for `list_skills` / `get_skill` (same leftover pattern as #205 skill resources; async FastMCP tools are not auto-threadpooled).
- Add thread-affinity coverage for those tools plus a twin for `skills://{skill_name}`.
- Skip Galaxy API discovery in two search edge-case mocks that otherwise hit real HTTP / `ansible.cfg` (deferred from #205).

Closes #208

## Test plan

- [x] Affinity tests fail before tool fix (`get_skills_dirs` on event-loop thread), pass after
- [x] `test_resource_skill_content_resolves_dirs_via_executor` passes
- [x] `TestSearchCollectionsEdgeCases` passes offline without discovery network
- [x] `pytest tests/test_server.py tests/test_galaxy.py::TestSearchCollectionsEdgeCases` — 178 passed
- [x] `ruff check` clean on touched files
- [x] Bugbot + code-reviewer: no Critical/Important findings

Assisted-by: Cursor (Grok 4.5)