### PR TITLE
refactor: inject shared httpx into RedHatDocsClient (#197)

### DIFF
--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -196,8 +196,9 @@ layer and `_ReadmeParser` in `readme_parser.py` are the other classes.)
 - `RedHatDocsClient` methods are **async**. It manages its own MCP session
   lifecycle (lazy connect, auto-reconnect on 404 expiry). The client
   instance lives in `SharedState` (created at lifespan, closed at shutdown).
-  It is a transport client, not a data cache — `clear_cache` does not
-  touch it.
+  Prefer injecting the lifespan ``httpx.AsyncClient`` (shared transport);
+  ``close()`` only closes an owned fallback client. It is a transport
+  client, not a data cache — `clear_cache` does not touch it.
 
 ### Violations
 

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -293,8 +293,9 @@ State is split into process-wide and per-session layers (PR #87):
 - **`SharedState`** (process-wide): `galaxy_servers`, `version_info`,
   `enrichment_semaphore`, `redhat_client`. Created once in lifespan.
   `version_info` updated by periodic PyPI check. `redhat_client` is a
-  transport client (not a data cache) — manages its own MCP session
-  lifecycle and is closed at lifespan shutdown, not by `clear_cache`.
+  transport client (not a data cache) — shares the lifespan httpx client
+  when injected, manages MCP session lifecycle, and is closed at lifespan
+  shutdown (without closing the shared httpx client), not by `clear_cache`.
 - **`ServerState`** (per-session): `collection_manager`, `missing_collections`,
   `upgrade_warned`. Created lazily by `SessionManager.get_or_create()`.
 - **`SessionManager`**: manages session lifecycle with `asyncio.Lock`.

--- a/src/ansible_know/redhat_docs.py
+++ b/src/ansible_know/redhat_docs.py
@@ -20,6 +20,7 @@ from urllib.parse import urlparse, urlunparse
 
 import httpx
 
+from ansible_know.async_utils import optional_http_client
 from ansible_know.config import REDHAT_DOCS_MCP_URL, USER_AGENT
 from ansible_know.errors import AnsibleKnowError, ValidationError
 from ansible_know.text_utils import (
@@ -95,22 +96,38 @@ class RedHatDocsClient:
     Connects to ``docs-mcp.api.redhat.com`` via JSON-RPC over Streamable
     HTTP. Sessions are initialized lazily on first ``fetch()`` call and
     re-created transparently when the server returns 404 (session expiry).
+
+    Prefer injecting the lifespan ``httpx.AsyncClient`` so MCP traffic
+    shares the process pool/timeouts. When omitted, an owned client is
+    created on first connect and closed by :meth:`close`.
     """
 
-    def __init__(self, mcp_url: str | None = None):
+    def __init__(
+        self,
+        mcp_url: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ):
         self.mcp_url = mcp_url or REDHAT_DOCS_MCP_URL
         self._session_id: str | None = None
-        self._client: httpx.AsyncClient | None = None
+        self._http_client = http_client
+        self._owned_client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Return the shared client or create a short-lived owned one."""
+        if self._http_client is not None:
+            return self._http_client
+        if self._owned_client is None:
+            self._owned_client = httpx.AsyncClient(
+                timeout=httpx.Timeout(30.0, read=120.0),
+            )
+        return self._owned_client
 
     async def connect(self) -> None:
         """Initialize MCP session. Called automatically by ``fetch()``."""
-        if self._client is None:
-            self._client = httpx.AsyncClient(
-                timeout=httpx.Timeout(30.0, read=120.0),
-            )
+        client = self._get_client()
         self._session_id = None
 
-        resp = await self._client.post(
+        resp = await client.post(
             self.mcp_url,
             json={
                 "jsonrpc": "2.0",
@@ -127,7 +144,7 @@ class RedHatDocsClient:
         resp.raise_for_status()
         self._session_id = resp.headers.get("mcp-session-id")
 
-        await self._client.post(
+        await client.post(
             self.mcp_url,
             json={
                 "jsonrpc": "2.0",
@@ -162,9 +179,9 @@ class RedHatDocsClient:
 
     async def _call_tool(self, name: str, arguments: dict[str, Any]) -> str:
         """Call an MCP tool and return its text content."""
-        if self._client is None:
+        if self._session_id is None:
             raise AnsibleKnowError("RedHatDocsClient not connected")
-        resp = await self._client.post(
+        resp = await self._get_client().post(
             self.mcp_url,
             json={
                 "jsonrpc": "2.0",
@@ -205,10 +222,13 @@ class RedHatDocsClient:
         return _unwrap_mcp_result(raw)
 
     async def close(self) -> None:
-        """Close the HTTP client and clear session state."""
-        if self._client is not None:
-            await self._client.aclose()
-            self._client = None
+        """Close an owned HTTP client (if any) and clear session state.
+
+        Shared lifespan clients are never closed here.
+        """
+        if self._owned_client is not None:
+            await self._owned_client.aclose()
+            self._owned_client = None
         self._session_id = None
 
 
@@ -409,13 +429,9 @@ async def fetch_redhat_doc_http(
             "URL must start with https://docs.redhat.com/ for HTTP fallback"
         )
 
-    client = http_client
-    should_close = False
-    if client is None:
-        client = httpx.AsyncClient(timeout=httpx.Timeout(30.0))
-        should_close = True
-
-    try:
+    async with optional_http_client(
+        http_client, timeout=httpx.Timeout(30.0),
+    ) as client:
         resp = await _http_get_redhat_doc(client, url)
         _validate_redhat_http_response(resp, url)
 
@@ -429,9 +445,6 @@ async def fetch_redhat_doc_http(
             )
 
         return _finalize_doc_result(markdown, str(resp.url), max_tokens)
-    finally:
-        if should_close:
-            await client.aclose()
 
 
 async def fetch_redhat_doc(

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -118,17 +118,6 @@ async def app_lifespan(server):
     from ansible_know.redhat_docs import RedHatDocsClient
 
     galaxy_servers = await run_in_executor(load_galaxy_servers)
-    shared = SharedState(
-        galaxy_servers=galaxy_servers,
-        redhat_client=RedHatDocsClient(),
-    )
-    sessions = SessionManager(shared, collection_factory=CollectionManager)
-    _shared_state = shared
-    _session_manager = sessions
-    for gs in galaxy_servers:
-        auth_type = "token" if gs.token else ("basic" if gs.username else "none")
-        logger.info("Galaxy server: %s (%s, auth=%s)", gs.name, gs.url, auth_type)
-
     from ansible_know.config import USER_AGENT
 
     async with httpx.AsyncClient(
@@ -137,6 +126,17 @@ async def app_lifespan(server):
         follow_redirects=True,
         headers={"User-Agent": USER_AGENT},
     ) as client:
+        shared = SharedState(
+            galaxy_servers=galaxy_servers,
+            redhat_client=RedHatDocsClient(http_client=client),
+        )
+        sessions = SessionManager(shared, collection_factory=CollectionManager)
+        _shared_state = shared
+        _session_manager = sessions
+        for gs in galaxy_servers:
+            auth_type = "token" if gs.token else ("basic" if gs.username else "none")
+            logger.info("Galaxy server: %s (%s, auth=%s)", gs.name, gs.url, auth_type)
+
         shared.version_info = await _check_pypi_version(client)
         check_task = asyncio.create_task(
             _periodic_version_check(client, shared, sessions)

--- a/tests/test_redhat_docs.py
+++ b/tests/test_redhat_docs.py
@@ -127,8 +127,7 @@ class TestRedHatDocsClient:
         ])
         mock_client.aclose = AsyncMock()
 
-        client = RedHatDocsClient()
-        client._client = mock_client
+        client = RedHatDocsClient(http_client=mock_client)
 
         result = await client.fetch("https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/install")
         assert result == markdown
@@ -156,8 +155,7 @@ class TestRedHatDocsClient:
         ])
         mock_client.aclose = AsyncMock()
 
-        client = RedHatDocsClient()
-        client._client = mock_client
+        client = RedHatDocsClient(http_client=mock_client)
 
         result = await client.fetch("https://docs.redhat.com/some/page")
         assert result == markdown
@@ -184,8 +182,7 @@ class TestRedHatDocsClient:
         ])
         mock_client.aclose = AsyncMock()
 
-        client = RedHatDocsClient()
-        client._client = mock_client
+        client = RedHatDocsClient(http_client=mock_client)
 
         with pytest.raises(AnsibleKnowError, match="failed after"):
             await client.fetch("https://docs.redhat.com/broken")
@@ -204,8 +201,7 @@ class TestRedHatDocsClient:
         ])
         mock_client.aclose = AsyncMock()
 
-        client = RedHatDocsClient()
-        client._client = mock_client
+        client = RedHatDocsClient(http_client=mock_client)
 
         result = await client.fetch("https://docs.redhat.com/some/page")
         assert result == inner
@@ -234,8 +230,7 @@ class TestRedHatDocsClient:
         ])
         mock_client.aclose = AsyncMock()
 
-        client = RedHatDocsClient()
-        client._client = mock_client
+        client = RedHatDocsClient(http_client=mock_client)
 
         result = await client.fetch("https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7")
         parsed = json.loads(result)
@@ -247,6 +242,14 @@ class TestRedHatDocsClient:
         client = RedHatDocsClient()
         await client.close()
         await client.close()
+
+    @pytest.mark.asyncio
+    async def test_close_does_not_close_shared_client(self):
+        shared = AsyncMock(spec=httpx.AsyncClient)
+        shared.aclose = AsyncMock()
+        client = RedHatDocsClient(http_client=shared)
+        await client.close()
+        shared.aclose.assert_not_called()
 
 
 class TestCleanRedhatMarkdown:
@@ -697,8 +700,7 @@ class TestCallToolIsError:
         ])
         mock_client.aclose = AsyncMock()
 
-        client = RedHatDocsClient()
-        client._client = mock_client
+        client = RedHatDocsClient(http_client=mock_client)
 
         with pytest.raises(AnsibleKnowError, match="Not a valid Red Hat Documentation link"):
             await client.fetch(


### PR DESCRIPTION
## Summary
- Inject lifespan `httpx.AsyncClient` into `RedHatDocsClient` (Galaxy-style shared vs owned client)
- Keep MCP session reconnect; `close()` never closes the shared client
- Use `optional_http_client` for RH HTTP fallback (`#183`/`#206` path unchanged in behavior)

## Stack
- Base: `refactor/117-http-client-lifecycle` (PR #218)
- `stack_ci: serial` — draft until #218 merges; then rebase onto `main`

## Test plan
- [x] `uv run ruff check` on touched files
- [x] `uv run python -m pytest tests/` (1001 passed)
- [ ] CI green after undraft/rebase onto main

Closes #197.

Assisted-by: Cursor (Grok 4.5)