### PR TITLE
feat: Lola-compatible packaging helper (#149)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Runtime requirement: `ansible-core` must be installed in the same environment (f
 
 ```
 src/ansible_know/
-├── server.py              # FastMCP server: 18 tools, 6 resources, 5 prompts (entrypoint)
+├── server.py              # FastMCP server: 19 tools, 6 resources, 5 prompts (entrypoint)
 ├── parser.py              # ansible-doc wrapper — module discovery and metadata extraction
 ├── resolution.py          # local-then-Galaxy doc resolution + multi-server search
 ├── readme_parser.py       # Parse Galaxy role README HTML into structured data
@@ -57,6 +57,7 @@ src/ansible_know/
 | `generate_plugin_skill` | idempotent write | Generate a skill package for one plugin |
 | `generate_role_skill` | idempotent write | Generate a skill package for one role |
 | `generate_collection_skills` | idempotent write | Batch generate skills for a collection |
+| `package_for_lola` | idempotent write | Wrap generated skills into a Lola module directory |
 | `clear_cache` | idempotent write | Clear Galaxy and/or doc manifest caches |
 
 ## MCP Resources

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Together with [Ansible Devtools MCP](https://github.com/ansible/ansible-dev-tool
  | generate_plugin_skill      |  |                          |  |              |
  | generate_collection_skills |  |                          |  |              |
  | list_skills / get_skill    |  |                          |  |              |
+ | package_for_lola           |  |                          |  |              |
  | clear_cache                |  |                          |  |              |
  |                            |  |                          |  |              |
  | LEARN                      |  | CREATE + TEST            |  | DEPLOY       |
@@ -261,6 +262,7 @@ claude mcp add ansible-know --transport http https://know.ansible.ar/mcp
 | `generate_role_skill(role_name, install_to?)` | Generate a skill package for one role |
 | `generate_plugin_skill(plugin_name, plugin_type, install_to?)` | Generate a skill package for one plugin |
 | `generate_collection_skills(collection_namespace, install_to?)` | Batch generate skills for an entire collection |
+| `package_for_lola(collection, output_dir, source_dir?, module_name?, write_market_yml?)` | Wrap generated skills into a Lola module directory (Layer 2 packaging; does not change `generate_*` layout) |
 
 ### Maintenance
 

--- a/docs/architecture/adr/0007-agentskills-spec-compliance.md
+++ b/docs/architecture/adr/0007-agentskills-spec-compliance.md
@@ -116,11 +116,11 @@ gap, not a spec violation on our side.
 We propose patching next-mcp's `_loadLocalSource` to scan 2+ levels,
 citing the spec. This benefits all skill producers that use namespace grouping.
 
-### Lola packaging is a user concern
+### Lola packaging is a packaging concern (not a generation format)
 
 Lola is a distribution channel, not a generation format. Our spec-compliant
-output can be wrapped into a Lola module by the user as a packaging step.
-No special output mode needed.
+output is wrapped into a Lola module as a separate packaging step
+(``package_for_lola`` / #149). No special ``generate_*`` output mode.
 
 ## Consequences
 

--- a/docs/architecture/adr/0008-three-layer-distribution.md
+++ b/docs/architecture/adr/0008-three-layer-distribution.md
@@ -69,8 +69,8 @@ Two consumption paths:
   (`skills/{collection}/{module}/SKILL.md`) is **not** Lola layout —
   wrap via #149 (or equivalent) before relying on GitHub Lola loading.
   Vercel/generic GitHub loaders remain 1-level.
-- **Lola:** Users wrap skills into a Lola module and distribute to
-  40+ agents via `lola install` (#149).
+- **Lola:** Wrap generated skills with ``package_for_lola`` (#149), then
+  distribute to 40+ agents via `lola install` / marketplace.
 
 **Value:** Persistence, sharing, version control, cross-agent reach.
 

--- a/docs/architecture/adr/0008-three-layer-distribution.md
+++ b/docs/architecture/adr/0008-three-layer-distribution.md
@@ -126,7 +126,9 @@ would break. Spec compliance makes the layers possible.
   Alignment details:
   [`docs/superpowers/specs/2026-08-02-skill-discoverability-alignment.md`](../../superpowers/specs/2026-08-02-skill-discoverability-alignment.md)
 - **Layer 2** (repository): generated skills pushed to a GitHub repo;
-  Lola packaging is a separate user concern (#149).
+  Lola packaging via MCP tool ``package_for_lola`` / Domain
+  ``package_collection_for_lola`` (#149) — wrap only; does not change
+  ``generate_*`` layout (ADR-0007).
 - **Layer 3** (remote): FastMCP HTTP/SSE transport (see ADR-0001). Not
   yet implemented — requires hosting, auth, and monitoring infrastructure
   (#71).

--- a/docs/architecture/project-strategy.md
+++ b/docs/architecture/project-strategy.md
@@ -132,8 +132,8 @@ Cross-agent AI skill package manager by Red Hat Product Security.
 
 - **Repo:** `github.com/LobsterTrap/lola`
 - **Marketplace:** `github.com/RedHatProductSecurity/lola-market`
-- **Relationship:** Distribution channel. Users wrap our spec-compliant skills into Lola modules for cross-agent installation (40+ agents).
-- **Not a generation format** — Lola packaging is a user's distribution step, not our output format.
+- **Relationship:** Distribution channel. Wrap our spec-compliant skills with MCP tool ``package_for_lola`` (#149) into Lola modules for cross-agent installation (40+ agents).
+- **Not a generation format** — Lola packaging is a post-generate wrap step, not a `generate_*` output mode.
 
 ### agentskills.io
 

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -57,7 +57,7 @@ decorated tool, resource, and prompt handler functions. FastMCP manages:
 
 | Element | File | Registration |
 |---------|------|--------------|
-| 18 tool handlers | `server.py` | `@mcp.tool(annotations=ToolAnnotations(...))` |
+| 19 tool handlers | `server.py` | `@mcp.tool(annotations=ToolAnnotations(...))` |
 | 6 resource handlers | `server.py` | `@mcp.resource(uri, ...)` |
 | 5 prompt handlers | `server.py` | `@mcp.prompt` |
 | Lifespan hook | `server.py` | `@lifespan` decorator on `app_lifespan()` |

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -105,7 +105,7 @@ business logic. Domain modules are imported lazily to avoid loading
 | Domain Module | Functions Called | File |
 |---------------|----------------|------|
 | `parser` | `search_modules()`, `get_module_doc()`, `get_module_docs()`, `load_module_metadata_batch()`, `get_plugin_doc()`, `get_plugin_docs()`, `load_plugin_metadata_batch()`, `get_role_doc()`, `list_roles()`, `extract_module_metadata()`, `extract_role_metadata()` | `parser.py` |
-| `skills` | `render_skill()`, `write_skill_package()`, `render_role_skill()`, `write_role_skill_package()`, `_module_to_skill_name()` | `skills.py` |
+| `skills` | `render_skill()`, `write_skill_package()`, `render_role_skill()`, `write_role_skill_package()`, `package_collection_for_lola()`, `list_skills_sync()`, `get_skill_sync()`, `collection_skill_name()` / `fqcn_to_skill_name()` / related naming helpers | `skills.py` |
 | `collection_manifest` | `generate_manifest()`, `load_cached_manifest()` | `collection_manifest.py` |
 | `docs` | `search_docs()`, `fetch_doc_content()` | `docs.py` |
 | `collections` | `ensure_collection()`, `list_installed()` | `collections.py` |
@@ -118,7 +118,8 @@ business logic. Domain modules are imported lazily to avoid loading
 | Down | `str` (module_name, keyword, namespace) | Primitives, validated by Orchestration |
 | Up | `ModuleMetadata` | `types.py:8-15` — TypedDict |
 | Up | `RoleMetadata` | `types.py:18-23` — TypedDict |
-| Up | `EnsureCollectionResult` | `types.py:43-49` — TypedDict (added in PR #60) |
+| Up | `EnsureCollectionResult` | `types.py` — TypedDict (added in PR #60) |
+| Up | `PackageForLolaResult` | `types.py` — TypedDict (added in #149) |
 | Up | `dict[str, str]` | Search results (module FQCN → description) |
 | Up | `dict[str, Any]` | Raw ansible-doc JSON, manifest dicts |
 | Up | Exceptions | `AnsibleDocError`, `CollectionNotFoundError`, `CollectionInstallError` |

--- a/skills/pr-architecture-review/SKILL.md
+++ b/skills/pr-architecture-review/SKILL.md
@@ -306,7 +306,7 @@ For each finding, report:
 
 ---
 
-## Last reviewed: 2026-07-17
+## Last reviewed: 2026-08-07
 
 ## Revision History
 
@@ -315,3 +315,4 @@ For each finding, report:
 | 2026-06-19 | Initial skill — layer map, 8 review checklists, parallel dispatch model |
 | 2026-06-27 | Updated layer map (added resolution.py, text_utils.py, manifest_builder.py, cli.py). Updated known violations to current state (most fixed). Added Step 9: ADR and strategy compliance (ADRs 0006-0008). Updated state management checklist for SharedState/ServerState/SessionManager/CollectionManager. Made frontmatter agentskills.io spec-compliant. Added revision history. |
 | 2026-07-17 | Added redhat_docs.py to External Access layer map (PR #178). |
+| 2026-08-07 | PR #211 / #149: service-contracts tool count 19 + `PackageForLolaResult`; ADR-0007/0008 note Layer 2 wrap via `package_for_lola` (no new layer-map modules). |

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1,6 +1,6 @@
 """Ansible Know MCP Server.
 
-Provides 17 tools, 6 resources, and 5 prompts for module, role, and plugin discovery,
+Provides 19 tools, 6 resources, and 5 prompts for module, role, and plugin discovery,
 documentation search, Galaxy collection discovery, and skill generation
 via the Model Context Protocol.
 """
@@ -36,6 +36,7 @@ from ansible_know.types import (
     GetRoleDocResult,
     ManifestResult,
     ModuleMetadata,
+    PackageForLolaResult,
     PluginManifestInput,
     PluginMetadata,
     SearchDocsEntry,
@@ -50,6 +51,7 @@ from ansible_know.validation import (
     validate_fqcn,
     validate_install_path,
     validate_keyword,
+    validate_lola_module_name,
     validate_namespace,
     validate_plugin_type,
     validate_query,
@@ -1414,6 +1416,85 @@ async def generate_collection_skills(
     except Exception as exc:
         logger.warning("generate_collection_skills failed: %s", exc)
         return {"error": maybe_add_hint(sanitize_error(str(exc)), collection_namespace)}
+
+
+@mcp.tool(annotations=ToolAnnotations(idempotentHint=True, readOnlyHint=False, destructiveHint=False))
+async def package_for_lola(
+    collection: Annotated[
+        str,
+        "Collection namespace whose generated skills to wrap (e.g. 'netbox.netbox').",
+    ],
+    output_dir: Annotated[
+        str,
+        "Parent directory where the Lola module directory will be created "
+        "(e.g. '.' or '/tmp/lola-modules').",
+    ],
+    source_dir: Annotated[
+        str | None,
+        "Optional skills root to read from. Defaults to ANSIBLE_KNOW_SKILLS_PATH "
+        "or SKILLS_DIR (same roots as list_skills).",
+    ] = None,
+    module_name: Annotated[
+        str | None,
+        "Optional Lola module directory name. Defaults to "
+        "'ansible-{collection-kebab}' (e.g. 'ansible-netbox-netbox').",
+    ] = None,
+    write_market_yml: Annotated[
+        bool,
+        "When true (default), write lola-market.yml with collection metadata "
+        "beside the module skills/ tree.",
+    ] = True,
+) -> PackageForLolaResult | ErrorResponse:
+    """Wrap already-generated skills into a Lola-compatible module directory.
+
+    Does not change ``generate_*`` output layout. Copies
+    ``skills/{collection}/{skill}/`` into ``{output_dir}/{module}/skills/{skill}/``
+    for marketplace / ``lola mod add`` use.
+
+    Returns: {"collection", "module_name", "module_dir", "skill_count", "skills",
+    "market_yml"} or {"error": str} on failure.
+    """
+    logger.info(
+        "package_for_lola collection=%r output_dir=%r source_dir=%r module_name=%r",
+        collection,
+        output_dir,
+        source_dir,
+        module_name,
+    )
+    try:
+        validate_namespace(collection)
+        validate_install_path(output_dir)
+        if source_dir:
+            validate_install_path(source_dir)
+        if module_name:
+            validate_lola_module_name(module_name)
+    except ValidationError as exc:
+        return {"error": str(exc)}
+
+    try:
+        from ansible_know.config import get_skills_dirs
+        from ansible_know.skills import package_collection_for_lola
+
+        def _package() -> PackageForLolaResult:
+            skills_dirs = (
+                [validate_install_path(source_dir)] if source_dir else get_skills_dirs()
+            )
+            return package_collection_for_lola(
+                skills_dirs,
+                collection,
+                validate_install_path(output_dir),
+                write_market_yml=write_market_yml,
+                module_name=module_name,
+            )
+
+        return await run_in_executor(_package)
+    except FileNotFoundError as exc:
+        return {"error": str(exc)}
+    except ValidationError as exc:
+        return {"error": str(exc)}
+    except Exception as exc:
+        logger.warning("package_for_lola failed: %s", exc)
+        return {"error": sanitize_error(str(exc))}
 
 
 _VALID_CACHE_SCOPES = {"galaxy", "docs"}

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1418,7 +1418,7 @@ async def generate_collection_skills(
         return {"error": maybe_add_hint(sanitize_error(str(exc)), collection_namespace)}
 
 
-@mcp.tool(annotations=ToolAnnotations(idempotentHint=True, readOnlyHint=False, destructiveHint=False))
+@mcp.tool(annotations=ToolAnnotations(idempotentHint=True, readOnlyHint=False, destructiveHint=True))
 async def package_for_lola(
     collection: Annotated[
         str,
@@ -1448,8 +1448,10 @@ async def package_for_lola(
     """Wrap already-generated skills into a Lola-compatible module directory.
 
     Does not change ``generate_*`` output layout. Copies
-    ``skills/{collection}/{skill}/`` into ``{output_dir}/{module}/skills/{skill}/``
-    for marketplace / ``lola mod add`` use.
+    ``skills/{collection-kebab}/{skill}/`` into
+    ``{output_dir}/{module}/skills/{skill}/`` for marketplace /
+    ``lola mod add`` use. Replaces any existing ``skills/`` tree under the
+    target module directory (destructive but idempotent).
 
     Returns: {"collection", "module_name", "module_dir", "skill_count", "skills",
     "market_yml"} or {"error": str} on failure.
@@ -1464,9 +1466,9 @@ async def package_for_lola(
     try:
         validate_namespace(collection)
         validate_install_path(output_dir)
-        if source_dir:
+        if source_dir is not None:
             validate_install_path(source_dir)
-        if module_name:
+        if module_name is not None:
             validate_lola_module_name(module_name)
     except ValidationError as exc:
         return {"error": str(exc)}
@@ -1477,7 +1479,9 @@ async def package_for_lola(
 
         def _package() -> PackageForLolaResult:
             skills_dirs = (
-                [validate_install_path(source_dir)] if source_dir else get_skills_dirs()
+                [validate_install_path(source_dir)]
+                if source_dir is not None
+                else get_skills_dirs()
             )
             return package_collection_for_lola(
                 skills_dirs,
@@ -1489,7 +1493,7 @@ async def package_for_lola(
 
         return await run_in_executor(_package)
     except FileNotFoundError as exc:
-        return {"error": str(exc)}
+        return {"error": sanitize_error(str(exc))}
     except ValidationError as exc:
         return {"error": str(exc)}
     except Exception as exc:

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -852,16 +852,18 @@ def package_collection_for_lola(
     collection_dir_name = collection_dir.name
     collection_skill_md = collection_dir / "SKILL.md"
 
+    has_collection_skill = collection_skill_md.is_file()
+
     # Plan packable skills before mutating any existing Lola module output.
     nested_skill_dirs: list[Path] = []
     for entry in sorted(collection_dir.iterdir()):
         try:
             if not entry.is_dir() or entry.is_symlink():
                 continue
-            if entry.name == collection_dir_name:
-                # Would collide with the collection-level skill dirname.
+            if has_collection_skill and entry.name == collection_dir_name:
+                # Would overwrite the collection-level skill dirname.
                 logger.warning(
-                    "Skipping nested skill %r: name collides with collection dir",
+                    "Skipping nested skill %r: name collides with collection skill",
                     entry.name,
                 )
                 continue
@@ -871,7 +873,6 @@ def package_collection_for_lola(
             logger.warning("Skipping unreadable skill dir %s: %s", entry.name, exc)
             continue
 
-    has_collection_skill = collection_skill_md.is_file()
     if not has_collection_skill and not nested_skill_dirs:
         raise FileNotFoundError(
             f"Collection '{collection_fqcn}' has no SKILL.md packages to wrap."

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -33,6 +33,7 @@ from ansible_know.validation import (
 if TYPE_CHECKING:
     from ansible_know.types import (
         CollectionSkillContext,
+        LolaMarketYml,
         ModuleMetadata,
         ModuleTagEntry,
         PackageForLolaResult,
@@ -737,12 +738,18 @@ def resolve_collection_skills_dir(
     )
 
 
+def _ignore_symlinks(directory: str, names: list[str]) -> list[str]:
+    """Exclude symlink entries so copytree never follows link targets."""
+    base = Path(directory)
+    return [name for name in names if (base / name).is_symlink()]
+
+
 def _copy_skill_tree(src: Path, dest: Path, module_root: Path) -> None:
     """Copy one skill directory into the Lola module, replacing any prior copy."""
     validate_path_containment(dest.resolve(), module_root)
     if dest.exists():
         shutil.rmtree(dest)
-    shutil.copytree(src, dest, symlinks=False)
+    shutil.copytree(src, dest, symlinks=False, ignore=_ignore_symlinks)
 
 
 def _read_collection_version(collection_dir: Path) -> str | None:
@@ -772,7 +779,7 @@ def _write_lola_market_yml(
 ) -> Path:
     """Write optional marketplace metadata beside the Lola module skills tree."""
     namespace, collection_name = split_collection_fqcn(collection_fqcn)
-    payload = {
+    payload: LolaMarketYml = {
         "name": module_name,
         "description": description
         or f"Ansible skills for the {collection_fqcn} collection",
@@ -809,23 +816,67 @@ def package_collection_for_lola(
         {output_dir}/{module_name}/lola-market.yml   # optional
 
     Nested skill directories that contain ``SKILL.md`` are copied with supporting
-    files. A collection-level ``SKILL.md`` is packaged as
-    ``skills/{collection-kebab}/SKILL.md``. ``MANIFEST.json`` is not copied.
+    files (symlink members are skipped). A collection-level ``SKILL.md`` is
+    packaged as ``skills/{collection-kebab}/SKILL.md``. ``MANIFEST.json`` is
+    not copied. Existing ``skills/`` under the module root is replaced.
 
-    Callers MUST validate *collection_fqcn* with ``validate_namespace()`` and
-    *output_dir* / *module_name* with the matching validators first.
-
-    Raises:
-        FileNotFoundError: If the collection has no generated skills, or none
-            of those skills contain a ``SKILL.md``.
-        ValidationError: On path escape or invalid module name.
-        OSError: On filesystem permission or I/O errors.
+    Contract:
+        Preconditions:
+            - Callers MUST validate *collection_fqcn* with
+              ``validate_namespace()`` first.
+            - *output_dir* must be an allowed install path (validated here via
+              ``validate_install_path``).
+            - When *module_name* is not ``None``, it must already be a valid
+              Lola module name (or it is validated here). Empty string is
+              invalid — pass ``None`` for the default name.
+        Raises:
+            FileNotFoundError: If the collection has no generated skills, or
+                none of those skills contain a ``SKILL.md``.
+            ValidationError: On path escape or invalid module name.
+            OSError: On filesystem permission or I/O errors during mkdir,
+                copy, or market-yml write (not silenced).
+        Silences:
+            - Unreadable nested skill dirs (``OSError`` while iterating /
+              copying): logged and skipped; ``skill_count`` may omit them.
+            - Unreadable ``MANIFEST.json`` or collection skill description:
+              logged; version/description fall back to defaults.
     """
     resolved_output = validate_install_path(str(output_dir))
-    lola_name = module_name or default_lola_module_name(collection_fqcn)
+    if module_name is None:
+        lola_name = default_lola_module_name(collection_fqcn)
+    else:
+        lola_name = module_name
     validate_lola_module_name(lola_name)
 
     collection_dir = resolve_collection_skills_dir(skills_dirs, collection_fqcn)
+    collection_dir_name = collection_dir.name
+    collection_skill_md = collection_dir / "SKILL.md"
+
+    # Plan packable skills before mutating any existing Lola module output.
+    nested_skill_dirs: list[Path] = []
+    for entry in sorted(collection_dir.iterdir()):
+        try:
+            if not entry.is_dir() or entry.is_symlink():
+                continue
+            if entry.name == collection_dir_name:
+                # Would collide with the collection-level skill dirname.
+                logger.warning(
+                    "Skipping nested skill %r: name collides with collection dir",
+                    entry.name,
+                )
+                continue
+            if (entry / "SKILL.md").is_file():
+                nested_skill_dirs.append(entry)
+        except OSError as exc:
+            logger.warning("Skipping unreadable skill dir %s: %s", entry.name, exc)
+            continue
+
+    has_collection_skill = collection_skill_md.is_file()
+    if not has_collection_skill and not nested_skill_dirs:
+        raise FileNotFoundError(
+            f"Collection '{collection_fqcn}' has no SKILL.md packages to wrap."
+        )
+
     module_root = (resolved_output / lola_name).resolve()
     validate_path_containment(module_root, resolved_output)
     module_root.mkdir(parents=True, exist_ok=True)
@@ -838,21 +889,15 @@ def package_collection_for_lola(
     validate_path_containment(skills_out.resolve(), module_root)
 
     packaged: list[str] = []
-    collection_dir_name = collection_dir.name
-    collection_skill_md = collection_dir / "SKILL.md"
-    if collection_skill_md.is_file():
+    if has_collection_skill:
         dest = skills_out / collection_dir_name
         dest.mkdir(parents=True, exist_ok=True)
         validate_path_containment(dest.resolve(), module_root)
         shutil.copy2(collection_skill_md, dest / "SKILL.md")
         packaged.append(collection_dir_name)
 
-    for entry in sorted(collection_dir.iterdir()):
+    for entry in nested_skill_dirs:
         try:
-            if not entry.is_dir() or entry.is_symlink():
-                continue
-            if not (entry / "SKILL.md").is_file():
-                continue
             dest = skills_out / entry.name
             _copy_skill_tree(entry, dest, module_root)
             packaged.append(entry.name)

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -7,8 +7,10 @@ Generates SKILL.md skill packages from Ansible module, role, and collection meta
 from __future__ import annotations
 
 import functools
+import json
 import logging
 import re
+import shutil
 import stat
 import threading
 from collections import Counter
@@ -16,12 +18,15 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import yaml
+
 from ansible_know.config import TEMPLATE_DIR
 from ansible_know.tagging import derive_tags
 from ansible_know.validation import (
     split_collection_fqcn,
     truncate_response,
     validate_install_path,
+    validate_lola_module_name,
     validate_path_containment,
 )
 
@@ -30,6 +35,7 @@ if TYPE_CHECKING:
         CollectionSkillContext,
         ModuleMetadata,
         ModuleTagEntry,
+        PackageForLolaResult,
         ParamDict,
         PluginManifestInput,
         SkillEntry,
@@ -45,12 +51,15 @@ _agents_md_lock = threading.Lock()
 __all__ = [
     "PLUGIN_SKILL_DIR_RE",
     "collection_skill_name",
+    "default_lola_module_name",
     "extract_skill_description",
     "fqcn_to_skill_name",
     "get_skill_sync",
     "list_skills_sync",
     "module_to_skill_name",
+    "package_collection_for_lola",
     "plugin_skill_name",
+    "resolve_collection_skills_dir",
     "skill_dir_to_collection_fqcn",
     "skill_dir_to_short_fqcn",
     "render_collection_skill",
@@ -693,3 +702,204 @@ def write_collection_skill_package(
         collection_fqcn, metadata_list, collection_version, plugins_metadata,
     )
     (output_dir / "SKILL.md").write_text(content)
+
+
+# --- Lola packaging (Layer 2 distribution wrap; does not change generate_* layout) ---
+
+
+def default_lola_module_name(collection_fqcn: str) -> str:
+    """Return the default Lola module directory name for a collection FQCN."""
+    return f"ansible-{collection_skill_name(collection_fqcn)}"
+
+
+def resolve_collection_skills_dir(
+    skills_dirs: Path | Sequence[Path],
+    collection_fqcn: str,
+) -> Path:
+    """Locate a generated collection skills directory across skills roots.
+
+    Callers MUST validate *collection_fqcn* with ``validate_namespace()`` first.
+
+    Raises:
+        FileNotFoundError: If no matching collection directory exists.
+        ValidationError: If a resolved path escapes its skills root.
+    """
+    collection_dir_name = collection_skill_name(collection_fqcn)
+    for skills_dir in _normalize_skills_dirs(skills_dirs):
+        if not skills_dir.is_dir():
+            continue
+        collection_dir = (skills_dir / collection_dir_name).resolve()
+        validate_path_containment(collection_dir, skills_dir)
+        if collection_dir.is_dir():
+            return collection_dir
+    raise FileNotFoundError(
+        f"No generated skills found for collection '{collection_fqcn}'."
+    )
+
+
+def _copy_skill_tree(src: Path, dest: Path, module_root: Path) -> None:
+    """Copy one skill directory into the Lola module, replacing any prior copy."""
+    validate_path_containment(dest.resolve(), module_root)
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(src, dest, symlinks=False)
+
+
+def _read_collection_version(collection_dir: Path) -> str | None:
+    """Read ``collection_version`` from MANIFEST.json when present."""
+    manifest_path = collection_dir / "MANIFEST.json"
+    if not manifest_path.is_file():
+        return None
+    try:
+        data = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Ignoring unreadable MANIFEST.json at %s: %s", manifest_path, exc)
+        return None
+    if not isinstance(data, dict):
+        return None
+    version = data.get("collection_version")
+    return version if isinstance(version, str) and version else None
+
+
+def _write_lola_market_yml(
+    module_root: Path,
+    *,
+    module_name: str,
+    collection_fqcn: str,
+    description: str,
+    version: str | None,
+    skill_count: int,
+) -> Path:
+    """Write optional marketplace metadata beside the Lola module skills tree."""
+    namespace, collection_name = split_collection_fqcn(collection_fqcn)
+    payload = {
+        "name": module_name,
+        "description": description
+        or f"Ansible skills for the {collection_fqcn} collection",
+        "version": version or "0.0.0",
+        "collection": collection_fqcn,
+        "skill_count": skill_count,
+        "tags": sorted({"ansible", namespace, collection_name.replace("_", "-")}),
+    }
+    market_path = module_root / "lola-market.yml"
+    validate_path_containment(market_path.resolve(), module_root)
+    market_path.write_text(
+        yaml.safe_dump(payload, default_flow_style=False, sort_keys=False),
+    )
+    return market_path
+
+
+def package_collection_for_lola(
+    skills_dirs: Path | Sequence[Path],
+    collection_fqcn: str,
+    output_dir: Path,
+    *,
+    write_market_yml: bool = True,
+    module_name: str | None = None,
+) -> PackageForLolaResult:
+    """Wrap generated collection skills into a Lola module directory.
+
+    Source layout (unchanged)::
+
+        {skills_dir}/{collection-kebab}/{skill}/SKILL.md
+
+    Target Lola layout::
+
+        {output_dir}/{module_name}/skills/{skill}/SKILL.md
+        {output_dir}/{module_name}/lola-market.yml   # optional
+
+    Nested skill directories that contain ``SKILL.md`` are copied with supporting
+    files. A collection-level ``SKILL.md`` is packaged as
+    ``skills/{collection-kebab}/SKILL.md``. ``MANIFEST.json`` is not copied.
+
+    Callers MUST validate *collection_fqcn* with ``validate_namespace()`` and
+    *output_dir* / *module_name* with the matching validators first.
+
+    Raises:
+        FileNotFoundError: If the collection has no generated skills, or none
+            of those skills contain a ``SKILL.md``.
+        ValidationError: On path escape or invalid module name.
+        OSError: On filesystem permission or I/O errors.
+    """
+    resolved_output = validate_install_path(str(output_dir))
+    lola_name = module_name or default_lola_module_name(collection_fqcn)
+    validate_lola_module_name(lola_name)
+
+    collection_dir = resolve_collection_skills_dir(skills_dirs, collection_fqcn)
+    module_root = (resolved_output / lola_name).resolve()
+    validate_path_containment(module_root, resolved_output)
+    module_root.mkdir(parents=True, exist_ok=True)
+
+    skills_out = module_root / "skills"
+    if skills_out.exists():
+        validate_path_containment(skills_out.resolve(), module_root)
+        shutil.rmtree(skills_out)
+    skills_out.mkdir(parents=True)
+    validate_path_containment(skills_out.resolve(), module_root)
+
+    packaged: list[str] = []
+    collection_dir_name = collection_dir.name
+    collection_skill_md = collection_dir / "SKILL.md"
+    if collection_skill_md.is_file():
+        dest = skills_out / collection_dir_name
+        dest.mkdir(parents=True, exist_ok=True)
+        validate_path_containment(dest.resolve(), module_root)
+        shutil.copy2(collection_skill_md, dest / "SKILL.md")
+        packaged.append(collection_dir_name)
+
+    for entry in sorted(collection_dir.iterdir()):
+        try:
+            if not entry.is_dir() or entry.is_symlink():
+                continue
+            if not (entry / "SKILL.md").is_file():
+                continue
+            dest = skills_out / entry.name
+            _copy_skill_tree(entry, dest, module_root)
+            packaged.append(entry.name)
+        except OSError as exc:
+            logger.warning("Skipping unreadable skill dir %s: %s", entry.name, exc)
+            continue
+
+    if not packaged:
+        raise FileNotFoundError(
+            f"Collection '{collection_fqcn}' has no SKILL.md packages to wrap."
+        )
+
+    description = ""
+    if collection_skill_md.is_file():
+        try:
+            description = extract_skill_description(collection_skill_md)
+        except OSError as exc:
+            logger.warning("Could not read collection skill description: %s", exc)
+
+    market_path = module_root / "lola-market.yml"
+    market_yml_path: str | None = None
+    if write_market_yml:
+        market_yml_path = str(
+            _write_lola_market_yml(
+                module_root,
+                module_name=lola_name,
+                collection_fqcn=collection_fqcn,
+                description=description,
+                version=_read_collection_version(collection_dir),
+                skill_count=len(packaged),
+            )
+        )
+    elif market_path.is_file():
+        validate_path_containment(market_path.resolve(), module_root)
+        market_path.unlink()
+
+    logger.info(
+        "Packaged %d skills for %s into Lola module %s",
+        len(packaged),
+        collection_fqcn,
+        module_root,
+    )
+    return {
+        "collection": collection_fqcn,
+        "module_name": lola_name,
+        "module_dir": str(module_root),
+        "skill_count": len(packaged),
+        "skills": packaged,
+        "market_yml": market_yml_path,
+    }

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -346,6 +346,17 @@ class PackageForLolaResult(TypedDict):
     market_yml: str | None
 
 
+class LolaMarketYml(TypedDict):
+    """Shape written to ``lola-market.yml`` beside a packaged Lola module."""
+
+    name: str
+    description: str
+    version: str
+    collection: str
+    skill_count: int
+    tags: list[str]
+
+
 class _CollectionDocsResultBase(TypedDict):
     """Required fields for batch collection docs result."""
 

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -335,6 +335,17 @@ class ClearCacheResult(TypedDict):
     cleared: list[str]
 
 
+class PackageForLolaResult(TypedDict):
+    """Result of package_for_lola tool / package_collection_for_lola."""
+
+    collection: str
+    module_name: str
+    module_dir: str
+    skill_count: int
+    skills: list[str]
+    market_yml: str | None
+
+
 class _CollectionDocsResultBase(TypedDict):
     """Required fields for batch collection docs result."""
 

--- a/src/ansible_know/validation.py
+++ b/src/ansible_know/validation.py
@@ -20,6 +20,7 @@ __all__ = [
     "validate_fqcn",
     "validate_install_path",
     "validate_keyword",
+    "validate_lola_module_name",
     "validate_namespace",
     "validate_path_containment",
     "validate_plugin_type",
@@ -42,8 +43,10 @@ _NAMESPACE_RE = re.compile(r"^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$")
 _SKILL_NAME_RE = re.compile(r"^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)?$")
 _VERSION_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 _TAGS_RE = re.compile(r"^[a-zA-Z0-9_,-]+$")
+_LOLA_MODULE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$")
 _SENSITIVE_PREFIXES = ("/etc", "/usr", "/bin", "/sbin", "/boot", "/proc", "/sys", "/dev")
 _PATH_RE = re.compile(r"/(?:home|tmp|usr|etc|var|opt)/\S+")
+MAX_LOLA_MODULE_NAME_LENGTH = 128
 
 
 def validate_fqcn(name: str) -> None:
@@ -70,6 +73,26 @@ def validate_namespace(ns: str) -> None:
         raise ValidationError(
             "Invalid collection namespace: expected format 'namespace.collection' "
             "with alphanumeric/underscore segments."
+        )
+
+
+def validate_lola_module_name(name: str) -> None:
+    """Validate a Lola module directory / market ``name`` field.
+
+    Rejects empty values, path separators, and names that are not safe as a
+    single path segment under the packaging output directory.
+    """
+    if (
+        not name
+        or len(name) > MAX_LOLA_MODULE_NAME_LENGTH
+        or "/" in name
+        or "\\" in name
+        or name in {".", ".."}
+        or not _LOLA_MODULE_NAME_RE.match(name)
+    ):
+        raise ValidationError(
+            "Invalid Lola module name: use 1-128 alphanumeric characters, "
+            "dots, underscores, or hyphens (no path separators)."
         )
 
 

--- a/src/ansible_know/validation.py
+++ b/src/ansible_know/validation.py
@@ -43,10 +43,11 @@ _NAMESPACE_RE = re.compile(r"^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$")
 _SKILL_NAME_RE = re.compile(r"^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)?$")
 _VERSION_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 _TAGS_RE = re.compile(r"^[a-zA-Z0-9_,-]+$")
-_LOLA_MODULE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$")
+_LOLA_MODULE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 _SENSITIVE_PREFIXES = ("/etc", "/usr", "/bin", "/sbin", "/boot", "/proc", "/sys", "/dev")
 _PATH_RE = re.compile(r"/(?:home|tmp|usr|etc|var|opt)/\S+")
-MAX_LOLA_MODULE_NAME_LENGTH = 128
+# Allow "ansible-" + full kebab collection name (namespace max is 128).
+MAX_LOLA_MODULE_NAME_LENGTH = MAX_NAMESPACE_LENGTH + len("ansible-")
 
 
 def validate_fqcn(name: str) -> None:
@@ -81,6 +82,15 @@ def validate_lola_module_name(name: str) -> None:
 
     Rejects empty values, path separators, and names that are not safe as a
     single path segment under the packaging output directory.
+
+    Contract:
+        Preconditions:
+            - ``name`` must be a non-empty single path segment (1–
+              ``MAX_LOLA_MODULE_NAME_LENGTH`` chars).
+            - Allowed characters: alphanumeric, ``.``, ``_``, ``-``;
+              first character alphanumeric. No ``/``, ``\\``, ``.``, or ``..``.
+        Raises:
+            ValidationError: If any precondition fails (explicit check).
     """
     if (
         not name
@@ -91,7 +101,8 @@ def validate_lola_module_name(name: str) -> None:
         or not _LOLA_MODULE_NAME_RE.match(name)
     ):
         raise ValidationError(
-            "Invalid Lola module name: use 1-128 alphanumeric characters, "
+            "Invalid Lola module name: use 1-"
+            f"{MAX_LOLA_MODULE_NAME_LENGTH} alphanumeric characters, "
             "dots, underscores, or hyphens (no path separators)."
         )
 

--- a/tests/test_lola_packaging.py
+++ b/tests/test_lola_packaging.py
@@ -1,0 +1,245 @@
+"""Tests for Lola packaging helper (issue #149)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ansible_know.errors import ValidationError
+from ansible_know.skills import (
+    default_lola_module_name,
+    package_collection_for_lola,
+    resolve_collection_skills_dir,
+)
+from ansible_know.validation import validate_lola_module_name
+
+
+def _write_skill_tree(skills_root: Path, collection_kebab: str) -> Path:
+    """Create a minimal generated-skills tree for packaging tests."""
+    collection_dir = skills_root / collection_kebab
+    collection_dir.mkdir(parents=True)
+    (collection_dir / "SKILL.md").write_text(
+        "---\nname: netbox-netbox\ndescription: Collection overview\n---\n# Collection\n"
+    )
+    (collection_dir / "MANIFEST.json").write_text(
+        json.dumps({
+            "collection": "netbox.netbox",
+            "collection_version": "3.2.0",
+            "module_count": 1,
+        })
+    )
+    module_dir = collection_dir / "netbox-device"
+    module_dir.mkdir()
+    (module_dir / "SKILL.md").write_text(
+        "---\nname: netbox-device\ndescription: Manage devices\n---\n# Device\n"
+    )
+    scripts = module_dir / "scripts"
+    scripts.mkdir()
+    (scripts / "run.sh").write_text("#!/bin/sh\necho hi\n")
+    plugin_dir = collection_dir / "lookup-nb-lookup"
+    plugin_dir.mkdir()
+    (plugin_dir / "SKILL.md").write_text(
+        "---\nname: lookup-nb-lookup\ndescription: Lookup helper\n---\n# Lookup\n"
+    )
+    return collection_dir
+
+
+class TestValidateLolaModuleName:
+    def test_accepts_kebab_name(self) -> None:
+        validate_lola_module_name("ansible-netbox-netbox")
+
+    def test_rejects_path_separator(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid Lola module name"):
+            validate_lola_module_name("../escape")
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid Lola module name"):
+            validate_lola_module_name("")
+
+
+class TestDefaultLolaModuleName:
+    def test_prefixes_ansible(self) -> None:
+        assert default_lola_module_name("netbox.netbox") == "ansible-netbox-netbox"
+
+
+class TestResolveCollectionSkillsDir:
+    def test_finds_collection_dir(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        _write_skill_tree(skills, "netbox-netbox")
+        found = resolve_collection_skills_dir(skills, "netbox.netbox")
+        assert found == (skills / "netbox-netbox").resolve()
+
+    def test_searches_multiple_roots(self, tmp_path: Path) -> None:
+        first = tmp_path / "a"
+        second = tmp_path / "b"
+        first.mkdir()
+        _write_skill_tree(second, "netbox-netbox")
+        found = resolve_collection_skills_dir([first, second], "netbox.netbox")
+        assert found == (second / "netbox-netbox").resolve()
+
+    def test_missing_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="No generated skills"):
+            resolve_collection_skills_dir(tmp_path, "netbox.netbox")
+
+
+class TestPackageCollectionForLola:
+    def test_wraps_skills_into_lola_layout(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+
+        result = package_collection_for_lola(skills, "netbox.netbox", out)
+
+        module_dir = Path(result["module_dir"])
+        assert result["module_name"] == "ansible-netbox-netbox"
+        assert result["skill_count"] == 3
+        assert sorted(result["skills"]) == [
+            "lookup-nb-lookup",
+            "netbox-device",
+            "netbox-netbox",
+        ]
+        assert (module_dir / "skills" / "netbox-device" / "SKILL.md").is_file()
+        assert (module_dir / "skills" / "netbox-device" / "scripts" / "run.sh").is_file()
+        assert (module_dir / "skills" / "lookup-nb-lookup" / "SKILL.md").is_file()
+        assert (module_dir / "skills" / "netbox-netbox" / "SKILL.md").is_file()
+        assert not (module_dir / "skills" / "MANIFEST.json").exists()
+        assert not (module_dir / "skills" / "SKILL.md").exists()
+
+    def test_writes_market_yml_from_metadata(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+
+        result = package_collection_for_lola(skills, "netbox.netbox", out)
+
+        market_path = Path(result["market_yml"] or "")
+        assert market_path.is_file()
+        data = yaml.safe_load(market_path.read_text())
+        assert data["name"] == "ansible-netbox-netbox"
+        assert data["collection"] == "netbox.netbox"
+        assert data["version"] == "3.2.0"
+        assert data["skill_count"] == 3
+        assert data["description"] == "Collection overview"
+        assert "ansible" in data["tags"]
+
+    def test_skips_market_yml_when_disabled(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+
+        result = package_collection_for_lola(
+            skills, "netbox.netbox", out, write_market_yml=False,
+        )
+
+        assert result["market_yml"] is None
+        assert not (Path(result["module_dir"]) / "lola-market.yml").exists()
+
+    def test_custom_module_name(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+
+        result = package_collection_for_lola(
+            skills, "netbox.netbox", out, module_name="my-netbox-mod",
+        )
+
+        assert result["module_name"] == "my-netbox-mod"
+        assert Path(result["module_dir"]).name == "my-netbox-mod"
+
+    def test_idempotent_overwrite(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        collection_dir = _write_skill_tree(skills, "netbox-netbox")
+
+        first = package_collection_for_lola(skills, "netbox.netbox", out)
+        module_dir = Path(first["module_dir"])
+        stale = module_dir / "skills" / "netbox-device" / "stale.txt"
+        stale.write_text("old")
+        assert (module_dir / "lola-market.yml").is_file()
+
+        # Remove a source skill and disable market yml — orphans must go away.
+        shutil.rmtree(collection_dir / "lookup-nb-lookup")
+        second = package_collection_for_lola(
+            skills, "netbox.netbox", out, write_market_yml=False,
+        )
+
+        assert second["skill_count"] == 2
+        assert sorted(second["skills"]) == ["netbox-device", "netbox-netbox"]
+        assert not stale.exists()
+        assert not (module_dir / "skills" / "lookup-nb-lookup").exists()
+        assert second["market_yml"] is None
+        assert not (module_dir / "lola-market.yml").exists()
+
+    def test_rejects_output_path_escape_via_module_name(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+
+        with pytest.raises(ValidationError, match="Invalid Lola module name"):
+            package_collection_for_lola(
+                skills, "netbox.netbox", out, module_name="../escape",
+            )
+
+    def test_empty_collection_raises(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        empty = skills / "netbox-netbox"
+        empty.mkdir(parents=True)
+        (empty / "MANIFEST.json").write_text("{}")
+
+        with pytest.raises(FileNotFoundError, match="no SKILL.md"):
+            package_collection_for_lola(skills, "netbox.netbox", tmp_path / "out")
+
+
+@pytest.mark.asyncio
+class TestPackageForLolaTool:
+    async def test_package_for_lola_tool(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+        monkeypatch.delenv("ANSIBLE_KNOW_SKILLS_PATH", raising=False)
+        monkeypatch.setenv("ANSIBLE_KNOW_SKILLS_DIR", str(skills))
+        import ansible_know.config as config_mod
+
+        monkeypatch.delattr(config_mod, "SKILLS_DIR", raising=False)
+        config_mod.__dict__.pop("SKILLS_DIR", None)
+
+        from ansible_know.server import package_for_lola
+
+        result = await package_for_lola(
+            collection="netbox.netbox",
+            output_dir=str(out),
+        )
+
+        assert "error" not in result
+        assert result["skill_count"] == 3
+        assert Path(result["module_dir"]).is_dir()
+
+    async def test_package_for_lola_source_dir_override(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+
+        from ansible_know.server import package_for_lola
+
+        result = await package_for_lola(
+            collection="netbox.netbox",
+            output_dir=str(out),
+            source_dir=str(skills),
+            write_market_yml=False,
+        )
+
+        assert result["market_yml"] is None
+        assert result["skill_count"] == 3
+
+    async def test_package_for_lola_validation_error(self) -> None:
+        from ansible_know.server import package_for_lola
+
+        result = await package_for_lola(
+            collection="not a namespace",
+            output_dir="/tmp/out",
+        )
+        assert "error" in result

--- a/tests/test_lola_packaging.py
+++ b/tests/test_lola_packaging.py
@@ -255,6 +255,23 @@ class TestPackageCollectionForLola:
         assert "Collection overview" in overview
         assert "should be skipped" not in overview
 
+    def test_keeps_nested_dir_matching_collection_when_no_overview(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        collection_dir = skills / "ns-coll"
+        collection_dir.mkdir(parents=True)
+        nested = collection_dir / "ns-coll"
+        nested.mkdir()
+        (nested / "SKILL.md").write_text(
+            "---\nname: ns-coll\ndescription: module skill\n---\n# Module\n"
+        )
+
+        result = package_collection_for_lola(skills, "ns.coll", tmp_path / "out")
+        assert result["skills"] == ["ns-coll"]
+        content = (
+            Path(result["module_dir"]) / "skills" / "ns-coll" / "SKILL.md"
+        ).read_text()
+        assert "module skill" in content
+
 
 @pytest.mark.asyncio
 class TestPackageForLolaTool:

--- a/tests/test_lola_packaging.py
+++ b/tests/test_lola_packaging.py
@@ -60,6 +60,12 @@ class TestValidateLolaModuleName:
         with pytest.raises(ValidationError, match="Invalid Lola module name"):
             validate_lola_module_name("")
 
+    def test_accepts_ansible_prefix_at_namespace_max(self) -> None:
+        # ansible- (8) + 128-char kebab collection name
+        name = "ansible-" + ("a" * 60) + "-" + ("b" * 67)
+        assert len(name) == 136
+        validate_lola_module_name(name)
+
 
 class TestDefaultLolaModuleName:
     def test_prefixes_ansible(self) -> None:
@@ -192,6 +198,62 @@ class TestPackageCollectionForLola:
 
         with pytest.raises(FileNotFoundError, match="no SKILL.md"):
             package_collection_for_lola(skills, "netbox.netbox", tmp_path / "out")
+
+    def test_skips_nested_symlinks(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        collection_dir = _write_skill_tree(skills, "netbox-netbox")
+        secret = tmp_path / "secret.txt"
+        secret.write_text("do-not-copy")
+        link = collection_dir / "netbox-device" / "leak"
+        link.symlink_to(secret)
+
+        result = package_collection_for_lola(skills, "netbox.netbox", tmp_path / "out")
+        packaged = (
+            Path(result["module_dir"]) / "skills" / "netbox-device" / "leak"
+        )
+        assert not packaged.exists()
+
+    def test_rejects_empty_module_name(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        _write_skill_tree(skills, "netbox-netbox")
+        with pytest.raises(ValidationError, match="Invalid Lola module name"):
+            package_collection_for_lola(
+                skills, "netbox.netbox", tmp_path / "out", module_name="",
+            )
+
+    def test_failed_repackage_preserves_existing_skills(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        collection_dir = _write_skill_tree(skills, "netbox-netbox")
+        first = package_collection_for_lola(skills, "netbox.netbox", tmp_path / "out")
+        module_skills = Path(first["module_dir"]) / "skills"
+        assert (module_skills / "netbox-device" / "SKILL.md").is_file()
+
+        # Empty the source of all SKILL.md packages, then re-package.
+        (collection_dir / "SKILL.md").unlink()
+        shutil.rmtree(collection_dir / "netbox-device")
+        shutil.rmtree(collection_dir / "lookup-nb-lookup")
+
+        with pytest.raises(FileNotFoundError, match="no SKILL.md"):
+            package_collection_for_lola(skills, "netbox.netbox", tmp_path / "out")
+
+        assert (module_skills / "netbox-device" / "SKILL.md").is_file()
+
+    def test_skips_nested_dir_colliding_with_collection_name(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        collection_dir = _write_skill_tree(skills, "netbox-netbox")
+        collide = collection_dir / "netbox-netbox"
+        collide.mkdir()
+        (collide / "SKILL.md").write_text(
+            "---\nname: collide\ndescription: should be skipped\n---\n"
+        )
+
+        result = package_collection_for_lola(skills, "netbox.netbox", tmp_path / "out")
+        assert result["skills"].count("netbox-netbox") == 1
+        overview = (
+            Path(result["module_dir"]) / "skills" / "netbox-netbox" / "SKILL.md"
+        ).read_text()
+        assert "Collection overview" in overview
+        assert "should be skipped" not in overview
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add Domain helper `package_collection_for_lola` that wraps `skills/{collection}/{skill}/` into Lola layout `{module}/skills/{skill}/` without changing `generate_*` output (ADR-0007 / ADR-0008 Layer 2).
- Expose thin MCP tool `package_for_lola` (idempotent) with optional `lola-market.yml`, `source_dir`, and `module_name`; FS work runs via `run_in_executor`.
- Cover wrap paths, path containment, and true re-package idempotency (orphan skills + market.yml removal) in unit tests.

**Surface choice:** MCP tool `package_for_lola` (not a `generate_collection_skills` param, not a scripts/ CLI). Keeps generation layout single-format and fits the existing generate → list → package agent loop without bloating batch generation.

Closes #149

## Test plan
- [x] `ruff check` on touched files
- [x] `pytest tests/ -k 'lola or package_for' -q`
- [ ] Manual: `generate_collection_skills` then `package_for_lola` and confirm `lola mod add ./ansible-<collection>` layout

Assisted-by: Cursor (Grok 4.5)