### PR TITLE
types: AnsibleDocEntry for ansible-doc JSON payloads (#216)

### DIFF
--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -20,7 +20,7 @@ from ansible_know.errors import GalaxyError
 
 if TYPE_CHECKING:
     from ansible_know.galaxy_config import GalaxyServerConfig
-    from ansible_know.types import DocProvenance, ModuleMetadata
+    from ansible_know.types import AnsibleDocPayload, DocProvenance, ModuleMetadata
 
 logger = logging.getLogger("ansible_know")
 
@@ -632,7 +632,7 @@ class GalaxyClient:
 
     async def fetch_module_doc(
         self, module_name: str, version: str | None = None,
-    ) -> tuple[dict[str, Any], DocProvenance]:
+    ) -> tuple[AnsibleDocPayload, DocProvenance]:
         """Fetch module documentation from Galaxy.
 
         Returns (module_doc, meta) where module_doc mimics ansible-doc --json
@@ -720,7 +720,7 @@ class GalaxyClient:
 
     async def fetch_plugin_doc(
         self, plugin_name: str, plugin_type: str, version: str | None = None,
-    ) -> tuple[dict[str, Any], DocProvenance]:
+    ) -> tuple[AnsibleDocPayload, DocProvenance]:
         """Fetch plugin documentation from Galaxy.
 
         Returns (plugin_doc, meta) where plugin_doc mimics ansible-doc --json

--- a/src/ansible_know/parser.py
+++ b/src/ansible_know/parser.py
@@ -22,7 +22,14 @@ from ansible_know.errors import AnsibleDocError, CollectionNotFoundError, is_mis
 from ansible_know.validation import validate_plugin_type
 
 if TYPE_CHECKING:
-    from ansible_know.types import EntryPointInfo, ModuleMetadata, ParamDict, PluginMetadata, RoleMetadata
+    from ansible_know.types import (
+        AnsibleDocPayload,
+        EntryPointInfo,
+        ModuleMetadata,
+        ParamDict,
+        PluginMetadata,
+        RoleMetadata,
+    )
 
 logger = logging.getLogger("ansible_know")
 
@@ -73,7 +80,7 @@ def _batch_timeout(chunk_size: int) -> int:
     return max(60, min(300, 30 + 3 * chunk_size))
 
 
-def _parse_ansible_doc_json(raw: str, *, kind: str = "ansible-doc") -> dict[str, Any]:
+def _parse_ansible_doc_json(raw: str, *, kind: str = "ansible-doc") -> AnsibleDocPayload:
     """Parse ansible-doc --json stdout into a dict, or raise AnsibleDocError."""
     try:
         docs = json.loads(raw)
@@ -91,7 +98,7 @@ def _fetch_docs_chunk(
     *,
     plugin_type: str | None = None,
     collections_path: str | None = None,
-) -> dict[str, Any]:
+) -> AnsibleDocPayload:
     """Run one ansible-doc --json invocation for ``names`` (optionally typed)."""
     if plugin_type is None:
         args: tuple[str, ...] = (*names, "--json")
@@ -113,7 +120,7 @@ def _fetch_docs_batched(
     plugin_type: str | None = None,
     collections_path: str | None = None,
     label: str = "module",
-) -> dict[str, Any]:
+) -> AnsibleDocPayload:
     """Fetch docs for many names with chunking and per-name fallback.
 
     On multi-name chunk failure, falls back to one ansible-doc call per name
@@ -123,7 +130,7 @@ def _fetch_docs_batched(
     if not unique_names:
         return {}
 
-    merged: dict[str, Any] = {}
+    merged: AnsibleDocPayload = {}
     last_exc: AnsibleDocError | None = None
     for start in range(0, len(unique_names), _ANSIBLE_DOC_BATCH_SIZE):
         chunk = unique_names[start:start + _ANSIBLE_DOC_BATCH_SIZE]
@@ -213,7 +220,7 @@ def _run_ansible_doc(
 
 def get_module_doc(
     module_name: str, *, collections_path: str | None = None,
-) -> dict[str, Any]:
+) -> AnsibleDocPayload:
     """Fetch full documentation for a single module.
 
     Returns the parsed JSON from `ansible-doc <module> --json`.
@@ -226,7 +233,7 @@ def get_module_docs(
     module_names: Sequence[str],
     *,
     collections_path: str | None = None,
-) -> dict[str, Any]:
+) -> AnsibleDocPayload:
     """Fetch documentation for many modules in few ansible-doc subprocesses.
 
     ``ansible-doc`` accepts multiple plugin names per invocation. Names are
@@ -357,7 +364,7 @@ def search_modules(
     }
 
 
-def extract_params(module_doc: dict[str, Any]) -> list[ParamDict]:
+def extract_params(module_doc: AnsibleDocPayload) -> list[ParamDict]:
     """Extract parameter specs from a module doc.
 
     Returns:
@@ -388,20 +395,20 @@ def extract_params(module_doc: dict[str, Any]) -> list[ParamDict]:
     return params
 
 
-def extract_examples(module_doc: dict[str, Any]) -> str:
+def extract_examples(module_doc: AnsibleDocPayload) -> str:
     """Extract example YAML snippets from a module doc."""
     module_name = _get_module_name(module_doc)
     return module_doc[module_name].get("examples", "")
 
 
-def _get_module_name(module_doc: dict[str, Any]) -> str:
+def _get_module_name(module_doc: AnsibleDocPayload) -> str:
     """Return the first key from a module doc dict, or raise on empty."""
     if not module_doc:
         raise AnsibleDocError("Module not found or ansible-doc returned empty output.")
     return next(iter(module_doc))
 
 
-def extract_short_description(module_doc: dict[str, Any]) -> str:
+def extract_short_description(module_doc: AnsibleDocPayload) -> str:
     """Extract the module's one-line description."""
     module_name = _get_module_name(module_doc)
     doc_entry = module_doc[module_name].get("doc", {})
@@ -409,7 +416,7 @@ def extract_short_description(module_doc: dict[str, Any]) -> str:
     return desc.strip() if desc else ""
 
 
-def is_api_module(module_doc: dict[str, Any]) -> bool:
+def is_api_module(module_doc: AnsibleDocPayload) -> bool:
     """Detect whether a module talks to an API rather than managing system state over SSH."""
     module_name = _get_module_name(module_doc)
     doc_entry = module_doc[module_name].get("doc", {})
@@ -429,7 +436,7 @@ def is_api_module(module_doc: dict[str, Any]) -> bool:
     return False
 
 
-def extract_module_metadata(module_doc: dict[str, Any]) -> ModuleMetadata:
+def extract_module_metadata(module_doc: AnsibleDocPayload) -> ModuleMetadata:
     """Extract all metadata needed for skill generation."""
     module_name = _get_module_name(module_doc)
     logger.debug("Extracting module metadata for %s", module_name)
@@ -444,7 +451,7 @@ def extract_module_metadata(module_doc: dict[str, Any]) -> ModuleMetadata:
 
 def transform_galaxy_to_ansible_doc_format(
     fqcn: str, entry: dict[str, Any],
-) -> dict[str, Any]:
+) -> AnsibleDocPayload:
     """Convert a Galaxy docs-blob content entry to ansible-doc --json format."""
     ds = entry.get("doc_strings", {})
     raw_doc = ds.get("doc", {})
@@ -507,7 +514,7 @@ def list_roles(
 
 def get_role_doc(
     role_name: str, *, collections_path: str | None = None,
-) -> dict[str, Any]:
+) -> AnsibleDocPayload:
     """Fetch full documentation for a single role.
 
     Returns parsed JSON from ansible-doc. Returns {} if the role
@@ -521,7 +528,7 @@ def get_role_doc(
     return doc
 
 
-def extract_role_metadata(role_doc: dict[str, Any]) -> RoleMetadata:
+def extract_role_metadata(role_doc: AnsibleDocPayload) -> RoleMetadata:
     """Extract metadata from ansible-doc -t role JSON output.
 
     Returns dict with role_name, short_description, and entry_points.
@@ -608,7 +615,7 @@ def get_plugin_doc(
     plugin_type: str,
     *,
     collections_path: str | None = None,
-) -> dict[str, Any]:
+) -> AnsibleDocPayload:
     """Fetch full documentation for a single plugin.
 
     Returns the parsed JSON from `ansible-doc -t <type> <plugin> --json`.
@@ -623,7 +630,7 @@ def get_plugin_docs(
     plugin_type: str,
     *,
     collections_path: str | None = None,
-) -> dict[str, Any]:
+) -> AnsibleDocPayload:
     """Fetch documentation for many plugins of one type in few ansible-doc calls.
 
     Args:
@@ -755,7 +762,7 @@ def search_plugins(
 
 
 def extract_plugin_metadata(
-    plugin_doc: dict[str, Any], plugin_type: str,
+    plugin_doc: AnsibleDocPayload, plugin_type: str,
 ) -> PluginMetadata:
     """Extract all metadata needed for plugin skill generation."""
     plugin_name = _get_module_name(plugin_doc)

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -28,6 +28,27 @@ class ParamDict(TypedDict):
     aliases: list[str]
 
 
+AnsibleDocEntry = TypedDict(
+    "AnsibleDocEntry",
+    {
+        "doc": dict[str, Any],
+        "examples": str,
+        "return": Any,
+        "metadata": dict[str, Any],
+        "entry_points": dict[str, Any],
+    },
+    total=False,
+)
+"""Single ansible-doc --json entry (module, plugin, or role).
+
+All keys are optional (``total=False``) so extra ansible-doc fields are
+tolerated without breaking structural typing.
+"""
+
+AnsibleDocPayload = dict[str, AnsibleDocEntry]
+"""Raw ansible-doc --json payload keyed by FQCN."""
+
+
 class ModuleMetadata(TypedDict):
     """Module metadata extracted by parser.extract_module_metadata()."""
 
@@ -386,7 +407,7 @@ class GalaxyDocClient(Protocol):
 
     async def fetch_module_doc(
         self, module_name: str,
-    ) -> tuple[dict[str, Any], DocProvenance]: ...
+    ) -> tuple[AnsibleDocPayload, DocProvenance]: ...
 
     async def fetch_role_doc(
         self, role_name: str,
@@ -394,7 +415,7 @@ class GalaxyDocClient(Protocol):
 
     async def fetch_plugin_doc(
         self, plugin_name: str, plugin_type: str,
-    ) -> tuple[dict[str, Any], DocProvenance]: ...
+    ) -> tuple[AnsibleDocPayload, DocProvenance]: ...
 
     async def fetch_collection_docs(
         self, collection_namespace: str, version: str | None = None,

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,40 @@
 """Tests for ansible_know.types."""
 
-from ansible_know.types import ManifestPluginEntry, PluginMetadata
+from ansible_know.parser import transform_galaxy_to_ansible_doc_format
+from ansible_know.types import AnsibleDocEntry, AnsibleDocPayload, ManifestPluginEntry, PluginMetadata
+
+
+class TestAnsibleDocEntry:
+    def test_entry_optional_keys(self):
+        entry: AnsibleDocEntry = {
+            "doc": {"short_description": "Test module"},
+            "examples": "- name: example\n  module: test",
+            "return": [],
+            "metadata": {"status": ["preview"]},
+        }
+        assert entry["doc"]["short_description"] == "Test module"
+
+    def test_transform_produces_ansible_doc_payload(self):
+        galaxy_entry = {
+            "doc_strings": {
+                "doc": {
+                    "short_description": "Galaxy module",
+                    "options": [{"name": "foo", "type": "str"}],
+                },
+                "examples": "example yaml",
+                "return": [{"name": "bar"}],
+                "metadata": {"version_added": "1.0.0"},
+            }
+        }
+        payload: AnsibleDocPayload = transform_galaxy_to_ansible_doc_format(
+            "ns.col.mod", galaxy_entry,
+        )
+        assert "ns.col.mod" in payload
+        mod = payload["ns.col.mod"]
+        assert mod["doc"]["short_description"] == "Galaxy module"
+        assert mod["examples"] == "example yaml"
+        assert mod["return"] == [{"name": "bar"}]
+        assert mod["metadata"] == {"version_added": "1.0.0"}
 
 
 class TestPluginTypes:


### PR DESCRIPTION
## Summary
- Add `AnsibleDocEntry` / `AnsibleDocPayload` TypedDicts for raw `ansible-doc --json` shapes
- Annotate parser fetch/batch/transform helpers and Galaxy doc fetch returns
- No MCP tool return shape changes

## Test plan
- [x] `uv run ruff check src/ tests/`
- [x] Targeted + full unit suite green in worktree
- [ ] CI green on PR

Closes #216.

Assisted-by: Cursor (Grok 4.5)