### PR TITLE
refactor: share html_to_markdown and RTD API token headers

### DIFF
--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -229,6 +229,7 @@ dependencies on upper layers.
 | `galaxy_config.py` | Galaxy server config from `ansible.cfg` | `galaxy_config.py` |
 | `state.py` | Session state management (collection install tracking) | `state.py` |
 | `tagging.py` | Tag derivation from module FQCN segments | `tagging.py` |
+| `text_utils.py` | RTD/RH markdown cleaning, HTML→markdown, token estimate | `text_utils.py` |
 | `validation.py` | Input validation, error sanitization, response truncation | `validation.py` |
 | `errors.py` | Exception hierarchy and error helpers | `errors.py` |
 | `types.py` | `TypedDict` definitions, `GalaxyDocClient` Protocol | `types.py` |

--- a/src/ansible_know/docs.py
+++ b/src/ansible_know/docs.py
@@ -29,7 +29,7 @@ from ansible_know.config import (
     get_rtd_api_token,
 )
 from ansible_know.errors import AnsibleKnowError
-from ansible_know.text_utils import clean_rtd_markdown, html_to_markdown
+from ansible_know.text_utils import clean_rtd_markdown, estimate_tokens, html_to_markdown
 from ansible_know.types import FetchDocResult, SearchDocsEntry
 from ansible_know.validation import sanitize_error, truncate_response
 
@@ -255,8 +255,14 @@ async def _search_rtd_api(
             "q": f"project:{slug}/latest {query}",
             "page_size": min(limit, 20),
         }
+        headers = _rtd_api_headers()
         try:
-            resp = await client.get(RTD_SEARCH_URL, params=params, timeout=5.0)
+            resp = await client.get(
+                RTD_SEARCH_URL,
+                params=params,
+                headers=headers,
+                timeout=5.0,
+            )
             resp.raise_for_status()
             data = resp.json()
         except (httpx.HTTPError, ValueError) as exc:
@@ -411,11 +417,6 @@ def clear_cache() -> None:
 MAX_DOC_FETCH_SIZE = 2_000_000  # 2MB
 
 
-def _estimate_tokens(text: str) -> int:
-    """Rough token estimate (~4 chars/token) when no x-markdown-tokens header."""
-    return len(text) // 4
-
-
 def _map_docs_url_to_rtd(url: str) -> str:
     """Rewrite docs.ansible.com URLs to ansible.readthedocs.io for Embed API.
 
@@ -430,8 +431,8 @@ def _map_docs_url_to_rtd(url: str) -> str:
     return urlunparse(parsed._replace(netloc=RTD_EMBED_DOCS_HOST))
 
 
-def _rtd_embed_headers() -> dict[str, str]:
-    """Build Embed API headers; optional RTD token increases rate limits."""
+def _rtd_api_headers() -> dict[str, str]:
+    """Build RTD API headers (Embed/Search); optional token increases rate limits."""
     headers = {
         "Accept": "application/json",
         "User-Agent": USER_AGENT,
@@ -465,7 +466,7 @@ async def _fetch_via_rtd_embed(
         resp = await client.get(
             RTD_EMBED_URL,
             params={"url": rtd_url},
-            headers=_rtd_embed_headers(),
+            headers=_rtd_api_headers(),
             follow_redirects=False,
             timeout=30.0,
         )
@@ -524,7 +525,7 @@ async def _fetch_via_rtd_embed(
     markdown = html_to_markdown(html_content)
     content, title = clean_rtd_markdown(markdown)
     # Estimate before truncate so max_tokens matches primary-path gating intent.
-    tokens = _estimate_tokens(content)
+    tokens = estimate_tokens(content)
     if max_tokens is not None and tokens > max_tokens:
         raise AnsibleKnowError(
             f"Page has {tokens} tokens (max_tokens={max_tokens}). "

--- a/src/ansible_know/redhat_docs.py
+++ b/src/ansible_know/redhat_docs.py
@@ -11,12 +11,10 @@ fetch of docs.redhat.com and converts the HTML article to markdown.
 
 from __future__ import annotations
 
-import html
 import json
 import logging
 import re
 import uuid
-from html.parser import HTMLParser
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
@@ -24,7 +22,11 @@ import httpx
 
 from ansible_know.config import REDHAT_DOCS_MCP_URL, USER_AGENT
 from ansible_know.errors import AnsibleKnowError, ValidationError
-from ansible_know.text_utils import clean_redhat_markdown
+from ansible_know.text_utils import (
+    clean_redhat_markdown,
+    estimate_tokens,
+    html_to_markdown,
+)
 from ansible_know.types import FetchDocResult
 from ansible_know.validation import sanitize_error, truncate_response, validate_doc_url
 
@@ -226,16 +228,6 @@ def _mcp_headers(session_id: str | None) -> dict[str, str]:
     return headers
 
 
-def _estimate_tokens(text: str) -> int:
-    """Rough token estimate (~4 chars/token) for Red Hat docs.
-
-    The Red Hat MCP server provides no x-markdown-tokens header, unlike
-    docs.ansible.com's Cloudflare endpoint. This approximation is
-    intentionally rough — used only for max_tokens gating.
-    """
-    return len(text) // 4
-
-
 def _is_mcp_url_rejection(exc: BaseException) -> bool:
     """Return True when *exc* is an upstream RH Docs MCP URL-validation error."""
     if not isinstance(exc, AnsibleKnowError):
@@ -293,241 +285,6 @@ def _alternate_redhat_doc_url(url: str) -> str | None:
     return urlunparse(parsed._replace(path=path or "/"))
 
 
-def _extract_tagged_region(raw_html: str, tag: str) -> str | None:
-    """Extract first ``<tag>...</tag>`` region without catastrophic backtracking."""
-    lower = raw_html.lower()
-    start_token = f"<{tag}"
-    close_token = f"</{tag}>"
-    search_from = 0
-    while True:
-        start = lower.find(start_token, search_from)
-        if start < 0:
-            return None
-        after = start + len(start_token)
-        if after < len(raw_html) and raw_html[after] not in " \t\r\n/>":
-            search_from = after
-            continue
-        end = lower.find(close_token, after)
-        if end < 0:
-            return None
-        return raw_html[start:end + len(close_token)]
-
-
-def _extract_content_html(raw_html: str) -> str:
-    """Prefer ``<article>`` (then ``<main>``) for conversion; else full document."""
-    return (
-        _extract_tagged_region(raw_html, "article")
-        or _extract_tagged_region(raw_html, "main")
-        or raw_html
-    )
-
-
-def _format_markdown_link(label: str, href: str) -> str:
-    """Build a CommonMark link, escaping delimiters; drop unsafe schemes."""
-    href = href.strip()
-    label = label.strip() or href
-    if not href:
-        return label
-
-    parsed = urlparse(href)
-    scheme = (parsed.scheme or "").lower()
-    if scheme and scheme not in {"http", "https"}:
-        # javascript:/data:/mailto: etc. — keep visible text only
-        return label
-    if href.startswith("//"):
-        return label
-
-    safe_label = (
-        label.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
-    )
-    safe_href = href.replace("\\", "\\\\").replace(")", "\\)")
-    if re.search(r"\s", safe_href):
-        return f"[{safe_label}](<{safe_href}>)"
-    return f"[{safe_label}]({safe_href})"
-
-
-class _HtmlToMarkdownParser(HTMLParser):
-    """Minimal HTML→Markdown converter for Red Hat docs article markup."""
-
-    _SKIP_TAGS = frozenset({
-        "script", "style", "nav", "header", "footer", "aside",
-        "button", "svg", "noscript", "form", "rh-button", "rh-icon",
-        "rh-surface", "rh-breadcrumb", "pf-popover",
-    })
-    _BLOCK_TAGS = frozenset({
-        "p", "div", "section", "li", "tr", "blockquote", "pre",
-        "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "table",
-        "article", "main", "br", "hr",
-    })
-
-    def __init__(self) -> None:
-        super().__init__(convert_charrefs=True)
-        self._parts: list[str] = []
-        self._skip_depth = 0
-        self._in_pre = False
-        self._list_stack: list[str] = []  # "ul" | "ol"
-        self._ol_index: list[int] = []
-        self._href: str | None = None
-        self._pending_href_text: list[str] = []
-
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        tag = tag.lower()
-        if self._skip_depth:
-            if tag in self._SKIP_TAGS:
-                self._skip_depth += 1
-            return
-        if tag in self._SKIP_TAGS:
-            self._skip_depth = 1
-            return
-
-        attr_map = {k.lower(): (v or "") for k, v in attrs}
-
-        if tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
-            self._ensure_blank_line()
-            self._parts.append("#" * int(tag[1]) + " ")
-        elif tag == "br":
-            self._parts.append("\n")
-        elif tag == "hr":
-            self._ensure_blank_line()
-            self._parts.append("---\n\n")
-        elif tag == "p":
-            self._ensure_blank_line()
-        elif tag in {"ul", "ol"}:
-            self._ensure_blank_line()
-            self._list_stack.append(tag)
-            self._ol_index.append(0)
-        elif tag == "li":
-            self._ensure_newline()
-            depth = max(len(self._list_stack) - 1, 0)
-            indent = "  " * depth
-            if self._list_stack and self._list_stack[-1] == "ol":
-                self._ol_index[-1] += 1
-                self._parts.append(f"{indent}{self._ol_index[-1]}. ")
-            else:
-                self._parts.append(f"{indent}- ")
-        elif tag == "pre":
-            self._ensure_blank_line()
-            self._emit("```\n")
-            self._in_pre = True
-        elif tag == "code" and not self._in_pre:
-            self._emit("`")
-        elif tag in {"strong", "b"}:
-            self._emit("**")
-        elif tag in {"em", "i"}:
-            self._emit("*")
-        elif tag == "a":
-            href = attr_map.get("href", "")
-            if href and not href.startswith("#"):
-                self._href = href
-                self._pending_href_text = []
-        elif tag == "img":
-            alt = attr_map.get("alt", "")
-            if alt:
-                self._emit(alt)
-
-    def handle_endtag(self, tag: str) -> None:
-        tag = tag.lower()
-        if self._skip_depth:
-            if tag in self._SKIP_TAGS:
-                self._skip_depth -= 1
-            return
-
-        if tag in {"h1", "h2", "h3", "h4", "h5", "h6", "p"}:
-            self._emit("\n\n")
-        elif tag in {"ul", "ol"}:
-            if self._list_stack:
-                self._list_stack.pop()
-            if self._ol_index:
-                self._ol_index.pop()
-            self._emit("\n")
-        elif tag == "li":
-            self._emit("\n")
-        elif tag == "pre":
-            if self._href is not None:
-                if not "".join(self._pending_href_text).endswith("\n"):
-                    self._emit("\n")
-            elif not self._parts or not self._parts[-1].endswith("\n"):
-                self._emit("\n")
-            self._emit("```\n\n")
-            self._in_pre = False
-        elif tag == "code" and not self._in_pre:
-            self._emit("`")
-        elif tag in {"strong", "b"}:
-            self._emit("**")
-        elif tag in {"em", "i"}:
-            self._emit("*")
-        elif tag == "a" and self._href is not None:
-            label = "".join(self._pending_href_text).strip() or self._href
-            self._parts.append(_format_markdown_link(label, self._href))
-            self._href = None
-            self._pending_href_text = []
-        elif tag in self._BLOCK_TAGS:
-            self._ensure_newline()
-
-    def handle_data(self, data: str) -> None:
-        if self._skip_depth:
-            return
-        if self._in_pre:
-            self._emit(data)
-            return
-        # Collapse runs of whitespace outside pre/code blocks
-        if not data.strip():
-            if self._href is not None:
-                pending = "".join(self._pending_href_text)
-                if data and pending and not pending.endswith(("\n", " ", "\t")):
-                    self._emit(" ")
-                return
-            if data and self._parts and not self._parts[-1].endswith(("\n", " ", "\t")):
-                self._emit(" ")
-            return
-        collapsed = re.sub(r"[ \t\r\n]+", " ", data)
-        self._emit(collapsed)
-
-    def _emit(self, text: str) -> None:
-        """Append to link buffer while inside ``<a>``, else to output parts."""
-        if self._href is not None:
-            self._pending_href_text.append(text)
-        else:
-            self._parts.append(text)
-
-    def _ensure_newline(self) -> None:
-        if self._parts and not self._parts[-1].endswith("\n"):
-            self._parts.append("\n")
-
-    def _ensure_blank_line(self) -> None:
-        if not self._parts:
-            return
-        # Inspect a short suffix only — avoid O(n²) joins on large pages.
-        suffix = "".join(self._parts[-3:])
-        if suffix.endswith("\n\n"):
-            return
-        if suffix.endswith("\n"):
-            self._parts.append("\n")
-        else:
-            self._parts.append("\n\n")
-
-    def get_markdown(self) -> str:
-        return "".join(self._parts)
-
-
-def html_to_markdown(raw_html: str) -> str:
-    """Convert Red Hat docs HTML to markdown (stdlib HTMLParser, no extra deps)."""
-    if not raw_html:
-        return ""
-    fragment = _extract_content_html(raw_html)
-    parser = _HtmlToMarkdownParser()
-    try:
-        parser.feed(fragment)
-        parser.close()
-    except Exception:
-        # Best-effort: fall back to stripped text rather than failing the fetch.
-        logger.debug("HTML→markdown parse failed; using stripped text fallback", exc_info=True)
-        text = re.sub(r"(?is)<(script|style).*?>.*?</\1>", "", fragment)
-        text = re.sub(r"(?s)<[^>]+>", " ", text)
-        return html.unescape(re.sub(r"\s+", " ", text)).strip()
-    return parser.get_markdown()
-
-
 def _finalize_doc_result(
     raw_markdown: str,
     source_url: str,
@@ -546,7 +303,7 @@ def _finalize_doc_result(
 
     content, title = clean_redhat_markdown(raw_markdown)
     content = truncate_response(content)
-    tokens = _estimate_tokens(content)
+    tokens = estimate_tokens(content)
 
     if max_tokens is not None and tokens > max_tokens:
         raise AnsibleKnowError(

--- a/src/ansible_know/text_utils.py
+++ b/src/ansible_know/text_utils.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 __all__ = [
     "clean_redhat_markdown",
     "clean_rtd_markdown",
+    "estimate_tokens",
     "html_to_markdown",
 ]
 
@@ -193,6 +194,8 @@ class _HtmlToMarkdownParser(HTMLParser):
     _SKIP_TAGS = frozenset({
         "script", "style", "nav", "header", "footer", "aside",
         "button", "svg", "noscript", "form",
+        # Red Hat / PatternFly chrome (harmless no-ops for Sphinx/RTD HTML)
+        "rh-button", "rh-icon", "rh-surface", "rh-breadcrumb", "pf-popover",
     })
     _BLOCK_TAGS = frozenset({
         "p", "div", "section", "li", "tr", "blockquote", "pre",
@@ -345,6 +348,11 @@ class _HtmlToMarkdownParser(HTMLParser):
 
     def get_markdown(self) -> str:
         return "".join(self._parts)
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token estimate (~4 chars/token) when no provider token header exists."""
+    return len(text) // 4
 
 
 def html_to_markdown(raw_html: str) -> str:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -419,6 +419,22 @@ class TestSearchRtdApi:
         results = await _search_rtd_api("test", limit=5, http_client=mock_client)
         assert len(results) <= 5
 
+    @pytest.mark.asyncio
+    async def test_uses_rtd_token_when_set(self, monkeypatch):
+        monkeypatch.setenv("ANSIBLE_KNOW_RTD_TOKEN", "search-token")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"count": 0, "results": []}
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        await _search_rtd_api("variables", source="ansible-core", http_client=mock_client)
+        headers = mock_client.get.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Token search-token"
+        assert "User-Agent" in headers
+
 
 LINT_MANIFEST = {
     "version": "2.0",

--- a/tests/test_redhat_docs.py
+++ b/tests/test_redhat_docs.py
@@ -12,13 +12,15 @@ import pytest
 from ansible_know.errors import AnsibleKnowError
 from ansible_know.redhat_docs import (
     RedHatDocsClient,
-    _format_markdown_link,
     fetch_redhat_doc,
     fetch_redhat_doc_http,
     html_to_markdown,
     parse_mcp_sse,
 )
-from ansible_know.text_utils import clean_redhat_markdown
+from ansible_know.text_utils import (
+    _format_markdown_link,
+    clean_redhat_markdown,
+)
 
 
 class TestParseMcpSse:


### PR DESCRIPTION
## Summary
- Deduplicate HTML→markdown into Foundation `text_utils.html_to_markdown` (RH PatternFly skip tags included); `redhat_docs` re-exports the shared helper (−250 lines)
- Share `estimate_tokens` across docs Embed fallback and Red Hat paths
- Send `ANSIBLE_KNOW_RTD_TOKEN` on RTD Search as well as Embed via `_rtd_api_headers`
- Document `text_utils.py` in `service-contracts.md` Foundation table

## Test plan
- [x] `pytest tests/test_docs.py tests/test_redhat_docs.py -q` (115 passed locally before commit; targeted 31 passed after polish)
- [x] `ruff check` on touched files
- [ ] CI green

Partial progress on #117 (shared Foundation helpers). Does not close #117 — remaining: `_optional_client`, shared `fetch_rtd_markdown` pipeline, async manifest file I/O.

Assisted-by: Cursor (Grok 4.5)