### PR TITLE
feat: RTD Embed API fallback for fetch_doc (#168)

### DIFF
--- a/src/ansible_know/config.py
+++ b/src/ansible_know/config.py
@@ -290,6 +290,13 @@ REDHAT_DOCS_MCP_URL = os.environ.get(
     "https://docs-mcp.api.redhat.com/mcp",
 )
 
+def get_rtd_api_token() -> str:
+    """Optional Read the Docs API token (Embed/Search).
+
+    When set, increases unauthenticated rate limits from 5 req/min to 60 req/min.
+    """
+    return os.environ.get("ANSIBLE_KNOW_RTD_TOKEN", "").strip()
+
 PLUGIN_TYPES: tuple[str, ...] = (
     "become", "cache", "callback", "cliconf", "connection",
     "filter", "httpapi", "inventory", "lookup", "netconf",

--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -11,10 +11,12 @@ import asyncio
 import json
 import logging
 import math
+import os
 import time
 from itertools import zip_longest
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 
@@ -27,9 +29,9 @@ from ansible_know.config import (
     get_doc_sources,
 )
 from ansible_know.errors import AnsibleKnowError
-from ansible_know.text_utils import clean_rtd_markdown
+from ansible_know.text_utils import clean_rtd_markdown, html_to_markdown
 from ansible_know.types import FetchDocResult, SearchDocsEntry
-from ansible_know.validation import truncate_response
+from ansible_know.validation import sanitize_error, truncate_response
 
 logger = logging.getLogger("ansible_know")
 
@@ -43,7 +45,10 @@ MAX_MANIFEST_SIZE = 5_000_000  # 5MB
 CACHE_TTL_SECONDS = 3600
 MANIFEST_VERSION_MAJOR = "2"
 RTD_SEARCH_URL = "https://app.readthedocs.org/api/v3/search/"
+RTD_EMBED_URL = "https://app.readthedocs.org/api/v3/embed/"
 RTD_DOCS_DOMAIN = "https://docs.ansible.com"
+RTD_EMBED_DOCS_HOST = "ansible.readthedocs.io"
+CF_CHALLENGE_MARKER = "Cloudflare managed challenge"
 
 _manifest_cache: BoundedCache[str, list[dict[str, Any]]] = BoundedCache(
     max_size=50, ttl=CACHE_TTL_SECONDS,
@@ -406,6 +411,134 @@ def clear_cache() -> None:
 MAX_DOC_FETCH_SIZE = 2_000_000  # 2MB
 
 
+def _estimate_tokens(text: str) -> int:
+    """Rough token estimate (~4 chars/token) when no x-markdown-tokens header."""
+    return len(text) // 4
+
+
+def _map_docs_url_to_rtd(url: str) -> str:
+    """Rewrite docs.ansible.com URLs to ansible.readthedocs.io for Embed API.
+
+    Paths are identical across the custom domain and the RTD project domain.
+    Host is hard-coded after validation — never taken from redirect targets.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "docs.ansible.com":
+        raise AnsibleKnowError(
+            "RTD Embed fallback only supports https://docs.ansible.com/ URLs"
+        )
+    return urlunparse(parsed._replace(netloc=RTD_EMBED_DOCS_HOST))
+
+
+def _rtd_embed_headers() -> dict[str, str]:
+    """Build Embed API headers; optional token raises unauthenticated rate limits."""
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": USER_AGENT,
+    }
+    token = os.environ.get("ANSIBLE_KNOW_RTD_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = f"Token {token}"
+    return headers
+
+
+def _is_embed_fallback_error(exc: Exception) -> bool:
+    """Return True for CF challenge or persistent HTTP 429 from docs.ansible.com."""
+    if isinstance(exc, AnsibleKnowError) and CF_CHALLENGE_MARKER in str(exc):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        response = exc.response
+        return response is not None and response.status_code == 429
+    return False
+
+
+async def _fetch_via_rtd_embed(
+    client: httpx.AsyncClient,
+    url: str,
+    max_tokens: int | None = None,
+) -> FetchDocResult:
+    """Fetch page content via RTD Embed API (bypasses docs.ansible.com Cloudflare)."""
+    rtd_url = _map_docs_url_to_rtd(url)
+    try:
+        resp = await client.get(
+            RTD_EMBED_URL,
+            params={"url": rtd_url},
+            headers=_rtd_embed_headers(),
+            follow_redirects=False,
+            timeout=30.0,
+        )
+    except httpx.HTTPError as exc:
+        raise AnsibleKnowError(
+            f"RTD Embed API request failed: {sanitize_error(str(exc))}"
+        ) from exc
+
+    if resp.url.host != "app.readthedocs.org":
+        raise AnsibleKnowError(
+            f"RTD Embed redirected to unexpected domain: {resp.url.host}"
+        )
+
+    if len(resp.content) > MAX_DOC_FETCH_SIZE:
+        raise AnsibleKnowError(
+            f"RTD Embed response too large: {len(resp.content)} bytes "
+            f"(max {MAX_DOC_FETCH_SIZE})"
+        )
+
+    if resp.status_code >= 400:
+        detail = ""
+        try:
+            payload = resp.json()
+        except ValueError:
+            payload = None
+        if isinstance(payload, dict) and payload.get("error"):
+            detail = f": {sanitize_error(str(payload['error']))}"
+        raise AnsibleKnowError(
+            f"RTD Embed API returned HTTP {resp.status_code}{detail}"
+        )
+
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        raise AnsibleKnowError("RTD Embed API returned invalid JSON") from exc
+
+    if not isinstance(data, dict):
+        raise AnsibleKnowError("RTD Embed API returned unexpected JSON shape")
+
+    if data.get("error"):
+        raise AnsibleKnowError(
+            f"RTD Embed API error: {sanitize_error(str(data['error']))}"
+        )
+
+    html_content = data.get("content")
+    if not isinstance(html_content, str) or not html_content.strip():
+        raise AnsibleKnowError("RTD Embed API returned empty content")
+
+    html_bytes = len(html_content.encode("utf-8"))
+    if html_bytes > MAX_DOC_FETCH_SIZE:
+        raise AnsibleKnowError(
+            f"RTD Embed content too large: {html_bytes} bytes "
+            f"(max {MAX_DOC_FETCH_SIZE})"
+        )
+
+    markdown = html_to_markdown(html_content)
+    content, title = clean_rtd_markdown(markdown)
+    # Estimate before truncate so max_tokens matches primary-path gating intent.
+    tokens = _estimate_tokens(content)
+    if max_tokens is not None and tokens > max_tokens:
+        raise AnsibleKnowError(
+            f"Page has {tokens} tokens (max_tokens={max_tokens}). "
+            f"Fetch without max_tokens or increase the limit."
+        )
+    content = truncate_response(content)
+
+    result: FetchDocResult = {
+        "content": content,
+        "title": title,
+        "tokens": tokens,
+        "source_url": url,
+    }
+    return result
+
+
 async def fetch_doc_content(
     url: str,
     max_tokens: int | None = None,
@@ -414,6 +547,8 @@ async def fetch_doc_content(
     """Fetch a docs.ansible.com page as clean markdown.
 
     Uses Cloudflare's ``Accept: text/markdown`` content negotiation.
+    On Cloudflare managed challenge or persistent HTTP 429, falls back to
+    the Read the Docs Embed API (different domain, bypasses the CF zone).
 
     Args:
         url: Full docs.ansible.com URL (caller must validate first).
@@ -424,8 +559,8 @@ async def fetch_doc_content(
         FetchDocResult on success.
 
     Raises:
-        httpx.HTTPError: On HTTP request failure after retries.
-        AnsibleKnowError: On CF challenge, content-type mismatch,
+        httpx.HTTPError: On HTTP request failure after retries (non-fallback).
+        AnsibleKnowError: On CF+Embed failure, content-type mismatch,
             size/token limit, or redirect to unexpected domain.
     """
     cached = _page_cache.get(url)
@@ -443,48 +578,69 @@ async def fetch_doc_content(
         should_close = True
 
     try:
-        resp = await _fetch_with_retry(client, url)
+        try:
+            resp = await _fetch_with_retry(client, url)
+        except (AnsibleKnowError, httpx.HTTPStatusError) as primary_exc:
+            if not _is_embed_fallback_error(primary_exc):
+                raise
+            logger.info(
+                "docs.ansible.com blocked (%s); trying RTD Embed fallback",
+                type(primary_exc).__name__,
+            )
+            try:
+                result = await _fetch_via_rtd_embed(
+                    client, url, max_tokens=max_tokens,
+                )
+            except AnsibleKnowError as embed_exc:
+                raise AnsibleKnowError(
+                    f"{sanitize_error(str(primary_exc))} "
+                    f"RTD Embed fallback also failed: "
+                    f"{sanitize_error(str(embed_exc))}"
+                ) from embed_exc
+            _page_cache.put(url, result)
+            return result
+
+        if resp.url.host != "docs.ansible.com":
+            raise AnsibleKnowError(f"Redirect to unexpected domain: {resp.url.host}")
+
+        if len(resp.content) > MAX_DOC_FETCH_SIZE:
+            raise AnsibleKnowError(
+                f"Response too large: {len(resp.content)} bytes "
+                f"(max {MAX_DOC_FETCH_SIZE})"
+            )
+
+        content_type = resp.headers.get("content-type", "")
+        if "text/markdown" not in content_type:
+            raise AnsibleKnowError(
+                f"Expected text/markdown but got {content_type!r} for {url}"
+            )
+
+        tokens_str = resp.headers.get("x-markdown-tokens", "0")
+        try:
+            tokens = int(tokens_str)
+        except ValueError:
+            tokens = 0
+
+        if max_tokens is not None and tokens > max_tokens:
+            raise AnsibleKnowError(
+                f"Page has {tokens} tokens (max_tokens={max_tokens}). "
+                f"Fetch without max_tokens or increase the limit."
+            )
+
+        content, title = clean_rtd_markdown(resp.text)
+        content = truncate_response(content)
+
+        result = {
+            "content": content,
+            "title": title,
+            "tokens": tokens,
+            "source_url": str(resp.url),
+        }
+        _page_cache.put(url, result)
+        return result
     finally:
         if should_close:
             await client.aclose()
-
-    if resp.url.host != "docs.ansible.com":
-        raise AnsibleKnowError(f"Redirect to unexpected domain: {resp.url.host}")
-
-    if len(resp.content) > MAX_DOC_FETCH_SIZE:
-        raise AnsibleKnowError(
-            f"Response too large: {len(resp.content)} bytes (max {MAX_DOC_FETCH_SIZE})"
-        )
-
-    content_type = resp.headers.get("content-type", "")
-    if "text/markdown" not in content_type:
-        raise AnsibleKnowError(
-            f"Expected text/markdown but got {content_type!r} for {url}"
-        )
-
-    tokens_str = resp.headers.get("x-markdown-tokens", "0")
-    try:
-        tokens = int(tokens_str)
-    except ValueError:
-        tokens = 0
-
-    if max_tokens is not None and tokens > max_tokens:
-        raise AnsibleKnowError(
-            f"Page has {tokens} tokens (max_tokens={max_tokens}). "
-            f"Fetch without max_tokens or increase the limit."
-        )
-
-    content, title = clean_rtd_markdown(resp.text)
-    content = truncate_response(content)
-
-    result: FetchDocResult = {
-        "content": content,
-        "title": title,
-        "tokens": tokens,
-        "source_url": str(resp.url),
-    }
-    _page_cache.put(url, result)
-    return result
 
 
 async def _fetch_with_retry(

--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -11,7 +11,6 @@ import asyncio
 import json
 import logging
 import math
-import os
 import time
 from itertools import zip_longest
 from pathlib import Path
@@ -27,6 +26,7 @@ from ansible_know.config import (
     SEARCH_DOCS_LIMIT,
     USER_AGENT,
     get_doc_sources,
+    get_rtd_api_token,
 )
 from ansible_know.errors import AnsibleKnowError
 from ansible_know.text_utils import clean_rtd_markdown, html_to_markdown
@@ -431,18 +431,20 @@ def _map_docs_url_to_rtd(url: str) -> str:
 
 
 def _rtd_embed_headers() -> dict[str, str]:
-    """Build Embed API headers; optional token raises unauthenticated rate limits."""
+    """Build Embed API headers; optional RTD token increases rate limits."""
     headers = {
         "Accept": "application/json",
         "User-Agent": USER_AGENT,
     }
-    token = os.environ.get("ANSIBLE_KNOW_RTD_TOKEN", "").strip()
+    token = get_rtd_api_token()
     if token:
         headers["Authorization"] = f"Token {token}"
     return headers
 
 
-def _is_embed_fallback_error(exc: Exception) -> bool:
+def _is_embed_fallback_error(
+    exc: AnsibleKnowError | httpx.HTTPStatusError,
+) -> bool:
     """Return True for CF challenge or persistent HTTP 429 from docs.ansible.com."""
     if isinstance(exc, AnsibleKnowError) and CF_CHALLENGE_MARKER in str(exc):
         return True
@@ -553,6 +555,8 @@ async def fetch_doc_content(
     Args:
         url: Full docs.ansible.com URL (caller must validate first).
         max_tokens: If set, raise when page exceeds this token count.
+            Primary path uses Cloudflare ``x-markdown-tokens``; Embed
+            fallback estimates ``len(content) // 4`` (no token header).
         http_client: Optional shared httpx client.
 
     Returns:
@@ -630,7 +634,7 @@ async def fetch_doc_content(
         content, title = clean_rtd_markdown(resp.text)
         content = truncate_response(content)
 
-        result = {
+        result: FetchDocResult = {
             "content": content,
             "title": title,
             "tokens": tokens,

--- a/src/ansible_know/text_utils.py
+++ b/src/ansible_know/text_utils.py
@@ -1,13 +1,20 @@
-"""Text cleaning utilities for RTD markdown content (Foundation layer)."""
+"""Text cleaning utilities for RTD / docs markdown content (Foundation layer)."""
 
 from __future__ import annotations
 
+import html
+import logging
 import re
+from html.parser import HTMLParser
+from urllib.parse import urlparse
 
 __all__ = [
     "clean_redhat_markdown",
     "clean_rtd_markdown",
+    "html_to_markdown",
 ]
+
+logger = logging.getLogger("ansible_know")
 
 _DOCTYPE_RE = re.compile(r"<!DOCTYPE\s+html>", re.IGNORECASE)
 _H1_RE = re.compile(r"^# (.+?)(?:\s*\{#[\w-]+\})?\s*$", re.MULTILINE)
@@ -87,3 +94,246 @@ def clean_redhat_markdown(raw: str) -> tuple[str, str]:
     text = "\n".join(filtered)
     text = _EXCESS_BLANKS_RE.sub("\n\n", text)
     return text.strip(), title
+
+
+def _format_markdown_link(label: str, href: str) -> str:
+    """Build a CommonMark link, escaping delimiters; drop unsafe schemes."""
+    href = href.strip()
+    label = label.strip() or href
+    if not href:
+        return label
+
+    parsed = urlparse(href)
+    scheme = (parsed.scheme or "").lower()
+    if scheme and scheme not in {"http", "https"}:
+        return label
+    if href.startswith("//"):
+        return label
+
+    safe_label = (
+        label.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
+    )
+    safe_href = href.replace("\\", "\\\\").replace(")", "\\)")
+    if re.search(r"\s", safe_href):
+        return f"[{safe_label}](<{safe_href}>)"
+    return f"[{safe_label}]({safe_href})"
+
+
+def _extract_tagged_region(raw_html: str, tag: str) -> str | None:
+    """Extract first ``<tag>...</tag>`` region without catastrophic backtracking."""
+    lower = raw_html.lower()
+    start_token = f"<{tag}"
+    close_token = f"</{tag}>"
+    search_from = 0
+    while True:
+        start = lower.find(start_token, search_from)
+        if start < 0:
+            return None
+        after = start + len(start_token)
+        if after < len(raw_html) and raw_html[after] not in " \t\r\n/>":
+            search_from = after
+            continue
+        end = lower.find(close_token, after)
+        if end < 0:
+            return None
+        return raw_html[start:end + len(close_token)]
+
+
+def _extract_content_html(raw_html: str) -> str:
+    """Prefer ``<article>`` / ``<main>`` / ``role=main``; else full document."""
+    for tag in ("article", "main"):
+        region = _extract_tagged_region(raw_html, tag)
+        if region:
+            return region
+    # RTD Embed often wraps content in <div role="main" …>
+    role_main = re.search(
+        r'(?is)<div\b[^>]*\brole\s*=\s*["\']main["\'][^>]*>',
+        raw_html,
+    )
+    if role_main:
+        return raw_html[role_main.start():]
+    return raw_html
+
+
+class _HtmlToMarkdownParser(HTMLParser):
+    """Minimal HTML→Markdown converter for Sphinx / RTD / docs HTML fragments."""
+
+    _SKIP_TAGS = frozenset({
+        "script", "style", "nav", "header", "footer", "aside",
+        "button", "svg", "noscript", "form",
+    })
+    _BLOCK_TAGS = frozenset({
+        "p", "div", "section", "li", "tr", "blockquote", "pre",
+        "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "table",
+        "article", "main", "br", "hr",
+    })
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._parts: list[str] = []
+        self._skip_depth = 0
+        self._in_pre = False
+        self._list_stack: list[str] = []
+        self._ol_index: list[int] = []
+        self._href: str | None = None
+        self._pending_href_text: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if self._skip_depth:
+            if tag in self._SKIP_TAGS:
+                self._skip_depth += 1
+            return
+        if tag in self._SKIP_TAGS:
+            self._skip_depth = 1
+            return
+
+        attr_map = {k.lower(): (v or "") for k, v in attrs}
+
+        if tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            self._ensure_blank_line()
+            self._parts.append("#" * int(tag[1]) + " ")
+        elif tag == "br":
+            self._parts.append("\n")
+        elif tag == "hr":
+            self._ensure_blank_line()
+            self._parts.append("---\n\n")
+        elif tag == "p":
+            self._ensure_blank_line()
+        elif tag in {"ul", "ol"}:
+            self._ensure_blank_line()
+            self._list_stack.append(tag)
+            self._ol_index.append(0)
+        elif tag == "li":
+            self._ensure_newline()
+            depth = max(len(self._list_stack) - 1, 0)
+            indent = "  " * depth
+            if self._list_stack and self._list_stack[-1] == "ol":
+                self._ol_index[-1] += 1
+                self._parts.append(f"{indent}{self._ol_index[-1]}. ")
+            else:
+                self._parts.append(f"{indent}- ")
+        elif tag == "pre":
+            self._ensure_blank_line()
+            self._emit("```\n")
+            self._in_pre = True
+        elif tag == "code" and not self._in_pre:
+            self._emit("`")
+        elif tag in {"strong", "b"}:
+            self._emit("**")
+        elif tag in {"em", "i"}:
+            self._emit("*")
+        elif tag == "a":
+            href = attr_map.get("href", "")
+            if href and not href.startswith("#"):
+                self._href = href
+                self._pending_href_text = []
+        elif tag == "img":
+            alt = attr_map.get("alt", "")
+            if alt:
+                self._emit(alt)
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if self._skip_depth:
+            if tag in self._SKIP_TAGS:
+                self._skip_depth -= 1
+            return
+
+        if tag in {"h1", "h2", "h3", "h4", "h5", "h6", "p"}:
+            self._emit("\n\n")
+        elif tag in {"ul", "ol"}:
+            if self._list_stack:
+                self._list_stack.pop()
+            if self._ol_index:
+                self._ol_index.pop()
+            self._emit("\n")
+        elif tag == "li":
+            self._emit("\n")
+        elif tag == "pre":
+            if self._href is not None:
+                if not "".join(self._pending_href_text).endswith("\n"):
+                    self._emit("\n")
+            elif not self._parts or not self._parts[-1].endswith("\n"):
+                self._emit("\n")
+            self._emit("```\n\n")
+            self._in_pre = False
+        elif tag == "code" and not self._in_pre:
+            self._emit("`")
+        elif tag in {"strong", "b"}:
+            self._emit("**")
+        elif tag in {"em", "i"}:
+            self._emit("*")
+        elif tag == "a" and self._href is not None:
+            label = "".join(self._pending_href_text).strip() or self._href
+            self._parts.append(_format_markdown_link(label, self._href))
+            self._href = None
+            self._pending_href_text = []
+        elif tag in self._BLOCK_TAGS:
+            self._ensure_newline()
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth:
+            return
+        if self._in_pre:
+            self._emit(data)
+            return
+        if not data.strip():
+            if self._href is not None:
+                pending = "".join(self._pending_href_text)
+                if data and pending and not pending.endswith(("\n", " ", "\t")):
+                    self._emit(" ")
+                return
+            if data and self._parts and not self._parts[-1].endswith(("\n", " ", "\t")):
+                self._emit(" ")
+            return
+        collapsed = re.sub(r"[ \t\r\n]+", " ", data)
+        self._emit(collapsed)
+
+    def _emit(self, text: str) -> None:
+        if self._href is not None:
+            self._pending_href_text.append(text)
+        else:
+            self._parts.append(text)
+
+    def _ensure_newline(self) -> None:
+        if self._parts and not self._parts[-1].endswith("\n"):
+            self._parts.append("\n")
+
+    def _ensure_blank_line(self) -> None:
+        if not self._parts:
+            return
+        suffix = "".join(self._parts[-3:])
+        if suffix.endswith("\n\n"):
+            return
+        if suffix.endswith("\n"):
+            self._parts.append("\n")
+        else:
+            self._parts.append("\n\n")
+
+    def get_markdown(self) -> str:
+        return "".join(self._parts)
+
+
+def html_to_markdown(raw_html: str) -> str:
+    """Convert HTML documentation fragments to markdown (stdlib, no extra deps).
+
+    Used by RTD Embed fallback and available as a Foundation helper for other
+    doc fetchers. Prefer ``<article>`` / ``<main>`` / ``role=main`` regions.
+    """
+    if not raw_html:
+        return ""
+    fragment = _extract_content_html(raw_html)
+    parser = _HtmlToMarkdownParser()
+    try:
+        parser.feed(fragment)
+        parser.close()
+    except Exception:
+        logger.debug(
+            "HTML→markdown parse failed; using stripped text fallback",
+            exc_info=True,
+        )
+        text = re.sub(r"(?is)<(script|style).*?>.*?</\1>", "", fragment)
+        text = re.sub(r"(?s)<[^>]+>", " ", text)
+        return html.unescape(re.sub(r"\s+", " ", text)).strip()
+    return parser.get_markdown()

--- a/src/ansible_know/text_utils.py
+++ b/src/ansible_know/text_utils.py
@@ -139,19 +139,51 @@ def _extract_tagged_region(raw_html: str, tag: str) -> str | None:
         return raw_html[start:end + len(close_token)]
 
 
+def _extract_role_main_div(raw_html: str) -> str | None:
+    """Extract the closed ``<div role="main">...</div>`` region, if present."""
+    match = re.search(
+        r'(?is)<div\b[^>]*\brole\s*=\s*["\']main["\'][^>]*>',
+        raw_html,
+    )
+    if not match:
+        return None
+    start = match.start()
+    # Depth-count div tags from the opening role=main tag to its closer.
+    lower = raw_html.lower()
+    pos = match.end()
+    depth = 1
+    while pos < len(lower) and depth > 0:
+        next_open = lower.find("<div", pos)
+        next_close = lower.find("</div>", pos)
+        if next_close < 0:
+            return None
+        if next_open >= 0 and next_open < next_close:
+            after = next_open + 4
+            if after < len(raw_html) and raw_html[after] in " \t\r\n/>":
+                gt = lower.find(">", next_open)
+                if gt < 0:
+                    return None
+                depth += 1
+                pos = gt + 1
+            else:
+                pos = after
+            continue
+        depth -= 1
+        pos = next_close + len("</div>")
+    if depth != 0:
+        return None
+    return raw_html[start:pos]
+
+
 def _extract_content_html(raw_html: str) -> str:
     """Prefer ``<article>`` / ``<main>`` / ``role=main``; else full document."""
     for tag in ("article", "main"):
         region = _extract_tagged_region(raw_html, tag)
         if region:
             return region
-    # RTD Embed often wraps content in <div role="main" …>
-    role_main = re.search(
-        r'(?is)<div\b[^>]*\brole\s*=\s*["\']main["\'][^>]*>',
-        raw_html,
-    )
-    if role_main:
-        return raw_html[role_main.start():]
+    role_main = _extract_role_main_div(raw_html)
+    if role_main is not None:
+        return role_main
     return raw_html
 
 
@@ -318,8 +350,11 @@ class _HtmlToMarkdownParser(HTMLParser):
 def html_to_markdown(raw_html: str) -> str:
     """Convert HTML documentation fragments to markdown (stdlib, no extra deps).
 
-    Used by RTD Embed fallback and available as a Foundation helper for other
-    doc fetchers. Prefer ``<article>`` / ``<main>`` / ``role=main`` regions.
+    Contract:
+        Prefers ``<article>`` / ``<main>`` / closed ``role=main`` regions.
+        On HTMLParser failure (malformed markup), falls back to tag-stripped
+        plain text rather than raising — callers treat this as best-effort
+        conversion for untrusted upstream HTML.
     """
     if not raw_html:
         return ""
@@ -328,7 +363,8 @@ def html_to_markdown(raw_html: str) -> str:
     try:
         parser.feed(fragment)
         parser.close()
-    except Exception:
+    except (ValueError, TypeError, AssertionError, RecursionError):
+        # HTMLParser has no stable public error type for broken markup.
         logger.debug(
             "HTML→markdown parse failed; using stripped text fallback",
             exc_info=True,

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1046,11 +1046,13 @@ class TestFetchDocRtdEmbedFallback:
     def test_html_to_markdown_skips_script_and_keeps_headings(self):
         md = html_to_markdown(
             '<div role="main"><script>banner()</script>'
-            "<h1>Loops</h1><p>Use <code>loop</code>.</p></div>",
+            "<h1>Loops</h1><p>Use <code>loop</code>.</p></div>"
+            "<footer>Do not include</footer>",
         )
         assert "# Loops" in md
         assert "`loop`" in md
         assert "banner" not in md
+        assert "Do not include" not in md
 
     @pytest.mark.asyncio
     async def test_embed_uses_rtd_token_when_set(self, monkeypatch):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -11,7 +11,7 @@ import pytest
 
 import ansible_know.docs as docs_mod
 from ansible_know.docs import _search_rtd_api, clear_cache, fetch_doc_content, search_docs
-from ansible_know.text_utils import clean_rtd_markdown
+from ansible_know.text_utils import clean_rtd_markdown, html_to_markdown
 
 MOCK_MANIFEST = {
     "version": "2.0",
@@ -857,53 +857,94 @@ class TestFetchDocRetry:
         assert mock_client.get.call_count == docs_mod.MAX_RETRY_ATTEMPTS
 
 
+def _make_cf_challenge_response() -> MagicMock:
+    """Build a mock Cloudflare managed-challenge response."""
+    cf_resp = MagicMock()
+    cf_resp.status_code = 429
+    cf_resp.headers = {"cf-mitigated": "challenge", "content-type": "text/html"}
+    cf_resp.raise_for_status = MagicMock()
+    cf_resp.url = _mock_url("https://docs.ansible.com/projects/ansible/latest/guide.html")
+    cf_resp.content = b"<html>challenge</html>"
+    return cf_resp
+
+
+def _make_embed_response(
+    html: str = "<div role='main'><h1>Embed Title</h1><p>From RTD Embed.</p></div>",
+    status_code: int = 200,
+    error: str | None = None,
+) -> MagicMock:
+    """Build a mock RTD Embed API JSON response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    payload: dict[str, str] = {
+        "url": "https://ansible.readthedocs.io/x",
+        "content": html,
+    }
+    if error is not None:
+        payload = {"error": error}
+    body = json.dumps(payload).encode()
+    resp.content = body
+    resp.text = body.decode()
+    resp.json = MagicMock(return_value=payload)
+    resp.headers = {"content-type": "application/json"}
+    embed_url = MagicMock()
+    embed_url.host = "app.readthedocs.org"
+    embed_url.__str__ = lambda self: docs_mod.RTD_EMBED_URL
+    resp.url = embed_url
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
 class TestFetchDocCfChallenge:
     @pytest.mark.asyncio
-    async def test_cf_challenge_raises_immediately(self):
-        from ansible_know.errors import AnsibleKnowError
-
-        cf_resp = MagicMock()
-        cf_resp.status_code = 429
-        cf_resp.headers = {"cf-mitigated": "challenge", "content-type": "text/html"}
-        cf_resp.raise_for_status = MagicMock()
+    async def test_cf_challenge_falls_back_to_rtd_embed(self):
+        """CF challenge should not surface when RTD Embed succeeds."""
+        cf_resp = _make_cf_challenge_response()
+        embed_resp = _make_embed_response()
 
         mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=cf_resp)
+        mock_client.get = AsyncMock(side_effect=[cf_resp, embed_resp])
 
-        with pytest.raises(AnsibleKnowError, match="Cloudflare managed challenge"):
-            await fetch_doc_content(
-                "https://docs.ansible.com/projects/ansible/latest/guide.html",
-                http_client=mock_client,
-            )
+        result = await fetch_doc_content(
+            "https://docs.ansible.com/projects/ansible/latest/guide.html",
+            http_client=mock_client,
+        )
+
+        assert "Embed Title" in result["title"] or "Embed Title" in result["content"]
+        assert "From RTD Embed" in result["content"]
+        assert result["source_url"] == (
+            "https://docs.ansible.com/projects/ansible/latest/guide.html"
+        )
+        assert mock_client.get.call_count == 2
+        embed_call = mock_client.get.call_args_list[1]
+        assert embed_call.args[0] == docs_mod.RTD_EMBED_URL
+        assert embed_call.kwargs["params"]["url"] == (
+            "https://ansible.readthedocs.io/projects/ansible/latest/guide.html"
+        )
 
     @pytest.mark.asyncio
-    async def test_cf_challenge_no_retry(self):
+    async def test_cf_challenge_no_retry_before_embed(self):
+        """CF challenge must not retry docs.ansible.com; one primary + one Embed."""
         from ansible_know.errors import AnsibleKnowError
 
-        cf_resp = MagicMock()
-        cf_resp.status_code = 429
-        cf_resp.headers = {"cf-mitigated": "challenge", "content-type": "text/html"}
-        cf_resp.raise_for_status = MagicMock()
+        cf_resp = _make_cf_challenge_response()
+        embed_resp = _make_embed_response(error="Can't find content", status_code=404)
 
         mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=cf_resp)
+        mock_client.get = AsyncMock(side_effect=[cf_resp, embed_resp])
 
-        with pytest.raises(AnsibleKnowError):
+        with pytest.raises(AnsibleKnowError, match="RTD Embed fallback also failed"):
             await fetch_doc_content(
                 "https://docs.ansible.com/projects/ansible/latest/guide.html",
                 http_client=mock_client,
             )
 
-        assert mock_client.get.call_count == 1
+        assert mock_client.get.call_count == 2
 
     @pytest.mark.asyncio
     async def test_regular_429_retries_but_cf_429_does_not(self):
-        from ansible_know.errors import AnsibleKnowError
-
-        cf_resp = MagicMock()
-        cf_resp.status_code = 429
-        cf_resp.headers = {"cf-mitigated": "challenge", "content-type": "text/html"}
-        cf_resp.raise_for_status = MagicMock()
+        cf_resp = _make_cf_challenge_response()
+        embed_resp = _make_embed_response()
 
         regular_429 = MagicMock()
         regular_429.status_code = 429
@@ -913,17 +954,18 @@ class TestFetchDocCfChallenge:
         ok_resp = _make_ok_response()
 
         mock_client_cf = AsyncMock()
-        mock_client_cf.get = AsyncMock(return_value=cf_resp)
+        mock_client_cf.get = AsyncMock(side_effect=[cf_resp, embed_resp])
 
         mock_client_regular = AsyncMock()
         mock_client_regular.get = AsyncMock(side_effect=[regular_429, ok_resp])
 
-        with pytest.raises(AnsibleKnowError, match="Cloudflare"):
-            await fetch_doc_content(
-                "https://docs.ansible.com/projects/ansible/latest/guide.html",
-                http_client=mock_client_cf,
-            )
-        assert mock_client_cf.get.call_count == 1
+        result_cf = await fetch_doc_content(
+            "https://docs.ansible.com/projects/ansible/latest/guide.html",
+            http_client=mock_client_cf,
+        )
+        assert "From RTD Embed" in result_cf["content"]
+        # One CF probe + one Embed — no docs.ansible.com retries on challenge
+        assert mock_client_cf.get.call_count == 2
 
         docs_mod._page_cache.clear()
         docs_mod._doc_last_request = 0.0
@@ -935,6 +977,122 @@ class TestFetchDocCfChallenge:
             )
         assert result["title"] == "Test Page"
         assert mock_client_regular.get.call_count == 2
+
+
+class TestFetchDocRtdEmbedFallback:
+    @pytest.mark.asyncio
+    async def test_persistent_429_falls_back_to_embed(self):
+        """After exhausting 429 retries, fall back to RTD Embed."""
+        regular_429 = MagicMock()
+        regular_429.status_code = 429
+        regular_429.headers = {"retry-after": "0"}
+        regular_429.content = b""
+        regular_429.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "429 Too Many Requests",
+                request=MagicMock(),
+                response=MagicMock(status_code=429),
+            )
+        )
+
+        embed_resp = _make_embed_response(
+            html="<h1>After 429</h1><p>Embed recovered.</p>",
+        )
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=[regular_429, regular_429, regular_429, embed_resp],
+        )
+
+        with patch("ansible_know.docs.asyncio.sleep", new_callable=AsyncMock):
+            result = await fetch_doc_content(
+                "https://docs.ansible.com/projects/ansible/latest/guide.html",
+                http_client=mock_client,
+            )
+
+        assert "Embed recovered" in result["content"]
+        assert mock_client.get.call_count == docs_mod.MAX_RETRY_ATTEMPTS + 1
+
+    @pytest.mark.asyncio
+    async def test_embed_failure_surfaces_clean_combined_error(self):
+        from ansible_know.errors import AnsibleKnowError
+
+        cf_resp = _make_cf_challenge_response()
+        embed_resp = _make_embed_response(error="External domain not allowed", status_code=400)
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[cf_resp, embed_resp])
+
+        with pytest.raises(AnsibleKnowError, match="Cloudflare managed challenge") as exc_info:
+            await fetch_doc_content(
+                "https://docs.ansible.com/projects/ansible/latest/guide.html",
+                http_client=mock_client,
+            )
+
+        message = str(exc_info.value)
+        assert "RTD Embed fallback also failed" in message
+        assert "External domain not allowed" in message
+        # No filesystem paths leaked
+        assert "/home/" not in message
+        assert "/tmp/" not in message
+
+    def test_map_docs_url_to_rtd(self):
+        mapped = docs_mod._map_docs_url_to_rtd(
+            "https://docs.ansible.com/projects/lint/rules/yaml.html#details",
+        )
+        assert mapped == (
+            "https://ansible.readthedocs.io/projects/lint/rules/yaml.html#details"
+        )
+
+    def test_html_to_markdown_skips_script_and_keeps_headings(self):
+        md = html_to_markdown(
+            '<div role="main"><script>banner()</script>'
+            "<h1>Loops</h1><p>Use <code>loop</code>.</p></div>",
+        )
+        assert "# Loops" in md
+        assert "`loop`" in md
+        assert "banner" not in md
+
+    @pytest.mark.asyncio
+    async def test_embed_uses_rtd_token_when_set(self, monkeypatch):
+        monkeypatch.setenv("ANSIBLE_KNOW_RTD_TOKEN", "secret-token")
+        cf_resp = _make_cf_challenge_response()
+        embed_resp = _make_embed_response()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[cf_resp, embed_resp])
+
+        await fetch_doc_content(
+            "https://docs.ansible.com/projects/ansible/latest/guide.html",
+            http_client=mock_client,
+        )
+
+        embed_headers = mock_client.get.call_args_list[1].kwargs["headers"]
+        assert embed_headers["Authorization"] == "Token secret-token"
+
+    @pytest.mark.asyncio
+    async def test_non_429_http_error_does_not_use_embed(self):
+        """Exhausted 503 must not trigger Embed fallback."""
+        error_resp = MagicMock()
+        error_resp.status_code = 503
+        error_resp.headers = {}
+        error_resp.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "503 Service Unavailable",
+                request=MagicMock(),
+                response=error_resp,
+            )
+        )
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=error_resp)
+
+        with patch("ansible_know.docs.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(httpx.HTTPStatusError):
+                await fetch_doc_content(
+                    "https://docs.ansible.com/projects/ansible/latest/guide.html",
+                    http_client=mock_client,
+                )
+
+        assert mock_client.get.call_count == docs_mod.MAX_RETRY_ATTEMPTS
 
 
 class TestFetchDocRedhat:


### PR DESCRIPTION
## Summary
- When `fetch_doc` hits a Cloudflare managed challenge or persistent HTTP 429 on `docs.ansible.com`, fall back to the RTD Embed API (`app.readthedocs.org/api/v3/embed/`) which bypasses the Cloudflare zone
- Map `docs.ansible.com` → `ansible.readthedocs.io` (paths unchanged), convert Embed HTML to markdown via a Foundation `html_to_markdown` helper, then `clean_rtd_markdown` with existing size/token limits and `sanitize_error`
- Optional `ANSIBLE_KNOW_RTD_TOKEN` for higher Embed rate limits; Red Hat `docs.redhat.com` path (`#183`/`#206`) untouched

## Test plan
- [x] `pytest tests/test_docs.py tests/test_server.py -k 'fetch_doc or embed or rtd' -q` (24 passed)
- [x] `pytest tests/test_docs.py tests/test_redhat_docs.py -q` (114 passed; RH path unchanged)
- [x] `ruff check` on touched files
- [ ] Manual: force CF/429 conditions (or mock) and confirm Embed returns markdown for a known ansible docs URL

Closes #168

Assisted-by: Cursor (Grok 4.5)