### PR TITLE
perf: batch ansible-doc for collection manifest and skill gen (#191)

### DIFF
--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -104,7 +104,7 @@ business logic. Domain modules are imported lazily to avoid loading
 
 | Domain Module | Functions Called | File |
 |---------------|----------------|------|
-| `parser` | `search_modules()`, `get_module_doc()`, `get_role_doc()`, `list_roles()`, `extract_module_metadata()`, `extract_role_metadata()` | `parser.py` |
+| `parser` | `search_modules()`, `get_module_doc()`, `get_module_docs()`, `load_module_metadata_batch()`, `get_plugin_doc()`, `get_plugin_docs()`, `load_plugin_metadata_batch()`, `get_role_doc()`, `list_roles()`, `extract_module_metadata()`, `extract_role_metadata()` | `parser.py` |
 | `skills` | `render_skill()`, `write_skill_package()`, `render_role_skill()`, `write_role_skill_package()`, `_module_to_skill_name()` | `skills.py` |
 | `collection_manifest` | `generate_manifest()`, `load_cached_manifest()` | `collection_manifest.py` |
 | `docs` | `search_docs()`, `fetch_doc_content()` | `docs.py` |

--- a/src/ansible_know/parser.py
+++ b/src/ansible_know/parser.py
@@ -53,7 +53,6 @@ __all__ = [
 ]
 
 
-
 def _find_ansible_doc() -> str:
     """Locate the ansible-doc binary, preferring the current Python environment."""
     env_bin = Path(sys.executable).parent / "ansible-doc"
@@ -125,7 +124,7 @@ def _fetch_docs_batched(
         return {}
 
     merged: dict[str, Any] = {}
-    chunk_errors: list[str] = []
+    last_exc: AnsibleDocError | None = None
     for start in range(0, len(unique_names), _ANSIBLE_DOC_BATCH_SIZE):
         chunk = unique_names[start:start + _ANSIBLE_DOC_BATCH_SIZE]
         try:
@@ -140,7 +139,7 @@ def _fetch_docs_batched(
                 "falling back per-%s",
                 label, len(chunk), exc, label,
             )
-            chunk_errors.append(str(exc))
+            last_exc = exc
             for name in chunk:
                 try:
                     merged.update(_fetch_docs_chunk(
@@ -148,13 +147,17 @@ def _fetch_docs_batched(
                         plugin_type=plugin_type,
                         collections_path=collections_path,
                     ))
-                except AnsibleDocError:
-                    continue
-    if not merged and chunk_errors:
+                except AnsibleDocError as name_exc:
+                    last_exc = name_exc
+                    logger.debug(
+                        "Per-%s doc fallback failed for %s: %s",
+                        label, name, name_exc,
+                    )
+    if not merged and last_exc is not None:
         raise AnsibleDocError(
             f"Batch {label} doc fetch failed for all chunks. "
-            f"Last error: {chunk_errors[-1]}"
-        )
+            f"Last error: {last_exc}"
+        ) from last_exc
     return merged
 
 
@@ -232,21 +235,29 @@ def get_module_docs(
 
     Args:
         module_names: FQCNs to document. Empty sequence returns ``{}`` without
-            invoking ansible-doc. Duplicates are preserved in the request order
-            of first occurrence only when building chunks from a de-duplicated
-            list.
+            invoking ansible-doc. Duplicates are removed; first-occurrence
+            order is kept when building chunks.
         collections_path: Optional path prepended to ``ANSIBLE_COLLECTIONS_PATH``.
 
     Returns:
         Parsed ansible-doc ``--json`` object keyed by FQCN. Modules that
         ansible-doc cannot resolve are omitted (warnings go to stderr).
 
-    Raises:
-        AnsibleDocError: On subprocess failure, timeout, or invalid JSON.
-            Multi-name chunk failures fall back per-module before raising
-            only when every name in every chunk failed.
-        CollectionNotFoundError: When ansible-doc reports a missing collection
-            for a single-name request (re-raised; not swallowed by fallback).
+    Contract:
+        Preconditions:
+            - ``module_names`` may be empty; returns ``{}`` with no subprocess.
+        Raises:
+            AnsibleDocError: Subprocess/timeout/JSON failure when no names
+                succeed after chunking and per-name fallback.
+            CollectionNotFoundError: Re-raised when the request dedupes to
+                exactly one name and that call reports a missing collection.
+        Silences:
+            - Unresolved FQCNs omitted from ansible-doc JSON (see Returns).
+            - Per-name ``AnsibleDocError`` (including
+              ``CollectionNotFoundError``) during multi-name chunk fallback;
+              those names are omitted from the result (logged at debug).
+            - Partial success: if any name succeeds, returns the merged dict
+              without raising even when other names failed.
     """
     return _fetch_docs_batched(
         module_names,
@@ -273,8 +284,15 @@ def load_module_metadata_batch(
         Mapping of FQCN → ``ModuleMetadata`` for modules present in the
         ansible-doc response. Missing modules are skipped (logged at debug).
 
-    Raises:
-        AnsibleDocError: Propagated from ``get_module_docs`` on hard failures.
+    Contract:
+        Preconditions:
+            - Same as ``get_module_docs`` for ``module_names``.
+        Raises:
+            AnsibleDocError: Propagated from ``get_module_docs`` when every
+                name fails hard (no docs returned).
+        Silences:
+            - Names missing from the ansible-doc response (debug log, skip).
+            - ``extract_module_metadata`` ``AnsibleDocError`` (warning log, skip).
     """
     docs = get_module_docs(module_names, collections_path=collections_path)
     result: dict[str, ModuleMetadata] = {}
@@ -610,6 +628,7 @@ def get_plugin_docs(
 
     Args:
         plugin_names: Plugin FQCNs of ``plugin_type``. Empty returns ``{}``.
+            Duplicates are removed; first-occurrence order is kept.
         plugin_type: One of ``PLUGIN_TYPES`` (validated).
         collections_path: Optional path prepended to ``ANSIBLE_COLLECTIONS_PATH``.
 
@@ -617,13 +636,21 @@ def get_plugin_docs(
         Parsed ansible-doc ``--json`` object keyed by FQCN. Unresolved plugins
         are omitted.
 
-    Raises:
-        ValidationError: When ``plugin_type`` is not a known plugin type.
-        AnsibleDocError: On subprocess failure, timeout, or invalid JSON.
-            Multi-name chunk failures fall back per-plugin before raising
-            only when every name in every chunk failed.
-        CollectionNotFoundError: When ansible-doc reports a missing collection
-            for a single-name request (re-raised; not swallowed by fallback).
+    Contract:
+        Preconditions:
+            - ``plugin_type`` must be a known plugin type (validated first).
+            - ``plugin_names`` may be empty; returns ``{}`` with no subprocess.
+        Raises:
+            ValidationError: When ``plugin_type`` is not a known plugin type.
+            AnsibleDocError: Subprocess/timeout/JSON failure when no names
+                succeed after chunking and per-name fallback.
+            CollectionNotFoundError: Re-raised when the request dedupes to
+                exactly one name and that call reports a missing collection.
+        Silences:
+            - Unresolved FQCNs omitted from ansible-doc JSON (see Returns).
+            - Per-name ``AnsibleDocError`` during multi-name chunk fallback;
+              those names are omitted (logged at debug).
+            - Partial success returns the merged dict without raising.
     """
     validate_plugin_type(plugin_type)
     return _fetch_docs_batched(
@@ -651,9 +678,16 @@ def load_plugin_metadata_batch(
         Mapping of FQCN → ``PluginMetadata`` for plugins present in the
         ansible-doc response. Missing plugins are skipped (logged at debug).
 
-    Raises:
-        ValidationError: When ``plugin_type`` is not a known plugin type.
-        AnsibleDocError: Propagated from ``get_plugin_docs`` on hard failures.
+    Contract:
+        Preconditions:
+            - Same as ``get_plugin_docs`` for ``plugin_names`` / ``plugin_type``.
+        Raises:
+            ValidationError: When ``plugin_type`` is not a known plugin type.
+            AnsibleDocError: Propagated from ``get_plugin_docs`` when every
+                name fails hard (no docs returned).
+        Silences:
+            - Names missing from the ansible-doc response (debug log, skip).
+            - ``extract_plugin_metadata`` ``AnsibleDocError`` (warning log, skip).
     """
     docs = get_plugin_docs(
         plugin_names, plugin_type, collections_path=collections_path,

--- a/src/ansible_know/parser.py
+++ b/src/ansible_know/parser.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -25,6 +26,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("ansible_know")
 
+# Chunk size for multi-name ansible-doc invocations (avoids huge argv / timeouts).
+_ANSIBLE_DOC_BATCH_SIZE = 50
+
 __all__ = [
     "extract_examples",
     "extract_module_metadata",
@@ -33,12 +37,16 @@ __all__ = [
     "extract_role_metadata",
     "extract_short_description",
     "get_module_doc",
+    "get_module_docs",
     "get_plugin_doc",
+    "get_plugin_docs",
     "get_role_doc",
     "is_api_module",
     "list_modules",
     "list_plugins",
     "list_roles",
+    "load_module_metadata_batch",
+    "load_plugin_metadata_batch",
     "search_modules",
     "search_plugins",
     "transform_galaxy_to_ansible_doc_format",
@@ -59,8 +67,101 @@ def _find_ansible_doc() -> str:
     )
 
 
+def _batch_timeout(chunk_size: int) -> int:
+    """Return a subprocess timeout scaled for multi-name ansible-doc calls."""
+    # Single-name calls keep the historic 60s budget; larger chunks get more
+    # headroom (capped) because one process documents many plugins.
+    return max(60, min(300, 30 + 3 * chunk_size))
+
+
+def _parse_ansible_doc_json(raw: str, *, kind: str = "ansible-doc") -> dict[str, Any]:
+    """Parse ansible-doc --json stdout into a dict, or raise AnsibleDocError."""
+    try:
+        docs = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise AnsibleDocError(f"Failed to parse {kind} JSON: {exc}") from exc
+    if not isinstance(docs, dict):
+        raise AnsibleDocError(
+            f"Unexpected {kind} JSON type: {type(docs).__name__}"
+        )
+    return docs
+
+
+def _fetch_docs_chunk(
+    names: Sequence[str],
+    *,
+    plugin_type: str | None = None,
+    collections_path: str | None = None,
+) -> dict[str, Any]:
+    """Run one ansible-doc --json invocation for ``names`` (optionally typed)."""
+    if plugin_type is None:
+        args: tuple[str, ...] = (*names, "--json")
+        kind = "ansible-doc"
+    else:
+        args = ("-t", plugin_type, *names, "--json")
+        kind = "plugin doc"
+    raw = _run_ansible_doc(
+        *args,
+        collections_path=collections_path,
+        timeout=_batch_timeout(len(names)),
+    )
+    return _parse_ansible_doc_json(raw, kind=kind)
+
+
+def _fetch_docs_batched(
+    names: Sequence[str],
+    *,
+    plugin_type: str | None = None,
+    collections_path: str | None = None,
+    label: str = "module",
+) -> dict[str, Any]:
+    """Fetch docs for many names with chunking and per-name fallback.
+
+    On multi-name chunk failure, falls back to one ansible-doc call per name
+    so earlier successes are kept. Single-name failures re-raise unchanged.
+    """
+    unique_names = list(dict.fromkeys(names))
+    if not unique_names:
+        return {}
+
+    merged: dict[str, Any] = {}
+    chunk_errors: list[str] = []
+    for start in range(0, len(unique_names), _ANSIBLE_DOC_BATCH_SIZE):
+        chunk = unique_names[start:start + _ANSIBLE_DOC_BATCH_SIZE]
+        try:
+            merged.update(_fetch_docs_chunk(
+                chunk, plugin_type=plugin_type, collections_path=collections_path,
+            ))
+        except AnsibleDocError as exc:
+            if len(chunk) == 1:
+                raise
+            logger.warning(
+                "Batch %s doc fetch failed for %d names (%s); "
+                "falling back per-%s",
+                label, len(chunk), exc, label,
+            )
+            chunk_errors.append(str(exc))
+            for name in chunk:
+                try:
+                    merged.update(_fetch_docs_chunk(
+                        [name],
+                        plugin_type=plugin_type,
+                        collections_path=collections_path,
+                    ))
+                except AnsibleDocError:
+                    continue
+    if not merged and chunk_errors:
+        raise AnsibleDocError(
+            f"Batch {label} doc fetch failed for all chunks. "
+            f"Last error: {chunk_errors[-1]}"
+        )
+    return merged
+
+
 def _run_ansible_doc(
-    *args: str, collections_path: str | None = None,
+    *args: str,
+    collections_path: str | None = None,
+    timeout: int = 60,
 ) -> str:
     """Execute ansible-doc with the given arguments and return stdout."""
     ansible_doc = _find_ansible_doc()
@@ -80,7 +181,7 @@ def _run_ansible_doc(
             cmd,
             capture_output=True,
             text=True,
-            timeout=60,
+            timeout=timeout,
             env=env,
         )
     except FileNotFoundError as exc:
@@ -115,12 +216,78 @@ def get_module_doc(
     Returns the parsed JSON from `ansible-doc <module> --json`.
     The top-level dict is keyed by the fully-qualified module name.
     """
-    raw = _run_ansible_doc(module_name, "--json", collections_path=collections_path)
-    try:
-        doc = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise AnsibleDocError(f"Failed to parse ansible-doc JSON: {exc}") from exc
-    return doc
+    return get_module_docs([module_name], collections_path=collections_path)
+
+
+def get_module_docs(
+    module_names: Sequence[str],
+    *,
+    collections_path: str | None = None,
+) -> dict[str, Any]:
+    """Fetch documentation for many modules in few ansible-doc subprocesses.
+
+    ``ansible-doc`` accepts multiple plugin names per invocation. Names are
+    chunked into groups of ``_ANSIBLE_DOC_BATCH_SIZE`` to bound argv size and
+    per-call runtime.
+
+    Args:
+        module_names: FQCNs to document. Empty sequence returns ``{}`` without
+            invoking ansible-doc. Duplicates are preserved in the request order
+            of first occurrence only when building chunks from a de-duplicated
+            list.
+        collections_path: Optional path prepended to ``ANSIBLE_COLLECTIONS_PATH``.
+
+    Returns:
+        Parsed ansible-doc ``--json`` object keyed by FQCN. Modules that
+        ansible-doc cannot resolve are omitted (warnings go to stderr).
+
+    Raises:
+        AnsibleDocError: On subprocess failure, timeout, or invalid JSON.
+            Multi-name chunk failures fall back per-module before raising
+            only when every name in every chunk failed.
+        CollectionNotFoundError: When ansible-doc reports a missing collection
+            for a single-name request (re-raised; not swallowed by fallback).
+    """
+    return _fetch_docs_batched(
+        module_names,
+        collections_path=collections_path,
+        label="module",
+    )
+
+
+def load_module_metadata_batch(
+    module_names: Sequence[str],
+    *,
+    collections_path: str | None = None,
+) -> dict[str, ModuleMetadata]:
+    """Batch-fetch module docs and extract skill/manifest metadata.
+
+    Shared by collection manifest and collection skill generation so both
+    paths pay O(chunks) ansible-doc calls instead of O(modules).
+
+    Args:
+        module_names: Module FQCNs (order preserved in the returned dict).
+        collections_path: Optional path prepended to ``ANSIBLE_COLLECTIONS_PATH``.
+
+    Returns:
+        Mapping of FQCN → ``ModuleMetadata`` for modules present in the
+        ansible-doc response. Missing modules are skipped (logged at debug).
+
+    Raises:
+        AnsibleDocError: Propagated from ``get_module_docs`` on hard failures.
+    """
+    docs = get_module_docs(module_names, collections_path=collections_path)
+    result: dict[str, ModuleMetadata] = {}
+    for name in dict.fromkeys(module_names):
+        entry = docs.get(name)
+        if entry is None:
+            logger.debug("No ansible-doc output for module %s", name)
+            continue
+        try:
+            result[name] = extract_module_metadata({name: entry})
+        except AnsibleDocError as exc:
+            logger.warning("Failed to extract metadata for %s: %s", name, exc)
+    return result
 
 
 def list_modules(
@@ -428,16 +595,82 @@ def get_plugin_doc(
 
     Returns the parsed JSON from `ansible-doc -t <type> <plugin> --json`.
     """
-    validate_plugin_type(plugin_type)
-    raw = _run_ansible_doc(
-        "-t", plugin_type, plugin_name, "--json",
-        collections_path=collections_path,
+    return get_plugin_docs(
+        [plugin_name], plugin_type, collections_path=collections_path,
     )
-    try:
-        doc = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise AnsibleDocError(f"Failed to parse plugin doc JSON: {exc}") from exc
-    return doc
+
+
+def get_plugin_docs(
+    plugin_names: Sequence[str],
+    plugin_type: str,
+    *,
+    collections_path: str | None = None,
+) -> dict[str, Any]:
+    """Fetch documentation for many plugins of one type in few ansible-doc calls.
+
+    Args:
+        plugin_names: Plugin FQCNs of ``plugin_type``. Empty returns ``{}``.
+        plugin_type: One of ``PLUGIN_TYPES`` (validated).
+        collections_path: Optional path prepended to ``ANSIBLE_COLLECTIONS_PATH``.
+
+    Returns:
+        Parsed ansible-doc ``--json`` object keyed by FQCN. Unresolved plugins
+        are omitted.
+
+    Raises:
+        ValidationError: When ``plugin_type`` is not a known plugin type.
+        AnsibleDocError: On subprocess failure, timeout, or invalid JSON.
+            Multi-name chunk failures fall back per-plugin before raising
+            only when every name in every chunk failed.
+        CollectionNotFoundError: When ansible-doc reports a missing collection
+            for a single-name request (re-raised; not swallowed by fallback).
+    """
+    validate_plugin_type(plugin_type)
+    return _fetch_docs_batched(
+        plugin_names,
+        plugin_type=plugin_type,
+        collections_path=collections_path,
+        label="plugin",
+    )
+
+
+def load_plugin_metadata_batch(
+    plugin_names: Sequence[str],
+    plugin_type: str,
+    *,
+    collections_path: str | None = None,
+) -> dict[str, PluginMetadata]:
+    """Batch-fetch plugin docs and extract skill/manifest metadata.
+
+    Args:
+        plugin_names: Plugin FQCNs of ``plugin_type``.
+        plugin_type: One of ``PLUGIN_TYPES``.
+        collections_path: Optional path prepended to ``ANSIBLE_COLLECTIONS_PATH``.
+
+    Returns:
+        Mapping of FQCN → ``PluginMetadata`` for plugins present in the
+        ansible-doc response. Missing plugins are skipped (logged at debug).
+
+    Raises:
+        ValidationError: When ``plugin_type`` is not a known plugin type.
+        AnsibleDocError: Propagated from ``get_plugin_docs`` on hard failures.
+    """
+    docs = get_plugin_docs(
+        plugin_names, plugin_type, collections_path=collections_path,
+    )
+    result: dict[str, PluginMetadata] = {}
+    for name in dict.fromkeys(plugin_names):
+        entry = docs.get(name)
+        if entry is None:
+            logger.debug("No ansible-doc output for plugin %s (%s)", name, plugin_type)
+            continue
+        try:
+            result[name] = extract_plugin_metadata({name: entry}, plugin_type)
+        except AnsibleDocError as exc:
+            logger.warning(
+                "Failed to extract plugin metadata for %s: %s", name, exc,
+            )
+    return result
 
 
 def search_plugins(

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -35,6 +35,8 @@ from ansible_know.types import (
     GetPluginDocResult,
     GetRoleDocResult,
     ManifestResult,
+    ModuleMetadata,
+    PluginMetadata,
     SearchDocsEntry,
     SkillEntry,
     VersionInfo,
@@ -701,15 +703,20 @@ async def get_collection_manifest(
                 + collection_hint(collection_namespace)
             )}
 
-        metadata_list = []
-        for module_name in sorted(modules):
-            try:
-                raw_doc = await run_in_executor(
-                    parser.get_module_doc, module_name, collections_path=cpath,
-                )
-                metadata_list.append(parser.extract_module_metadata(raw_doc))
-            except AnsibleDocError:
-                continue
+        # One (chunked) ansible-doc call instead of N per-module subprocesses.
+        try:
+            module_metadata_by_fqcn = await run_in_executor(
+                parser.load_module_metadata_batch,
+                sorted(modules),
+                collections_path=cpath,
+            )
+        except AnsibleDocError as exc:
+            logger.warning(
+                "Batch module doc fetch failed for %s: %s",
+                collection_namespace, exc,
+            )
+            module_metadata_by_fqcn = {}
+        metadata_list = list(module_metadata_by_fqcn.values())
 
         roles_metadata = []
         for role_fqcn, role_data in sorted(roles_raw.items()):
@@ -1209,16 +1216,31 @@ async def generate_collection_skills(
 
         installed_version = state.collection_manager.list_installed().get(collection_namespace)
 
-        # Generate module skills
+        # Generate module skills — batch ansible-doc, then write packages.
+        module_metadata_by_fqcn: dict[str, ModuleMetadata] = {}
+        if modules:
+            try:
+                module_metadata_by_fqcn = await run_in_executor(
+                    parser.load_module_metadata_batch,
+                    sorted(modules),
+                    collections_path=cpath,
+                )
+            except AnsibleDocError as exc:
+                logger.warning(
+                    "Batch module doc fetch failed for %s: %s",
+                    collection_namespace, exc,
+                )
+
         for module_name in sorted(modules):
             if ctx:
                 await ctx.report_progress(progress=current, total=total)
             current += 1
             try:
-                raw_doc = await run_in_executor(
-                    parser.get_module_doc, module_name, collections_path=cpath,
-                )
-                metadata = parser.extract_module_metadata(raw_doc)
+                metadata = module_metadata_by_fqcn.get(module_name)
+                if metadata is None:
+                    logger.warning("No ansible-doc output for module %s", module_name)
+                    failed += 1
+                    continue
                 metadata_list.append(metadata)
 
                 output_dir = base_dir / collection_dir_name / skills.fqcn_to_skill_name(module_name)
@@ -1283,19 +1305,37 @@ async def generate_collection_skills(
                 logger.warning("Role skill generation failed for %s: %s", role_fqcn, exc)
                 failed += 1
 
-        # Generate plugin skills
+        # Generate plugin skills — one (chunked) ansible-doc call per plugin type.
         plugins_metadata = []
         for ptype, type_plugins in plugin_list_results:
-            for pfqcn in sorted(type_plugins):
+            sorted_plugins = sorted(type_plugins)
+            plugin_metadata_by_fqcn: dict[str, PluginMetadata] = {}
+            if sorted_plugins:
+                try:
+                    plugin_metadata_by_fqcn = await run_in_executor(
+                        parser.load_plugin_metadata_batch,
+                        sorted_plugins,
+                        ptype,
+                        collections_path=cpath,
+                    )
+                except AnsibleDocError as exc:
+                    logger.warning(
+                        "Batch plugin doc fetch failed for %s type=%s: %s",
+                        collection_namespace, ptype, exc,
+                    )
+
+            for pfqcn in sorted_plugins:
                 if ctx:
                     await ctx.report_progress(progress=current, total=total)
                 current += 1
                 try:
-                    raw_doc = await run_in_executor(
-                        parser.get_plugin_doc, pfqcn, ptype,
-                        collections_path=cpath,
-                    )
-                    meta = parser.extract_plugin_metadata(raw_doc, ptype)
+                    meta = plugin_metadata_by_fqcn.get(pfqcn)
+                    if meta is None:
+                        logger.warning(
+                            "No ansible-doc output for plugin %s (%s)", pfqcn, ptype,
+                        )
+                        failed += 1
+                        continue
                     plugins_metadata.append({
                         "fqcn": pfqcn,
                         "plugin_type": ptype,

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -36,6 +36,7 @@ from ansible_know.types import (
     GetRoleDocResult,
     ManifestResult,
     ModuleMetadata,
+    PluginManifestInput,
     PluginMetadata,
     SearchDocsEntry,
     SkillEntry,
@@ -653,6 +654,10 @@ async def get_collection_manifest(
     Returns cached MANIFEST.json if available, otherwise generates on-demand
     (metadata extraction only, no skill generation).
     On failure returns {"error": str}.
+
+    Module docs are fetched in batched ansible-doc calls. If the entire batch
+    fails hard, the manifest is written with zero module entries (roles/plugins
+    from list discovery are still included when present).
     """
     logger.info("get_collection_manifest namespace=%r", collection_namespace)
     try:
@@ -1147,6 +1152,10 @@ async def generate_collection_skills(
     listing available collections for cross-agent discovery.
     Returns {"succeeded": int, "failed": int, "total": int, "manifest": dict, "collection_skill": str},
     or {"error": str} on failure.
+
+    Module/plugin docs use batched ansible-doc calls. Names missing from a
+    batch (or a hard batch failure) are counted in ``failed``; partial batch
+    success still writes skills for resolved names.
     """
     logger.info("generate_collection_skills namespace=%r install_to=%r", collection_namespace, install_to)
     await _maybe_warn_upgrade(ctx)
@@ -1306,7 +1315,7 @@ async def generate_collection_skills(
                 failed += 1
 
         # Generate plugin skills — one (chunked) ansible-doc call per plugin type.
-        plugins_metadata = []
+        plugins_metadata: list[PluginManifestInput] = []
         for ptype, type_plugins in plugin_list_results:
             sorted_plugins = sorted(type_plugins)
             plugin_metadata_by_fqcn: dict[str, PluginMetadata] = {}
@@ -1336,12 +1345,13 @@ async def generate_collection_skills(
                         )
                         failed += 1
                         continue
-                    plugins_metadata.append({
+                    entry: PluginManifestInput = {
                         "fqcn": pfqcn,
                         "plugin_type": ptype,
                         "description": meta["short_description"],
                         "param_count": len(meta["params"]),
-                    })
+                    }
+                    plugins_metadata.append(entry)
 
                     output_dir = base_dir / collection_dir_name / skills.plugin_skill_name(pfqcn, ptype)
                     await run_in_executor(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,13 @@ SAMPLE_MODULE_LIST = {
     "community.general.redis": "Various redis commands, replica and flush",
 }
 
+
+def sample_batch_module_docs(module_names: list[str] | None = None) -> dict:
+    """Build a multi-FQCN ansible-doc --json payload for batch-fetch tests."""
+    names = module_names if module_names is not None else list(SAMPLE_MODULE_LIST)
+    template = SAMPLE_MODULE_DOC["ansible.builtin.package"]
+    return dict.fromkeys(names, template)
+
 SAMPLE_ROLE_DOC = {
     "fedora.linux_system_roles.gfs2": {
         "collection": "fedora.linux_system_roles",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,11 +1,13 @@
 """Tests for ansible_know.parser."""
 
-from unittest.mock import MagicMock, patch
+import json
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
 from ansible_know.errors import AnsibleDocError, CollectionNotFoundError, ValidationError
 from ansible_know.parser import (
+    _ANSIBLE_DOC_BATCH_SIZE,
     extract_examples,
     extract_module_metadata,
     extract_params,
@@ -13,12 +15,16 @@ from ansible_know.parser import (
     extract_role_metadata,
     extract_short_description,
     get_module_doc,
+    get_module_docs,
     get_plugin_doc,
+    get_plugin_docs,
     get_role_doc,
     is_api_module,
     list_modules,
     list_plugins,
     list_roles,
+    load_module_metadata_batch,
+    load_plugin_metadata_batch,
     search_modules,
     search_plugins,
     transform_galaxy_to_ansible_doc_format,
@@ -35,6 +41,85 @@ class TestGetModuleDoc:
         with patch("ansible_know.parser._run_ansible_doc", return_value="not json"):
             with pytest.raises(AnsibleDocError, match="Failed to parse"):
                 get_module_doc("ansible.builtin.package")
+
+
+class TestGetModuleDocs:
+    def test_batches_names_in_one_call(self, sample_module_doc_json):
+        names = ["ansible.builtin.package", "ansible.builtin.apt"]
+        with patch(
+            "ansible_know.parser._run_ansible_doc", return_value=sample_module_doc_json,
+        ) as mock:
+            get_module_docs(names)
+        mock.assert_called_once_with(
+            "ansible.builtin.package", "ansible.builtin.apt", "--json",
+            collections_path=None, timeout=ANY,
+        )
+
+    def test_empty_names_skips_subprocess(self):
+        with patch("ansible_know.parser._run_ansible_doc") as mock:
+            assert get_module_docs([]) == {}
+        mock.assert_not_called()
+
+    def test_chunks_large_name_lists(self, sample_module_doc_json):
+        names = [f"ns.col.mod{i}" for i in range(_ANSIBLE_DOC_BATCH_SIZE + 3)]
+        with patch(
+            "ansible_know.parser._run_ansible_doc", return_value=sample_module_doc_json,
+        ) as mock:
+            get_module_docs(names)
+        assert mock.call_count == 2
+        # args are (*chunk, "--json"); collections_path is a kwarg
+        first_args = mock.call_args_list[0].args
+        second_args = mock.call_args_list[1].args
+        assert first_args[-1] == "--json"
+        assert len(first_args) - 1 == _ANSIBLE_DOC_BATCH_SIZE
+        assert second_args[-1] == "--json"
+        assert len(second_args) - 1 == 3
+
+    def test_deduplicates_names(self, sample_module_doc_json):
+        with patch(
+            "ansible_know.parser._run_ansible_doc", return_value=sample_module_doc_json,
+        ) as mock:
+            get_module_docs(["a.b.c", "a.b.c", "a.b.d"])
+        mock.assert_called_once_with(
+            "a.b.c", "a.b.d", "--json", collections_path=None, timeout=ANY,
+        )
+
+    def test_chunk_failure_falls_back_per_module(self, sample_module_doc):
+        names = ["ns.col.a", "ns.col.b"]
+        batch_error = AnsibleDocError("batch boom")
+        per_name = {
+            "ns.col.a": json.dumps({"ns.col.a": sample_module_doc["ansible.builtin.package"]}),
+            "ns.col.b": json.dumps({"ns.col.b": sample_module_doc["ansible.builtin.package"]}),
+        }
+
+        def side_effect(*args, **kwargs):
+            # Multi-name batch: (...names, "--json")
+            name_args = [a for a in args if a != "--json"]
+            if len(name_args) > 1:
+                raise batch_error
+            return per_name[name_args[0]]
+
+        with patch("ansible_know.parser._run_ansible_doc", side_effect=side_effect) as mock:
+            result = get_module_docs(names)
+        assert set(result) == set(names)
+        assert mock.call_count == 3  # 1 failed batch + 2 singles
+
+
+class TestLoadModuleMetadataBatch:
+    def test_extracts_metadata_for_present_modules(self, sample_module_doc):
+        docs = {
+            "ansible.builtin.package": sample_module_doc["ansible.builtin.package"],
+            "ansible.builtin.apt": sample_module_doc["ansible.builtin.package"],
+        }
+        with patch(
+            "ansible_know.parser.get_module_docs", return_value=docs,
+        ) as mock_docs:
+            result = load_module_metadata_batch(
+                ["ansible.builtin.package", "ansible.builtin.apt", "missing.mod"],
+            )
+        mock_docs.assert_called_once()
+        assert set(result) == {"ansible.builtin.package", "ansible.builtin.apt"}
+        assert result["ansible.builtin.package"]["module_name"] == "ansible.builtin.package"
 
 
 class TestListModules:
@@ -417,12 +502,43 @@ class TestGetPluginDoc:
             get_plugin_doc("netbox.netbox.nb_lookup", "lookup")
         mock.assert_called_once_with(
             "-t", "lookup", "netbox.netbox.nb_lookup", "--json",
-            collections_path=None,
+            collections_path=None, timeout=ANY,
         )
 
     def test_rejects_invalid_plugin_type(self):
         with pytest.raises(ValidationError, match="Invalid plugin type"):
             get_plugin_doc("foo.bar.baz", "bogus")
+
+
+class TestGetPluginDocs:
+    def test_batches_names_with_type_flag(self, sample_plugin_doc_json):
+        names = ["ansible.builtin.env", "ansible.builtin.file"]
+        with patch(
+            "ansible_know.parser._run_ansible_doc", return_value=sample_plugin_doc_json,
+        ) as mock:
+            get_plugin_docs(names, "lookup")
+        mock.assert_called_once_with(
+            "-t", "lookup", "ansible.builtin.env", "ansible.builtin.file", "--json",
+            collections_path=None, timeout=ANY,
+        )
+
+    def test_empty_names_skips_subprocess(self):
+        with patch("ansible_know.parser._run_ansible_doc") as mock:
+            assert get_plugin_docs([], "lookup") == {}
+        mock.assert_not_called()
+
+
+class TestLoadPluginMetadataBatch:
+    def test_extracts_metadata_for_present_plugins(self, sample_plugin_doc):
+        docs = {
+            "netbox.netbox.nb_lookup": sample_plugin_doc["netbox.netbox.nb_lookup"],
+        }
+        with patch("ansible_know.parser.get_plugin_docs", return_value=docs):
+            result = load_plugin_metadata_batch(
+                ["netbox.netbox.nb_lookup", "missing.lookup"], "lookup",
+            )
+        assert set(result) == {"netbox.netbox.nb_lookup"}
+        assert result["netbox.netbox.nb_lookup"]["plugin_type"] == "lookup"
 
 
 class TestSearchPlugins:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,8 +10,11 @@ import pytest
 from tests.conftest import (
     SAMPLE_MODULE_DOC,
     SAMPLE_MODULE_LIST,
+    SAMPLE_PLUGIN_DOC,
+    SAMPLE_PLUGIN_LIST,
     SAMPLE_ROLE_DOC,
     SAMPLE_ROLE_LIST,
+    sample_batch_module_docs,
 )
 
 
@@ -316,15 +319,15 @@ class TestGenerateSkillTool:
 class TestGenerateCollectionSkillsTool:
     @pytest.mark.asyncio
     async def test_generates_collection_skills(self, tmp_path, mock_ansible_doc, monkeypatch):
-        # Module list, role list (empty), 14x plugin list (empty), then 4x module docs
+        # Module list, role list (empty), 14x plugin list (empty), then 1 batch module docs
         responses = [
             json.dumps(SAMPLE_MODULE_LIST),  # search_modules
             json.dumps({}),  # list_roles
         ]
         # 14 plugin types all return empty
         responses.extend([json.dumps({})] * 14)
-        # 4 module doc fetches
-        responses.extend([json.dumps(SAMPLE_MODULE_DOC)] * 4)
+        # 1 batched module doc fetch (was 4 per-module calls)
+        responses.append(json.dumps(sample_batch_module_docs()))
 
         mock_ansible_doc.side_effect = responses
         monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
@@ -334,6 +337,30 @@ class TestGenerateCollectionSkillsTool:
         assert result["succeeded"] + result["failed"] == 4
         assert result["collection_skill"] == "ansible.builtin"
         assert (tmp_path / "ansible-builtin" / "SKILL.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_batches_module_doc_fetches(self, tmp_path, mock_ansible_doc, monkeypatch):
+        """N modules must not trigger N ansible-doc subprocesses for docs."""
+        responses = [
+            json.dumps(SAMPLE_MODULE_LIST),
+            json.dumps({}),
+        ]
+        responses.extend([json.dumps({})] * 14)
+        responses.append(json.dumps(sample_batch_module_docs()))
+        mock_ansible_doc.side_effect = responses
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+
+        from ansible_know.server import generate_collection_skills
+        result = await generate_collection_skills("ansible.builtin", install_to=str(tmp_path))
+
+        assert result["succeeded"] == 4
+        doc_calls = [
+            c for c in mock_ansible_doc.call_args_list
+            if "--list" not in c.args and "-t" not in c.args
+        ]
+        assert len(doc_calls) == 1
+        # All four FQCNs in a single ansible-doc argv
+        assert set(SAMPLE_MODULE_LIST).issubset(set(doc_calls[0].args))
 
     @pytest.mark.asyncio
     async def test_galaxy_batch_fallback(self, tmp_path, mock_ansible_doc, monkeypatch):
@@ -388,7 +415,7 @@ class TestGenerateCollectionSkillsTool:
             json.dumps({}),
         ]
         responses.extend([json.dumps({})] * 14)
-        responses.extend([json.dumps(SAMPLE_MODULE_DOC)] * 4)
+        responses.append(json.dumps(sample_batch_module_docs()))
 
         mock_ansible_doc.side_effect = responses
         skills_dir = tmp_path / "skills"
@@ -418,7 +445,7 @@ class TestGenerateCollectionSkillsTool:
             json.dumps({}),
         ]
         responses.extend([json.dumps({})] * 14)
-        responses.extend([json.dumps(SAMPLE_MODULE_DOC)] * 4)
+        responses.append(json.dumps(sample_batch_module_docs()))
         mock_ansible_doc.side_effect = responses
 
         skills_dir = tmp_path / "skills"
@@ -446,7 +473,7 @@ class TestGenerateCollectionSkillsTool:
             json.dumps({}),
         ]
         responses.extend([json.dumps({})] * 14)
-        responses.extend([json.dumps(SAMPLE_MODULE_DOC)] * 4)
+        responses.append(json.dumps(sample_batch_module_docs()))
         mock_ansible_doc.side_effect = responses
 
         other_dir = tmp_path / "elsewhere"
@@ -463,6 +490,52 @@ class TestGenerateCollectionSkillsTool:
 
         assert "error" not in result
         mock_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_batches_plugin_doc_fetches(self, tmp_path, mock_ansible_doc, monkeypatch):
+        """Plugins of one type share a single ansible-doc -t <type> call."""
+        lookup_plugins = {
+            "ansible.builtin.env": SAMPLE_PLUGIN_LIST["ansible.builtin.env"],
+            "ansible.builtin.file": SAMPLE_PLUGIN_LIST["ansible.builtin.file"],
+        }
+        batch_plugin_docs = dict.fromkeys(
+            lookup_plugins, SAMPLE_PLUGIN_DOC["netbox.netbox.nb_lookup"],
+        )
+
+        def side_effect(*args, **kwargs):
+            if "--list" in args and "-t" in args:
+                # Only the lookup type has plugins; others empty.
+                idx = args.index("-t")
+                if args[idx + 1] == "lookup":
+                    return json.dumps(lookup_plugins)
+                return json.dumps({})
+            if "--list" in args:
+                return json.dumps({})  # no modules
+            if "-t" in args and "lookup" in args:
+                return json.dumps(batch_plugin_docs)
+            return json.dumps({})
+
+        mock_ansible_doc.side_effect = side_effect
+        monkeypatch.setattr("ansible_know.config.SKILLS_DIR", tmp_path)
+
+        with patch(
+            "ansible_know.resolution.resolve_collection_module_docs",
+            new_callable=AsyncMock,
+            return_value={"error": "not installed"},
+        ):
+            from ansible_know.server import generate_collection_skills
+            result = await generate_collection_skills(
+                "ansible.builtin", install_to=str(tmp_path),
+            )
+
+        assert result["total"] == 2
+        assert result["succeeded"] == 2
+        plugin_doc_calls = [
+            c for c in mock_ansible_doc.call_args_list
+            if "--list" not in c.args and "-t" in c.args
+        ]
+        assert len(plugin_doc_calls) == 1
+        assert set(lookup_plugins).issubset(set(plugin_doc_calls[0].args))
 
 
 class TestFQCNValidation:
@@ -1964,7 +2037,7 @@ class TestGetCollectionManifestWithRoles:
                 return json.dumps(SAMPLE_ROLE_LIST)
             if "--list" in args:
                 return json.dumps(SAMPLE_MODULE_LIST)
-            return json.dumps(SAMPLE_MODULE_DOC)
+            return json.dumps(sample_batch_module_docs())
 
         mock_ansible_doc.side_effect = side_effect
 
@@ -1974,6 +2047,32 @@ class TestGetCollectionManifestWithRoles:
 
         assert "roles" in result
         assert "role_count" in result
+
+    @pytest.mark.asyncio
+    async def test_manifest_batches_module_doc_fetches(self, mock_ansible_doc):
+        """Manifest generation must use one ansible-doc call for N modules."""
+
+        def side_effect(*args, **kwargs):
+            if "-t" in args and "role" in args and "--list" in args:
+                return json.dumps({})
+            if "--list" in args:
+                return json.dumps(SAMPLE_MODULE_LIST)
+            return json.dumps(sample_batch_module_docs())
+
+        mock_ansible_doc.side_effect = side_effect
+
+        with patch("ansible_know.collection_manifest.load_cached_manifest", return_value=None):
+            from ansible_know.server import get_collection_manifest
+            result = await get_collection_manifest("ansible.builtin")
+
+        assert "error" not in result
+        assert result["module_count"] == 4
+        doc_calls = [
+            c for c in mock_ansible_doc.call_args_list
+            if "--list" not in c.args and "-t" not in c.args
+        ]
+        assert len(doc_calls) == 1
+        assert set(SAMPLE_MODULE_LIST).issubset(set(doc_calls[0].args))
 
     @pytest.mark.asyncio
     async def test_search_collections_has_role_count(self):


### PR DESCRIPTION
## Summary
- Batch `ansible-doc --json` multi-name calls (chunked at 50) via Domain helpers `get_module_docs` / `get_plugin_docs` and shared `load_*_metadata_batch`, used by both `get_collection_manifest` and `generate_collection_skills`.
- Removes sequential per-module / per-plugin subprocess N+1 while keeping tool APIs and return shapes stable; blocking work still goes through `run_in_executor`.
- Multi-name chunk failures fall back per-name (preserving partial success); timeouts scale with chunk size (60–300s). Does not start #192 server split.

### Call-count (before → after)
| Path | Before | After |
|------|--------|-------|
| `get_collection_manifest` module docs | **N** subprocesses (1 per module) | **⌈N/50⌉** (1 for typical collections) |
| `generate_collection_skills` module docs | **N** | **⌈N/50⌉** |
| `generate_collection_skills` plugin docs (per type) | **P** (1 per plugin) | **⌈P/50⌉** per plugin type |

Example: 100-module collection → **100 → 2** module doc subprocesses (plus unchanged list/discovery calls).

## Test plan
- [x] `pytest tests/test_parser.py tests/test_server.py -q` (243 passed)
- [x] `ruff check` on touched files
- [x] Unit tests assert a single `_run_ansible_doc` doc call for N modules / N plugins of one type
- [ ] Smoke: `get_collection_manifest` / `generate_collection_skills` on a locally installed multi-module collection

Closes #191

Assisted-by: Cursor (Grok 4.5)