### PR TITLE
feat: adopt Agent Plugins packaging for skill distribution (#223)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ src/ansible_know/
 | `generate_plugin_skill` | idempotent write | Generate a skill package for one plugin |
 | `generate_role_skill` | idempotent write | Generate a skill package for one role |
 | `generate_collection_skills` | idempotent write | Batch generate skills for a collection |
-| `package_as_plugin` | idempotent write | Wrap generated skills into an Agent Plugins directory |
+| `package_as_plugin` | idempotent write | Wrap generated skills into an Agent Plugins directory (+ optional `.tar.gz`, stdio/streamable-http) |
 | `package_for_lola` | idempotent write | Deprecated: wrap skills into a Lola module (prefer `package_as_plugin`) |
 | `clear_cache` | idempotent write | Clear Galaxy and/or doc manifest caches |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Runtime requirement: `ansible-core` must be installed in the same environment (f
 
 ```
 src/ansible_know/
-├── server.py              # FastMCP server: 19 tools, 6 resources, 5 prompts (entrypoint)
+├── server.py              # FastMCP server: 20 tools, 6 resources, 5 prompts (entrypoint)
 ├── parser.py              # ansible-doc wrapper — module discovery and metadata extraction
 ├── resolution.py          # local-then-Galaxy doc resolution + multi-server search
 ├── readme_parser.py       # Parse Galaxy role README HTML into structured data
@@ -57,7 +57,8 @@ src/ansible_know/
 | `generate_plugin_skill` | idempotent write | Generate a skill package for one plugin |
 | `generate_role_skill` | idempotent write | Generate a skill package for one role |
 | `generate_collection_skills` | idempotent write | Batch generate skills for a collection |
-| `package_for_lola` | idempotent write | Wrap generated skills into a Lola module directory |
+| `package_as_plugin` | idempotent write | Wrap generated skills into an Agent Plugins directory |
+| `package_for_lola` | idempotent write | Deprecated: wrap skills into a Lola module (prefer `package_as_plugin`) |
 | `clear_cache` | idempotent write | Clear Galaxy and/or doc manifest caches |
 
 ## MCP Resources

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ claude mcp add ansible-know --transport http https://know.ansible.ar/mcp
 | `generate_role_skill(role_name, install_to?)` | Generate a skill package for one role |
 | `generate_plugin_skill(plugin_name, plugin_type, install_to?)` | Generate a skill package for one plugin |
 | `generate_collection_skills(collection_namespace, install_to?)` | Batch generate skills for an entire collection |
-| `package_as_plugin(collection, output_dir, source_dir?, plugin_name?, include_mcp_config?, write_plugin_json?)` | Wrap generated skills into an Agent Plugins directory (`plugin.json` + flat `skills/` + optional `mcp.json`; does not change `generate_*` layout) |
+| `package_as_plugin(collection, output_dir, source_dir?, plugin_name?, include_mcp_config?, write_plugin_json?, write_tarball?, mcp_transport?, mcp_url?)` | Wrap generated skills into an Agent Plugins directory (`plugin.json` + flat `skills/` + optional `mcp.json` + `.tar.gz`; stdio or streamable-http; does not change `generate_*` layout) |
 | `package_for_lola(collection, output_dir, source_dir?, module_name?, write_market_yml?)` | **Deprecated** — prefer `package_as_plugin`. Wrap generated skills into a Lola module directory |
 
 ### Maintenance

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Together with [Ansible Devtools MCP](https://github.com/ansible/ansible-dev-tool
  | generate_plugin_skill      |  |                          |  |              |
  | generate_collection_skills |  |                          |  |              |
  | list_skills / get_skill    |  |                          |  |              |
+ | package_as_plugin          |  |                          |  |              |
  | package_for_lola           |  |                          |  |              |
  | clear_cache                |  |                          |  |              |
  |                            |  |                          |  |              |
@@ -262,7 +263,8 @@ claude mcp add ansible-know --transport http https://know.ansible.ar/mcp
 | `generate_role_skill(role_name, install_to?)` | Generate a skill package for one role |
 | `generate_plugin_skill(plugin_name, plugin_type, install_to?)` | Generate a skill package for one plugin |
 | `generate_collection_skills(collection_namespace, install_to?)` | Batch generate skills for an entire collection |
-| `package_for_lola(collection, output_dir, source_dir?, module_name?, write_market_yml?)` | Wrap generated skills into a Lola module directory (Layer 2 packaging; does not change `generate_*` layout) |
+| `package_as_plugin(collection, output_dir, source_dir?, plugin_name?, include_mcp_config?, write_plugin_json?)` | Wrap generated skills into an Agent Plugins directory (`plugin.json` + flat `skills/` + optional `mcp.json`; does not change `generate_*` layout) |
+| `package_for_lola(collection, output_dir, source_dir?, module_name?, write_market_yml?)` | **Deprecated** — prefer `package_as_plugin`. Wrap generated skills into a Lola module directory |
 
 ### Maintenance
 

--- a/docs/architecture/adr/0007-agentskills-spec-compliance.md
+++ b/docs/architecture/adr/0007-agentskills-spec-compliance.md
@@ -116,11 +116,12 @@ gap, not a spec violation on our side.
 We propose patching next-mcp's `_loadLocalSource` to scan 2+ levels,
 citing the spec. This benefits all skill producers that use namespace grouping.
 
-### Lola packaging is a packaging concern (not a generation format)
+### Packaging is a packaging concern (not a generation format)
 
-Lola is a distribution channel, not a generation format. Our spec-compliant
-output is wrapped into a Lola module as a separate packaging step
-(``package_for_lola`` / #149). No special ``generate_*`` output mode.
+Distribution wraps are separate from generation. Preferred Layer-2 wrap is
+Agent Plugins via ``package_as_plugin`` (#223 / ADR-0009). Deprecated Lola
+wrap ``package_for_lola`` (#149) remains for one release cycle. No special
+``generate_*`` output mode.
 
 ## Consequences
 
@@ -168,6 +169,8 @@ Issue [#148](https://github.com/leogallego/ansible-know-mcp/issues/148)
   required for interoperability with next-mcp's SkillRegistry
 - [ADR-0008](0008-three-layer-distribution.md) — one output format makes
   the three-layer model possible
+- [ADR-0009](0009-agent-plugins-distribution.md) — preferred Layer-2
+  packaging wrap (Agent Plugins)
 
 ## Revision History
 
@@ -175,3 +178,4 @@ Issue [#148](https://github.com/leogallego/ansible-know-mcp/issues/148)
 |------|--------|--------|
 | 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial proposal |
 | 2026-08-03 | Leonardo Gallego (Assisted-by: Cursor) | Accepted after #148; consumer gaps point to #200 / #149 |
+| 2026-08-11 | Leonardo Gallego (Assisted-by: Cursor (Grok 4.5)) | Prefer Agent Plugins packaging (#223 / ADR-0009); Lola wrap deprecated |

--- a/docs/architecture/adr/0008-three-layer-distribution.md
+++ b/docs/architecture/adr/0008-three-layer-distribution.md
@@ -62,15 +62,23 @@ next-mcp's local scanner is shallow.
 Skills are generated once by a platform team, pushed to a GitHub repo,
 consumed by multiple developers.
 
-Two consumption paths:
+Primary packaging path:
+- **Agent Plugins (preferred):** Wrap generated skills with
+  ``package_as_plugin`` / Domain ``package_as_agent_plugin`` (#223) into
+  an Agent Plugins directory (`plugin.json`, flat `skills/{skill}/SKILL.md`,
+  optional `mcp.json` for know-mcp). Any conformant client can discover the
+  package. See [ADR-0009](0009-agent-plugins-distribution.md).
+
+Secondary / legacy paths:
 - **next-mcp SkillRegistry:** `type: "github"` source. Lola format
   detection can load nested skills **only** when the repo uses Lola
   layout (`{module}/skills/{skill}/SKILL.md`). Raw ansible-know output
   (`skills/{collection}/{module}/SKILL.md`) is **not** Lola layout —
-  wrap via #149 (or equivalent) before relying on GitHub Lola loading.
-  Vercel/generic GitHub loaders remain 1-level.
-- **Lola:** Wrap generated skills with ``package_for_lola`` (#149), then
-  distribute to 40+ agents via `lola install` / marketplace.
+  wrap via Agent Plugins (#223) or deprecated ``package_for_lola`` (#149)
+  before relying on GitHub Lola loading. Vercel/generic GitHub loaders
+  remain 1-level; Agent Plugins flat `skills/` matches that scan depth.
+- **Lola (deprecated):** ``package_for_lola`` (#149) remains for one
+  release cycle, then removal. Prefer Agent Plugins.
 
 **Value:** Persistence, sharing, version control, cross-agent reach.
 
@@ -104,8 +112,9 @@ generated once per collection version, served to all developers.
 - **Layer 1 gap (next-mcp)**: `_loadLocalSource` scans 1 level. Our
   2-level output (collection/skill) is within agentskills.io bounds but
   missed by the current implementation until upstream expands depth.
-- **Layer 2 packaging**: Lola/GitHub Lola consumption needs a wrap step
-  (#149); not automatic from raw nested trees.
+- **Layer 2 packaging**: Repository consumption needs a wrap step
+  (#223 Agent Plugins preferred; #149 Lola deprecated); not automatic
+  from raw nested trees.
 - **Layer 3 infrastructure**: remote deployment requires hosting,
   authentication, and monitoring. Not trivial for enterprise environments.
 - **Scope creep risk**: three layers could expand the project's scope
@@ -126,9 +135,10 @@ would break. Spec compliance makes the layers possible.
   Alignment details:
   [`docs/superpowers/specs/2026-08-02-skill-discoverability-alignment.md`](../../superpowers/specs/2026-08-02-skill-discoverability-alignment.md)
 - **Layer 2** (repository): generated skills pushed to a GitHub repo;
-  Lola packaging via MCP tool ``package_for_lola`` / Domain
-  ``package_collection_for_lola`` (#149) — wrap only; does not change
-  ``generate_*`` layout (ADR-0007).
+  Agent Plugins packaging via MCP tool ``package_as_plugin`` / Domain
+  ``package_as_agent_plugin`` (#223 / ADR-0009) — wrap only; does not
+  change ``generate_*`` layout (ADR-0007). Deprecated Lola wrap
+  ``package_for_lola`` (#149) kept for one release cycle.
 - **Layer 3** (remote): FastMCP HTTP/SSE transport (see ADR-0001). Not
   yet implemented — requires hosting, auth, and monitoring infrastructure
   (#71).
@@ -147,6 +157,8 @@ would break. Spec compliance makes the layers possible.
   defines the post-upstream integration path
 - [ADR-0007](0007-agentskills-spec-compliance.md) — one output format
   makes the three-layer model possible
+- [ADR-0009](0009-agent-plugins-distribution.md) — Agent Plugins as
+  primary Layer-2 packaging format
 
 ## Revision History
 
@@ -155,3 +167,4 @@ would break. Spec compliance makes the layers possible.
 | 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial proposal |
 | 2026-08-03 | Leonardo Gallego (Assisted-by: Cursor) | Layer 1: project-scoped skills + AGENTS.md host discovery; correct Lola/GitHub claims; dual-config; scan-depth tracking |
 | 2026-08-03 | Leonardo Gallego (Assisted-by: Cursor) | Layer 1: optional `ANSIBLE_KNOW_SKILLS_PATH` multi-path reads (#182) |
+| 2026-08-11 | Leonardo Gallego (Assisted-by: Cursor (Grok 4.5)) | Layer 2: Agent Plugins primary (#223); Lola deprecated one cycle |

--- a/docs/architecture/adr/0009-agent-plugins-distribution.md
+++ b/docs/architecture/adr/0009-agent-plugins-distribution.md
@@ -1,0 +1,89 @@
+# ADR 0009: Agent Plugins as Layer-2 Distribution Format
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-11
+
+## Context
+
+Layer 2 repository distribution (ADR-0008) previously relied on Lola-specific
+packaging (`package_for_lola` / `lola-market.yml`, #149). That wrap works for
+the Lola ecosystem but is not a portable, multi-client standard.
+
+The [Agent Plugins specification v1.0.0](https://agent-plugins.org/specification)
+defines a vendor-neutral plugin directory with:
+
+- Required `plugin.json` (closed schema, `$schema` + `name`)
+- Optional flat `skills/` discovery (one level of `SKILL.md` children)
+- Optional `mcp.json` for bundled MCP servers (stdio / streamable-http / sse)
+
+Our generated skills already conform to the Agent Skills specification
+(ADR-0007 / #148). The remaining gap is packaging for portable discovery —
+including shipping know-mcp itself beside pre-generated skills.
+
+## Decision
+
+Adopt Agent Plugins as the **primary** Layer-2 packaging format.
+
+1. Add Domain function `package_as_agent_plugin()` and MCP tool
+   `package_as_plugin` that wrap already-generated nested skills into:
+
+   ```text
+   {plugin}/
+   ├── plugin.json
+   ├── mcp.json                 # optional (uvx ansible-know-mcp stdio)
+   └── skills/{skill}/SKILL.md  # flat; no recursive nesting
+   ```
+
+2. Keep `generate_*` output nested (`skills/{collection}/{module}/`) —
+   flatten **only** at packaging time (same wrap pattern as #149).
+
+3. Deprecate `package_for_lola` for one release cycle (still functional with
+   warning). Remove in a later release after consumers migrate.
+
+4. Default plugin name is `ansible-{collection-kebab}`. Names that violate
+   Agent Plugins §5.5 (including the 64-character limit) fail closed — callers
+   must supply an explicit `plugin_name`.
+
+## Consequences
+
+### Positive
+
+- Portable distribution across Agent Plugins–conformant clients.
+- Single directory can ship MCP tools **and** pre-generated skills.
+- Flat packaged `skills/` aligns with shallow scanners (related: #200).
+- No change to ADR-0007 generate-time layout.
+
+### Negative
+
+- Another packaging tool on the public MCP surface (20 tools).
+- Default names longer than 64 characters need an explicit override.
+- Lola consumers must migrate within one release cycle.
+
+### Neutral
+
+- `AGENTS.md` host discovery for flat vs nested trees remains Layer 1 and is
+  tracked separately (#222).
+
+## Related Decisions
+
+- [ADR-0007](0007-agentskills-spec-compliance.md) — skill content format
+- [ADR-0008](0008-three-layer-distribution.md) — three-layer model; Layer 2
+  now prefers Agent Plugins
+
+## References
+
+- [Agent Plugins Specification v1.0.0](https://agent-plugins.org/specification)
+- [Plugin manifest schema](https://agent-plugins.org/schemas/1.0.0/plugin.schema.json)
+- [MCP config schema](https://agent-plugins.org/schemas/1.0.0/mcp.schema.json)
+- Issue [#223](https://github.com/leogallego/ansible-know-mcp/issues/223)
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-08-11 | Leonardo Gallego (Assisted-by: Cursor (Grok 4.5)) | Initial acceptance |

--- a/docs/architecture/adr/0009-agent-plugins-distribution.md
+++ b/docs/architecture/adr/0009-agent-plugins-distribution.md
@@ -53,12 +53,18 @@ Adopt Agent Plugins as the **primary** Layer-2 packaging format.
 
 5. Artifact format is **`.tar.gz`** (not ZIP) for consistency with Ansible
    collections and Pulp. Filename is `{plugin-name}-{version}.tar.gz`.
+   Archives include only allowlisted members (`plugin.json`, `mcp.json`,
+   `skills/`); symlinks are omitted.
 
 6. `mcp.json` supports `stdio` (default `uvx ansible-know-mcp`) and
    `streamable-http` (requires `mcp_url` for AAP-hosted know-mcp).
 
 7. `plugin.json` `keywords` include `ansible`, `automation`, namespace,
    collection kebab, collection FQCN, and packaged skill names (capped).
+
+8. `write_plugin_json=False` is an intentional escape hatch for staging
+   trees that are **not** claimed as Agent Plugins–conformant packages.
+   Defaults write a valid `plugin.json`.
 
 ### Explicitly out of scope for know-mcp packaging
 

--- a/docs/architecture/adr/0009-agent-plugins-distribution.md
+++ b/docs/architecture/adr/0009-agent-plugins-distribution.md
@@ -35,8 +35,9 @@ Adopt Agent Plugins as the **primary** Layer-2 packaging format.
    ```text
    {plugin}/
    ├── plugin.json
-   ├── mcp.json                 # optional (uvx ansible-know-mcp stdio)
+   ├── mcp.json                 # optional (stdio or streamable-http)
    └── skills/{skill}/SKILL.md  # flat; no recursive nesting
+   {plugin}-{version}.tar.gz    # optional Pulp/AAP artifact (default on)
    ```
 
 2. Keep `generate_*` output nested (`skills/{collection}/{module}/`) —
@@ -49,6 +50,26 @@ Adopt Agent Plugins as the **primary** Layer-2 packaging format.
    Agent Plugins §5.5 (including the 64-character limit) fail closed — callers
    must supply an explicit `plugin_name`.
 
+5. Artifact format is **`.tar.gz`** (not ZIP) for consistency with Ansible
+   collections and Pulp. Filename is `{plugin-name}-{version}.tar.gz`.
+
+6. `mcp.json` supports `stdio` (default `uvx ansible-know-mcp`) and
+   `streamable-http` (requires `mcp_url` for AAP-hosted know-mcp).
+
+7. `plugin.json` `keywords` include `ansible`, `automation`, namespace,
+   collection kebab, collection FQCN, and packaged skill names (capped).
+
+### Explicitly out of scope for know-mcp packaging
+
+- **JFrog path-based identity** (`name/version/name-version.zip`): that layout
+  is a **registry storage convention**. know-mcp produces a portable plugin
+  directory + tarball; PAH/Pulp/Artifactory decide how to place the artifact
+  under their repository path scheme when uploading.
+- **Multi-harness manifest directories** (`.claude-plugin/`, `.cursor-plugin/`,
+  …): Agent Plugins v1 portable discovery uses root `plugin.json`. Harness-
+  specific sidecars are client/marketplace extensions and can be added later
+  without changing the core wrap.
+
 ## Consequences
 
 ### Positive
@@ -57,6 +78,8 @@ Adopt Agent Plugins as the **primary** Layer-2 packaging format.
 - Single directory can ship MCP tools **and** pre-generated skills.
 - Flat packaged `skills/` aligns with shallow scanners (related: #200).
 - No change to ADR-0007 generate-time layout.
+- `.tar.gz` artifact aligns with Pulp/AAP content pipelines.
+- Enterprise `mcp.json` can point at AAP-hosted streamable-http know-mcp.
 
 ### Negative
 
@@ -68,6 +91,7 @@ Adopt Agent Plugins as the **primary** Layer-2 packaging format.
 
 - `AGENTS.md` host discovery for flat vs nested trees remains Layer 1 and is
   tracked separately (#222).
+- Registry path layout and multi-harness sidecars remain hosting concerns.
 
 ## Related Decisions
 
@@ -87,3 +111,4 @@ Adopt Agent Plugins as the **primary** Layer-2 packaging format.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-08-11 | Leonardo Gallego (Assisted-by: Cursor (Grok 4.5)) | Initial acceptance |
+| 2026-08-11 | Leonardo Gallego (Assisted-by: Cursor (Grok 4.5)) | tar.gz artifact, streamable-http mcp.json, richer keywords; clarify registry/harness out of scope |

--- a/docs/architecture/adr/0009-agent-plugins-distribution.md
+++ b/docs/architecture/adr/0009-agent-plugins-distribution.md
@@ -64,7 +64,9 @@ Adopt Agent Plugins as the **primary** Layer-2 packaging format.
 
 8. `write_plugin_json=False` is an intentional escape hatch for staging
    trees that are **not** claimed as Agent Plugins–conformant packages.
-   Defaults write a valid `plugin.json`.
+   Defaults write a valid `plugin.json`. `write_tarball=True` requires
+   `write_plugin_json=True` so distribution artifacts always include the
+   required manifest.
 
 ### Explicitly out of scope for know-mcp packaging
 

--- a/docs/architecture/adr/0009-agent-plugins-distribution.md
+++ b/docs/architecture/adr/0009-agent-plugins-distribution.md
@@ -46,9 +46,10 @@ Adopt Agent Plugins as the **primary** Layer-2 packaging format.
 3. Deprecate `package_for_lola` for one release cycle (still functional with
    warning). Remove in a later release after consumers migrate.
 
-4. Default plugin name is `ansible-{collection-kebab}`. Names that violate
-   Agent Plugins §5.5 (including the 64-character limit) fail closed — callers
-   must supply an explicit `plugin_name`.
+4. Default plugin name is `ansible-{collection-kebab}-agentplugin` (distinct
+   from collection package names; signals Agent Plugins format). Names that
+   violate Agent Plugins §5.5 (including the 64-character limit) fail closed —
+   callers must supply an explicit `plugin_name`.
 
 5. Artifact format is **`.tar.gz`** (not ZIP) for consistency with Ansible
    collections and Pulp. Filename is `{plugin-name}-{version}.tar.gz`.
@@ -112,3 +113,4 @@ Adopt Agent Plugins as the **primary** Layer-2 packaging format.
 |------|--------|--------|
 | 2026-08-11 | Leonardo Gallego (Assisted-by: Cursor (Grok 4.5)) | Initial acceptance |
 | 2026-08-11 | Leonardo Gallego (Assisted-by: Cursor (Grok 4.5)) | tar.gz artifact, streamable-http mcp.json, richer keywords; clarify registry/harness out of scope |
+| 2026-08-11 | Leonardo Gallego (Assisted-by: Cursor (Grok 4.5)) | Default plugin name suffix `-agentplugin` to distinguish from collections |

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -16,6 +16,7 @@ decision with its context, rationale, and consequences.
 | [0006](0006-upstream-first-integration.md) | Upstream-First Integration with @ansible/mcp-server (next) | Proposed |
 | [0007](0007-agentskills-spec-compliance.md) | agentskills.io Specification Compliance | Accepted |
 | [0008](0008-three-layer-distribution.md) | Three-Layer Skill Distribution Model | Proposed |
+| [0009](0009-agent-plugins-distribution.md) | Agent Plugins as Layer-2 Distribution Format | Accepted |
 
 ## Format
 

--- a/docs/architecture/project-strategy.md
+++ b/docs/architecture/project-strategy.md
@@ -14,7 +14,7 @@
 | Language | Python (FastMCP) |
 | License | GPL-3.0-or-later |
 | Distribution | PyPI (`uvx ansible-know-mcp`) |
-| Tools | 18 |
+| Tools | 20 |
 | Resources | 6 |
 | Prompts | 5 |
 | Tests | 974 collected (unit + integration; integration skipped by default) |

--- a/docs/architecture/project-strategy.md
+++ b/docs/architecture/project-strategy.md
@@ -114,7 +114,7 @@ The Ansible DevTools MCP server, bundled in the VS Code extension. Our primary i
 - **Repo:** `github.com/ansible/vscode-ansible`
 - **Version:** 0.0.1 (pre-release)
 - **Relationship:** We upstream knowledge features; they distribute skills via the SkillRegistry
-- **Integration point:** Shared project `skills/` directory (Layer 1 dual-config + `AGENTS.md`; see ADR-0008 / #181) or GitHub source after Lola packaging (#149)
+- **Integration point:** Shared project `skills/` directory (Layer 1 dual-config + `AGENTS.md`; see ADR-0008 / #181) or GitHub/Agent Plugins packaging (#223; Lola wrap #149 deprecated)
 - **Gap:** `_loadLocalSource` scans 1 level; tracked in [#200](https://github.com/leogallego/ansible-know-mcp/issues/200) (upstream later)
 - **Pitch document:** [upstream-integration-proposal-2026-06-26.md](../research/upstream-integration-proposal-2026-06-26.md)
 
@@ -126,13 +126,25 @@ The AAP platform MCP server for Controller, EDA, and Gateway operations.
 - **Relationship:** Future home for `aap-mcp-skills` (Phase 4, TypeScript rewrite)
 - **No current integration** — the platform MCP ecosystem is the long-term direction
 
+### Agent Plugins
+
+Open packaging format for bundling Agent Skills and MCP servers.
+
+- **Spec:** [agent-plugins.org/specification](https://agent-plugins.org/specification)
+- **Relationship:** Primary Layer-2 distribution wrap via MCP tool
+  ``package_as_plugin`` (#223 / ADR-0009). Ships flat `skills/` plus optional
+  `mcp.json` for know-mcp.
+- **Not a generation format** — packaging is a post-generate wrap step; nested
+  `generate_*` layout is unchanged (ADR-0007).
+
 ### Lola
 
 Cross-agent AI skill package manager by Red Hat Product Security.
 
 - **Repo:** `github.com/LobsterTrap/lola`
 - **Marketplace:** `github.com/RedHatProductSecurity/lola-market`
-- **Relationship:** Distribution channel. Wrap our spec-compliant skills with MCP tool ``package_for_lola`` (#149) into Lola modules for cross-agent installation (40+ agents).
+- **Relationship:** Legacy distribution channel. ``package_for_lola`` (#149)
+  is deprecated for one release cycle in favor of Agent Plugins (#223).
 - **Not a generation format** — Lola packaging is a post-generate wrap step, not a `generate_*` output mode.
 
 ### agentskills.io

--- a/docs/architecture/project-strategy.md
+++ b/docs/architecture/project-strategy.md
@@ -163,7 +163,7 @@ The standard specification for AI agent skills.
 1. ~~**Finalize issue #148**~~ — **Done** (closed; ADR-0007 Accepted)
 2. ~~**Draft next-mcp scan depth proposal**~~ — **Tracked** as [#200](https://github.com/leogallego/ansible-know-mcp/issues/200)
 3. ~~**#182** — multi-path `list_skills` / `get_skill`~~ (done: `ANSIBLE_KNOW_SKILLS_PATH`)
-4. **#149** — Lola packaging helper (Layer 2)
+4. ~~**#149** — Lola packaging helper (Layer 2)~~ — **Done** (deprecated wrap; prefer [#223](https://github.com/leogallego/ansible-know-mcp/issues/223) / [ADR-0009](adr/0009-agent-plugins-distribution.md))
 5. **#189 / #125** — FastMCP 4 / MCP 2026-07-28 session migration (blocked on stable release)
 
 ---

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -265,6 +265,9 @@ dependencies on upper layers.
 | `ValidationError` | Exception | `errors.py:26-27` |
 | `PackageAsPluginResult` | `TypedDict` | `types.py` (added in #223) |
 | `AgentPluginManifest` | `TypedDict` | `types.py` (added in #223) |
+| `AgentMcpStdioServer` | `TypedDict` | `types.py` (added in #223) |
+| `AgentMcpHttpServer` | `TypedDict` | `types.py` (added in #223) |
+| `AgentMcpServer` | union alias | `types.py` (added in #223) |
 | `AgentMcpConfig` | `TypedDict` | `types.py` (added in #223) |
 | `PackageForLolaResult` | `TypedDict` | `types.py` (added in #149; deprecated wrap) |
 

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -263,6 +263,10 @@ dependencies on upper layers.
 | `GalaxyError` | Exception | `errors.py:18-19` |
 | `CollectionInstallError` | Exception | `errors.py:22-23` |
 | `ValidationError` | Exception | `errors.py:26-27` |
+| `PackageAsPluginResult` | `TypedDict` | `types.py` (added in #223) |
+| `AgentPluginManifest` | `TypedDict` | `types.py` (added in #223) |
+| `AgentMcpConfig` | `TypedDict` | `types.py` (added in #223) |
+| `PackageForLolaResult` | `TypedDict` | `types.py` (added in #149; deprecated wrap) |
 
 ### Error Hierarchy
 

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -57,7 +57,7 @@ decorated tool, resource, and prompt handler functions. FastMCP manages:
 
 | Element | File | Registration |
 |---------|------|--------------|
-| 19 tool handlers | `server.py` | `@mcp.tool(annotations=ToolAnnotations(...))` |
+| 20 tool handlers | `server.py` | `@mcp.tool(annotations=ToolAnnotations(...))` |
 | 6 resource handlers | `server.py` | `@mcp.resource(uri, ...)` |
 | 5 prompt handlers | `server.py` | `@mcp.prompt` |
 | Lifespan hook | `server.py` | `@lifespan` decorator on `app_lifespan()` |
@@ -105,7 +105,7 @@ business logic. Domain modules are imported lazily to avoid loading
 | Domain Module | Functions Called | File |
 |---------------|----------------|------|
 | `parser` | `search_modules()`, `get_module_doc()`, `get_module_docs()`, `load_module_metadata_batch()`, `get_plugin_doc()`, `get_plugin_docs()`, `load_plugin_metadata_batch()`, `get_role_doc()`, `list_roles()`, `extract_module_metadata()`, `extract_role_metadata()` | `parser.py` |
-| `skills` | `render_skill()`, `write_skill_package()`, `render_role_skill()`, `write_role_skill_package()`, `package_collection_for_lola()`, `list_skills_sync()`, `get_skill_sync()`, `collection_skill_name()` / `fqcn_to_skill_name()` / related naming helpers | `skills.py` |
+| `skills` | `render_skill()`, `write_skill_package()`, `render_role_skill()`, `write_role_skill_package()`, `package_as_agent_plugin()`, `package_collection_for_lola()` (deprecated), `list_skills_sync()`, `get_skill_sync()`, `collection_skill_name()` / `fqcn_to_skill_name()` / related naming helpers | `skills.py` |
 | `collection_manifest` | `generate_manifest()`, `load_cached_manifest()` | `collection_manifest.py` |
 | `docs` | `search_docs()`, `fetch_doc_content()` | `docs.py` |
 | `collections` | `ensure_collection()`, `list_installed()` | `collections.py` |
@@ -119,7 +119,8 @@ business logic. Domain modules are imported lazily to avoid loading
 | Up | `ModuleMetadata` | `types.py:8-15` — TypedDict |
 | Up | `RoleMetadata` | `types.py:18-23` — TypedDict |
 | Up | `EnsureCollectionResult` | `types.py` — TypedDict (added in PR #60) |
-| Up | `PackageForLolaResult` | `types.py` — TypedDict (added in #149) |
+| Up | `PackageAsPluginResult` | `types.py` — TypedDict (added in #223) |
+| Up | `PackageForLolaResult` | `types.py` — TypedDict (added in #149; deprecated wrap) |
 | Up | `dict[str, str]` | Search results (module FQCN → description) |
 | Up | `dict[str, Any]` | Raw ansible-doc JSON, manifest dicts |
 | Up | Exceptions | `AnsibleDocError`, `CollectionNotFoundError`, `CollectionInstallError` |

--- a/docs/superpowers/plans/2026-08-11-issue-223-agent-plugins.md
+++ b/docs/superpowers/plans/2026-08-11-issue-223-agent-plugins.md
@@ -1,0 +1,204 @@
+# Plan: Agent Plugins packaging (#223)
+
+**Issue:** [#223](https://github.com/leogallego/ansible-know-mcp/issues/223)  
+**Scope:** medium  
+**Branch:** `feat/223-agent-plugins` from `origin/main`  
+**Design decision:** Option (b) — keep nested `generate_*` layout; flatten only in packaging (mirror `package_collection_for_lola`).
+
+## Assessment summary
+
+```text
+Assessment:
+  codebase_still_matches: true
+  scope: medium
+  files_to_modify: [
+    src/ansible_know/skills.py,
+    src/ansible_know/server.py,
+    src/ansible_know/types.py,
+    src/ansible_know/validation.py,
+    docs/architecture/adr/0008-three-layer-distribution.md,
+    docs/architecture/adr/0009-agent-plugins-distribution.md (new),
+    docs/architecture/adr/README.md,
+    docs/architecture/service-contracts.md,
+    tests/test_agent_plugin_packaging.py (new),
+    README.md,
+    CLAUDE.md
+  ]
+  skills_needed: [pep8-review, pr-architecture-review, contract-docstrings, git-review]
+  risks: [public MCP API growth, plugin name constraints (64 chars), deprecate without breaking Lola]
+  blockers_found: []
+  out_of_scope: [#222 AGENTS.md enrichment, #200 scan depth, #148/#149 already done]
+  brief: Add Agent Plugins Layer-2 packaging (plugin.json + flat skills/ + optional mcp.json); deprecate Lola packaging for one release cycle.
+```
+
+## Acceptance criteria (from issue)
+
+1. `package_as_agent_plugin()` Domain function writes a conformant plugin directory.
+2. MCP tool `package_as_plugin` exposes it.
+3. `package_for_lola` remains functional but deprecated (warning + docs).
+4. ADR-0008 Layer 2 updated; ADR-0009 written.
+5. Tests cover packaging, name validation, mcp.json optional write, flatten layout.
+6. `generate_*` layout unchanged (ADR-0007).
+
+## File-by-file changes
+
+### 1. `src/ansible_know/validation.py`
+
+Add Foundation validators:
+
+- `validate_plugin_name(name: str)` — Agent Plugins §5.5:
+  - length 1–64
+  - charset `[a-z0-9.-]`
+  - start/end alphanumeric
+  - no `--` or `..`
+- Export in `__all__`.
+
+Reuse path validators already present (`validate_install_path`, `validate_path_containment`).
+
+### 2. `src/ansible_know/types.py`
+
+Add TypedDicts:
+
+```python
+class PackageAsPluginResult(TypedDict):
+    collection: str
+    plugin_name: str
+    plugin_dir: str
+    skill_count: int
+    skills: list[str]
+    plugin_json: str | None
+    mcp_json: str | None
+
+class AgentPluginManifest(TypedDict, total=False):
+    # required keys always set at write time; total=False allows optional metadata
+    ...
+
+class AgentPluginManifestRequired(TypedDict):
+    schema: Required via key "$schema"  # use TypedDict with quoted keys as elsewhere
+```
+
+Prefer a concrete closed-schema TypedDict matching Lola's `LolaMarketYml` pattern:
+
+```python
+class AgentPluginManifest(TypedDict):
+    """Shape written to plugin.json (closed schema — only these keys)."""
+    # use NotRequired for optional fields if on 3.11+ / typing_extensions
+```
+
+Keys allowed: `$schema`, `name`, `version`, `description`, `keywords` (and omit author/homepage/repository/license unless we have real values — do not invent).
+
+Also optional `AgentMcpConfig` TypedDict for mcp.json top-level shape if helpful.
+
+Keep `PackageForLolaResult` unchanged.
+
+### 3. `src/ansible_know/skills.py` (Domain)
+
+Add beside existing Lola packaging helpers; export both in `__all__`:
+
+- `default_plugin_name(collection_fqcn) -> str`  
+  Default: `ansible-{collection-kebab}` (same as Lola). **Fail closed:** if the default fails `validate_plugin_name` (e.g. >64 chars), raise `ValidationError` requiring an explicit `plugin_name`. No silent truncation.
+- `package_as_agent_plugin(skills_dirs, collection_fqcn, output_dir, *, plugin_name=None, include_mcp_config=True, write_plugin_json=True) -> PackageAsPluginResult`
+
+Contract (mirror Lola):
+
+- Preconditions: callers MUST `validate_namespace(collection_fqcn)` first; Domain validates `output_dir` via `validate_install_path`, validates `plugin_name` via `validate_plugin_name`, and `validate_path_containment` on all writes.
+- Raises: `FileNotFoundError` (no skills), `ValidationError` (name/path), `OSError` (I/O).
+- Silences: unreadable nested dirs / MANIFEST (log + skip / defaults), same as Lola.
+
+Behavior (reuse Lola planning/copy helpers where possible):
+
+1. Resolve collection skills dir via `resolve_collection_skills_dir`.
+2. Plan packable skills (same rules as Lola: collection-level SKILL.md + nested dirs with SKILL.md; skip symlink / collision / unreadable).
+3. Create `{output_dir}/{plugin_name}/`.
+4. Replace `{plugin}/skills/` and copy trees to **flat** `skills/{skill}/SKILL.md` (+ supporting files).
+5. If `write_plugin_json`: write closed-schema `plugin.json` via `AgentPluginManifest`:
+   - `$schema`: `https://agent-plugins.org/schemas/1.0.0/plugin.schema.json`
+   - `name`, `version` (from MANIFEST or `"0.0.0"`), `description`, `keywords` (`ansible`, namespace, collection kebab).
+6. If `include_mcp_config`: write `mcp.json`:
+   ```json
+   {
+     "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+     "mcpServers": {
+       "ansible-know": {
+         "type": "stdio",
+         "command": "uvx",
+         "args": ["ansible-know-mcp"]
+       }
+     }
+   }
+   ```
+   (`command` is a bare executable token — no placeholders; matches §7.2.1.)
+7. If flags false: omit corresponding files; if re-packaging and flag false for a file that exists, unlink it (same pattern as Lola `write_market_yml=False`).
+
+Contract docstring per `contract-docstrings` skill.
+
+Do **not** change `generate_*` or nested source layout.
+
+### 4. `src/ansible_know/server.py` (Orchestration)
+
+- New tool `package_as_plugin` (idempotent write, destructiveHint=True like Lola):
+  - params: `collection`, `output_dir`, `source_dir?`, `plugin_name?`, `include_mcp_config=True`, `write_plugin_json=True`
+  - Parity with `package_for_lola`: `validate_namespace`, `validate_install_path` (output + optional source), `validate_plugin_name` when provided; lazy-import Domain; `run_in_executor`; catch `FileNotFoundError` / `ValidationError` / `Exception` → `{"error"}` with `sanitize_error` where appropriate.
+- Deprecate `package_for_lola`:
+  - docstring note: prefer `package_as_plugin`
+  - on each call: `logger.warning("package_for_lola is deprecated; use package_as_plugin")`
+  - optional `warnings.warn(..., DeprecationWarning, stacklevel=2)` for programmatic callers
+
+Update tool count comments / instructions strings if they hardcode “19 tools”.
+
+### 5. Docs / ADRs
+
+- **ADR-0009** (new, Proposed/Accepted): adopt Agent Plugins as primary Layer-2 packaging format; cite spec URLs; decide option (b); keep Lola one-cycle deprecation.
+- **ADR-0008**: Layer 2 section — Agent Plugins primary; Lola secondary/deprecated; note flat `skills/` resolves next-mcp 1-level scan for packaged plugins.
+- **ADR README**: index ADR-0009.
+- **service-contracts.md**: add `package_as_agent_plugin()` to skills Domain table; add `PackageAsPluginResult` boundary type; bump tool count if documented.
+- **README.md** / **CLAUDE.md**: document `package_as_plugin`; mark `package_for_lola` deprecated.
+- **project-strategy.md**: one-line Layer-2 note — Agent Plugins primary; Lola deprecated one cycle.
+
+### 6. Tests — `tests/test_agent_plugin_packaging.py`
+
+Mirror `tests/test_lola_packaging.py` structure:
+
+- `validate_plugin_name` accept/reject cases (`My-Plugin`, `--`, `..`, length 65, leading `-`)
+- default name for `netbox.netbox` → `ansible-netbox-netbox`
+- default name for overlong collection FQCN → `ValidationError` (fail closed; no truncation)
+- packaging writes flat `skills/{name}/SKILL.md` (including collection overview skill)
+- copies supporting files (`scripts/`)
+- writes valid `plugin.json` / optional skip
+- writes / skips `mcp.json`
+- replaces existing `skills/` idempotently
+- missing skills → FileNotFoundError / tool error
+- MCP tool happy path + validation error
+- deprecation: calling `package_for_lola` still works (existing tests remain)
+
+Share `_write_skill_tree` helper (import from lola test module **or** extract tiny shared fixture — prefer duplicate minimal helper in new file to avoid cross-test coupling).
+
+## Test / lint commands
+
+```bash
+uv run pytest tests/test_agent_plugin_packaging.py tests/test_lola_packaging.py -v
+uv run ruff check src/ tests/test_agent_plugin_packaging.py
+uv run pytest tests/ -v
+```
+
+## Migration / compat
+
+- No migration of on-disk generated skills.
+- `package_for_lola` kept one release cycle with deprecation warning.
+- New tool is additive (tool count 19 → 20).
+
+## Out of scope (do not implement)
+
+- #222 AGENTS.md enrichment for flat layout
+- Changing `generate_*` nesting
+- Removing Lola packaging
+- Client extension namespaces / marketplace publishing
+
+## Implementation order
+
+1. validation + types  
+2. Domain `package_as_agent_plugin` + unit tests (TDD)  
+3. MCP tool + deprecation  
+4. ADRs / contracts / README / CLAUDE  
+5. Full test + ruff  
+6. PR with `Closes #223`

--- a/skills/pr-architecture-review/SKILL.md
+++ b/skills/pr-architecture-review/SKILL.md
@@ -22,7 +22,7 @@ Load these reference materials before starting — they define the layer
 boundaries, allowed dependencies, and known violations:
 
 1. Read `docs/architecture/service-contracts.md`
-2. Read all ADRs in `docs/architecture/adr/` (0001–0008)
+2. Read all ADRs in `docs/architecture/adr/` (0001–0009)
 3. Read `docs/architecture/project-strategy.md` for strategic context
 
 Pass the relevant sections to each subagent in Phase 2.
@@ -273,8 +273,9 @@ For changes that affect architecture or project direction:
   kebab-case names, include `metadata.fqcn`, `metadata.collection`,
   `metadata.plugin-type`, and `compatibility` fields. Validate with
   `agentskills validate`.
-- [ ] **Distribution model** (ADR-0008): skill output must work at all
-  three layers (local, repository, remote) without format changes.
+- [ ] **Distribution model** (ADR-0008 / ADR-0009): skill output must work
+  at all three layers without format changes. Layer 2 packaging prefers
+  Agent Plugins (`package_as_plugin`); `package_for_lola` is deprecated.
 - [ ] **ADR consistency**: if a PR contradicts an existing ADR, it must
   either update the ADR or document why the deviation is necessary.
 - [ ] **Tools to keep vs drop**: changes to tools marked for upstream
@@ -306,7 +307,7 @@ For each finding, report:
 
 ---
 
-## Last reviewed: 2026-08-07
+## Last reviewed: 2026-08-11
 
 ## Revision History
 
@@ -316,3 +317,4 @@ For each finding, report:
 | 2026-06-27 | Updated layer map (added resolution.py, text_utils.py, manifest_builder.py, cli.py). Updated known violations to current state (most fixed). Added Step 9: ADR and strategy compliance (ADRs 0006-0008). Updated state management checklist for SharedState/ServerState/SessionManager/CollectionManager. Made frontmatter agentskills.io spec-compliant. Added revision history. |
 | 2026-07-17 | Added redhat_docs.py to External Access layer map (PR #178). |
 | 2026-08-07 | PR #211 / #149: service-contracts tool count 19 + `PackageForLolaResult`; ADR-0007/0008 note Layer 2 wrap via `package_for_lola` (no new layer-map modules). |
+| 2026-08-11 | PR #224 / #223: ADRs 0001–0009; Layer 2 prefers `package_as_plugin` / ADR-0009; `package_for_lola` deprecated; service-contracts 20 tools + Agent Plugins TypedDicts. |

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1442,8 +1442,9 @@ async def package_as_plugin(
     plugin_name: Annotated[
         str | None,
         "Optional Agent Plugins manifest name / directory name. Defaults to "
-        "'ansible-{collection-kebab}' (e.g. 'ansible-netbox-netbox'). Must "
-        "satisfy Agent Plugins §5.5 (1-64 chars, [a-z0-9.-]).",
+        "'ansible-{collection-kebab}-agentplugin' "
+        "(e.g. 'ansible-netbox-netbox-agentplugin'). "
+        "Must satisfy Agent Plugins §5.5 (1-64 chars, [a-z0-9.-]).",
     ] = None,
     include_mcp_config: Annotated[
         bool,

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -54,6 +54,8 @@ from ansible_know.validation import (
     validate_install_path,
     validate_keyword,
     validate_lola_module_name,
+    validate_mcp_server_url,
+    validate_mcp_transport,
     validate_namespace,
     validate_plugin_name,
     validate_plugin_type,
@@ -1445,33 +1447,50 @@ async def package_as_plugin(
     ] = None,
     include_mcp_config: Annotated[
         bool,
-        "When true (default), write mcp.json with a stdio entry for "
-        "uvx ansible-know-mcp.",
+        "When true (default), write mcp.json for know-mcp (see mcp_transport).",
     ] = True,
     write_plugin_json: Annotated[
         bool,
         "When true (default), write plugin.json with Agent Plugins v1.0.0 "
         "manifest fields.",
     ] = True,
+    write_tarball: Annotated[
+        bool,
+        "When true (default), also write {plugin_name}-{version}.tar.gz beside "
+        "the plugin directory (Pulp/AAP-friendly artifact).",
+    ] = True,
+    mcp_transport: Annotated[
+        str,
+        "MCP transport for mcp.json when include_mcp_config is true: "
+        "'stdio' (default, uvx ansible-know-mcp) or 'streamable-http' "
+        "(requires mcp_url for an AAP-hosted know-mcp endpoint).",
+    ] = "stdio",
+    mcp_url: Annotated[
+        str | None,
+        "Absolute MCP endpoint URL when mcp_transport is 'streamable-http' "
+        "(e.g. 'https://aap.example.com/mcp/skills/'). Ignored for stdio.",
+    ] = None,
 ) -> PackageAsPluginResult | ErrorResponse:
     """Wrap already-generated skills into an Agent Plugins directory.
 
     Does not change ``generate_*`` output layout. Copies
     ``skills/{collection-kebab}/{skill}/`` into
     ``{output_dir}/{plugin}/skills/{skill}/`` and writes ``plugin.json``
-    (and optionally ``mcp.json``) per the Agent Plugins specification.
-    Replaces any existing ``skills/`` tree under the target plugin directory
-    (destructive but idempotent).
+    (and optionally ``mcp.json`` + ``.tar.gz``) per the Agent Plugins
+    specification. Replaces any existing ``skills/`` tree under the target
+    plugin directory (destructive but idempotent).
 
     Returns: {"collection", "plugin_name", "plugin_dir", "skill_count", "skills",
-    "plugin_json", "mcp_json"} or {"error": str} on failure.
+    "plugin_json", "mcp_json", "archive"} or {"error": str} on failure.
     """
     logger.info(
-        "package_as_plugin collection=%r output_dir=%r source_dir=%r plugin_name=%r",
+        "package_as_plugin collection=%r output_dir=%r source_dir=%r "
+        "plugin_name=%r mcp_transport=%r",
         collection,
         output_dir,
         source_dir,
         plugin_name,
+        mcp_transport,
     )
     try:
         validate_namespace(collection)
@@ -1480,6 +1499,14 @@ async def package_as_plugin(
             validate_install_path(source_dir)
         if plugin_name is not None:
             validate_plugin_name(plugin_name)
+        if include_mcp_config:
+            validate_mcp_transport(mcp_transport)
+            if mcp_transport == "streamable-http":
+                if not mcp_url:
+                    raise ValidationError(
+                        "mcp_url is required when mcp_transport is 'streamable-http'."
+                    )
+                validate_mcp_server_url(mcp_url)
     except ValidationError as exc:
         return {"error": str(exc)}
 
@@ -1500,6 +1527,9 @@ async def package_as_plugin(
                 plugin_name=plugin_name,
                 include_mcp_config=include_mcp_config,
                 write_plugin_json=write_plugin_json,
+                write_tarball=write_tarball,
+                mcp_transport=mcp_transport,
+                mcp_url=mcp_url,
             )
 
         return await run_in_executor(_package)

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1453,12 +1453,13 @@ async def package_as_plugin(
     write_plugin_json: Annotated[
         bool,
         "When true (default), write plugin.json with Agent Plugins v1.0.0 "
-        "manifest fields.",
+        "manifest fields. Required when write_tarball is true.",
     ] = True,
     write_tarball: Annotated[
         bool,
         "When true (default), also write {plugin_name}-{version}.tar.gz beside "
-        "the plugin directory (Pulp/AAP-friendly artifact).",
+        "the plugin directory (Pulp/AAP-friendly artifact). Requires "
+        "write_plugin_json=True.",
     ] = True,
     mcp_transport: Annotated[
         str,

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1,6 +1,6 @@
 """Ansible Know MCP Server.
 
-Provides 19 tools, 6 resources, and 5 prompts for module, role, and plugin discovery,
+Provides 20 tools, 6 resources, and 5 prompts for module, role, and plugin discovery,
 documentation search, Galaxy collection discovery, and skill generation
 via the Model Context Protocol.
 """
@@ -12,6 +12,7 @@ import contextlib
 import json
 import logging
 import os
+import warnings
 from importlib.metadata import version as pkg_version
 from typing import Annotated, Any
 
@@ -36,6 +37,7 @@ from ansible_know.types import (
     GetRoleDocResult,
     ManifestResult,
     ModuleMetadata,
+    PackageAsPluginResult,
     PackageForLolaResult,
     PluginManifestInput,
     PluginMetadata,
@@ -53,6 +55,7 @@ from ansible_know.validation import (
     validate_keyword,
     validate_lola_module_name,
     validate_namespace,
+    validate_plugin_name,
     validate_plugin_type,
     validate_query,
     validate_skill_name,
@@ -1419,6 +1422,97 @@ async def generate_collection_skills(
 
 
 @mcp.tool(annotations=ToolAnnotations(idempotentHint=True, readOnlyHint=False, destructiveHint=True))
+async def package_as_plugin(
+    collection: Annotated[
+        str,
+        "Collection namespace whose generated skills to wrap (e.g. 'netbox.netbox').",
+    ],
+    output_dir: Annotated[
+        str,
+        "Parent directory where the Agent Plugin directory will be created "
+        "(e.g. '.' or '/tmp/agent-plugins').",
+    ],
+    source_dir: Annotated[
+        str | None,
+        "Optional skills root to read from. Defaults to ANSIBLE_KNOW_SKILLS_PATH "
+        "or SKILLS_DIR (same roots as list_skills).",
+    ] = None,
+    plugin_name: Annotated[
+        str | None,
+        "Optional Agent Plugins manifest name / directory name. Defaults to "
+        "'ansible-{collection-kebab}' (e.g. 'ansible-netbox-netbox'). Must "
+        "satisfy Agent Plugins §5.5 (1-64 chars, [a-z0-9.-]).",
+    ] = None,
+    include_mcp_config: Annotated[
+        bool,
+        "When true (default), write mcp.json with a stdio entry for "
+        "uvx ansible-know-mcp.",
+    ] = True,
+    write_plugin_json: Annotated[
+        bool,
+        "When true (default), write plugin.json with Agent Plugins v1.0.0 "
+        "manifest fields.",
+    ] = True,
+) -> PackageAsPluginResult | ErrorResponse:
+    """Wrap already-generated skills into an Agent Plugins directory.
+
+    Does not change ``generate_*`` output layout. Copies
+    ``skills/{collection-kebab}/{skill}/`` into
+    ``{output_dir}/{plugin}/skills/{skill}/`` and writes ``plugin.json``
+    (and optionally ``mcp.json``) per the Agent Plugins specification.
+    Replaces any existing ``skills/`` tree under the target plugin directory
+    (destructive but idempotent).
+
+    Returns: {"collection", "plugin_name", "plugin_dir", "skill_count", "skills",
+    "plugin_json", "mcp_json"} or {"error": str} on failure.
+    """
+    logger.info(
+        "package_as_plugin collection=%r output_dir=%r source_dir=%r plugin_name=%r",
+        collection,
+        output_dir,
+        source_dir,
+        plugin_name,
+    )
+    try:
+        validate_namespace(collection)
+        validate_install_path(output_dir)
+        if source_dir is not None:
+            validate_install_path(source_dir)
+        if plugin_name is not None:
+            validate_plugin_name(plugin_name)
+    except ValidationError as exc:
+        return {"error": str(exc)}
+
+    try:
+        from ansible_know.config import get_skills_dirs
+        from ansible_know.skills import package_as_agent_plugin
+
+        def _package() -> PackageAsPluginResult:
+            skills_dirs = (
+                [validate_install_path(source_dir)]
+                if source_dir is not None
+                else get_skills_dirs()
+            )
+            return package_as_agent_plugin(
+                skills_dirs,
+                collection,
+                validate_install_path(output_dir),
+                plugin_name=plugin_name,
+                include_mcp_config=include_mcp_config,
+                write_plugin_json=write_plugin_json,
+            )
+
+        return await run_in_executor(_package)
+    except FileNotFoundError as exc:
+        return {"error": sanitize_error(str(exc))}
+    except ValidationError as exc:
+        return {"error": str(exc)}
+    except Exception as exc:
+        logger.warning("package_as_plugin failed: %s", exc)
+        return {"error": sanitize_error(str(exc))}
+
+
+@mcp.tool(annotations=ToolAnnotations(idempotentHint=True, readOnlyHint=False, destructiveHint=True))
 async def package_for_lola(
     collection: Annotated[
         str,
@@ -1447,6 +1541,10 @@ async def package_for_lola(
 ) -> PackageForLolaResult | ErrorResponse:
     """Wrap already-generated skills into a Lola-compatible module directory.
 
+    .. deprecated::
+        Prefer :func:`package_as_plugin` (Agent Plugins). Kept for one release
+        cycle for backward compatibility.
+
     Does not change ``generate_*`` output layout. Copies
     ``skills/{collection-kebab}/{skill}/`` into
     ``{output_dir}/{module}/skills/{skill}/`` for marketplace /
@@ -1456,6 +1554,12 @@ async def package_for_lola(
     Returns: {"collection", "module_name", "module_dir", "skill_count", "skills",
     "market_yml"} or {"error": str} on failure.
     """
+    warnings.warn(
+        "package_for_lola is deprecated; use package_as_plugin (Agent Plugins)",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    logger.warning("package_for_lola is deprecated; use package_as_plugin")
     logger.info(
         "package_for_lola collection=%r output_dir=%r source_dir=%r module_name=%r",
         collection,

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -28,14 +28,18 @@ from ansible_know.validation import (
     validate_install_path,
     validate_lola_module_name,
     validate_path_containment,
+    validate_plugin_name,
 )
 
 if TYPE_CHECKING:
     from ansible_know.types import (
+        AgentMcpConfig,
+        AgentPluginManifest,
         CollectionSkillContext,
         LolaMarketYml,
         ModuleMetadata,
         ModuleTagEntry,
+        PackageAsPluginResult,
         PackageForLolaResult,
         ParamDict,
         PluginManifestInput,
@@ -53,11 +57,13 @@ __all__ = [
     "PLUGIN_SKILL_DIR_RE",
     "collection_skill_name",
     "default_lola_module_name",
+    "default_plugin_name",
     "extract_skill_description",
     "fqcn_to_skill_name",
     "get_skill_sync",
     "list_skills_sync",
     "module_to_skill_name",
+    "package_as_agent_plugin",
     "package_collection_for_lola",
     "plugin_skill_name",
     "resolve_collection_skills_dir",
@@ -852,27 +858,8 @@ def package_collection_for_lola(
     collection_dir_name = collection_dir.name
     collection_skill_md = collection_dir / "SKILL.md"
 
-    has_collection_skill = collection_skill_md.is_file()
-
     # Plan packable skills before mutating any existing Lola module output.
-    nested_skill_dirs: list[Path] = []
-    for entry in sorted(collection_dir.iterdir()):
-        try:
-            if not entry.is_dir() or entry.is_symlink():
-                continue
-            if has_collection_skill and entry.name == collection_dir_name:
-                # Would overwrite the collection-level skill dirname.
-                logger.warning(
-                    "Skipping nested skill %r: name collides with collection skill",
-                    entry.name,
-                )
-                continue
-            if (entry / "SKILL.md").is_file():
-                nested_skill_dirs.append(entry)
-        except OSError as exc:
-            logger.warning("Skipping unreadable skill dir %s: %s", entry.name, exc)
-            continue
-
+    has_collection_skill, nested_skill_dirs = _plan_packable_skill_dirs(collection_dir)
     if not has_collection_skill and not nested_skill_dirs:
         raise FileNotFoundError(
             f"Collection '{collection_fqcn}' has no SKILL.md packages to wrap."
@@ -948,4 +935,246 @@ def package_collection_for_lola(
         "skill_count": len(packaged),
         "skills": packaged,
         "market_yml": market_yml_path,
+    }
+
+
+# --- Agent Plugins packaging (Layer 2; flatten only at package time) ---
+
+PLUGIN_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+MCP_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json"
+
+
+def default_plugin_name(collection_fqcn: str) -> str:
+    """Return the default Agent Plugins ``name`` for a collection FQCN.
+
+    Uses ``ansible-{collection-kebab}``. Fails closed if that value violates
+    Agent Plugins §5.5 (e.g. longer than 64 characters) — callers must pass
+    an explicit ``plugin_name``.
+
+    Contract:
+        Preconditions:
+            - Callers SHOULD validate *collection_fqcn* with
+              ``validate_namespace()`` first.
+        Raises:
+            ValidationError: If the default name fails ``validate_plugin_name``.
+    """
+    name = f"ansible-{collection_skill_name(collection_fqcn)}"
+    validate_plugin_name(name)
+    return name
+
+
+def _plan_packable_skill_dirs(collection_dir: Path) -> tuple[bool, list[Path]]:
+    """Plan collection-level + nested skill dirs for packaging wraps."""
+    collection_dir_name = collection_dir.name
+    collection_skill_md = collection_dir / "SKILL.md"
+    has_collection_skill = collection_skill_md.is_file()
+
+    nested_skill_dirs: list[Path] = []
+    for entry in sorted(collection_dir.iterdir()):
+        try:
+            if not entry.is_dir() or entry.is_symlink():
+                continue
+            if has_collection_skill and entry.name == collection_dir_name:
+                logger.warning(
+                    "Skipping nested skill %r: name collides with collection skill",
+                    entry.name,
+                )
+                continue
+            if (entry / "SKILL.md").is_file():
+                nested_skill_dirs.append(entry)
+        except OSError as exc:
+            logger.warning("Skipping unreadable skill dir %s: %s", entry.name, exc)
+            continue
+    return has_collection_skill, nested_skill_dirs
+
+
+def _write_plugin_json(
+    plugin_root: Path,
+    *,
+    plugin_name: str,
+    collection_fqcn: str,
+    description: str,
+    version: str | None,
+) -> Path:
+    """Write closed-schema ``plugin.json`` under the plugin root."""
+    namespace, collection_name = split_collection_fqcn(collection_fqcn)
+    payload: AgentPluginManifest = {
+        "$schema": PLUGIN_SCHEMA,
+        "name": plugin_name,
+        "version": version or "0.0.0",
+        "description": description
+        or f"Ansible skills for the {collection_fqcn} collection",
+        "keywords": sorted({
+            "ansible",
+            namespace.lower(),
+            collection_name.replace("_", "-").lower(),
+        }),
+    }
+    plugin_json_path = plugin_root / "plugin.json"
+    validate_path_containment(plugin_json_path.resolve(), plugin_root)
+    plugin_json_path.write_text(json.dumps(payload, indent=2) + "\n")
+    return plugin_json_path
+
+
+def _write_mcp_json(plugin_root: Path) -> Path:
+    """Write Agent Plugins ``mcp.json`` pointing at know-mcp via uvx stdio."""
+    payload: AgentMcpConfig = {
+        "$schema": MCP_SCHEMA,
+        "mcpServers": {
+            "ansible-know": {
+                "type": "stdio",
+                "command": "uvx",
+                "args": ["ansible-know-mcp"],
+            },
+        },
+    }
+    mcp_json_path = plugin_root / "mcp.json"
+    validate_path_containment(mcp_json_path.resolve(), plugin_root)
+    mcp_json_path.write_text(json.dumps(payload, indent=2) + "\n")
+    return mcp_json_path
+
+
+def package_as_agent_plugin(
+    skills_dirs: Path | Sequence[Path],
+    collection_fqcn: str,
+    output_dir: Path,
+    *,
+    plugin_name: str | None = None,
+    include_mcp_config: bool = True,
+    write_plugin_json: bool = True,
+) -> PackageAsPluginResult:
+    """Wrap generated collection skills into an Agent Plugins directory.
+
+    Source layout (unchanged)::
+
+        {skills_dir}/{collection-kebab}/{skill}/SKILL.md
+
+    Target Agent Plugins layout::
+
+        {output_dir}/{plugin_name}/plugin.json
+        {output_dir}/{plugin_name}/mcp.json          # optional
+        {output_dir}/{plugin_name}/skills/{skill}/SKILL.md
+
+    Nested skill directories that contain ``SKILL.md`` are copied with supporting
+    files (symlink members are skipped). A collection-level ``SKILL.md`` is
+    packaged as ``skills/{collection-kebab}/SKILL.md``. ``MANIFEST.json`` is
+    not copied. Existing ``skills/`` under the plugin root is replaced.
+
+    Contract:
+        Preconditions:
+            - Callers MUST validate *collection_fqcn* with
+              ``validate_namespace()`` first.
+            - *output_dir* must be an allowed install path (validated here via
+              ``validate_install_path``).
+            - When *plugin_name* is not ``None``, it must already satisfy
+              Agent Plugins §5.5 (or it is validated here). Empty string is
+              invalid — pass ``None`` for the default name.
+        Raises:
+            FileNotFoundError: If the collection has no generated skills, or
+                none of those skills contain a ``SKILL.md``.
+            ValidationError: On path escape or invalid plugin name (including
+                when the default name exceeds §5.5 limits).
+            OSError: On filesystem permission or I/O errors during mkdir,
+                copy, or manifest write (not silenced).
+        Silences:
+            - Unreadable nested skill dirs (``OSError`` while iterating /
+              copying): logged and skipped; ``skill_count`` may omit them.
+            - Unreadable ``MANIFEST.json`` or collection skill description:
+              logged; version/description fall back to defaults.
+    """
+    resolved_output = validate_install_path(str(output_dir))
+    if plugin_name is None:
+        name = default_plugin_name(collection_fqcn)
+    else:
+        name = plugin_name
+        validate_plugin_name(name)
+
+    collection_dir = resolve_collection_skills_dir(skills_dirs, collection_fqcn)
+    collection_dir_name = collection_dir.name
+    collection_skill_md = collection_dir / "SKILL.md"
+
+    has_collection_skill, nested_skill_dirs = _plan_packable_skill_dirs(collection_dir)
+    if not has_collection_skill and not nested_skill_dirs:
+        raise FileNotFoundError(
+            f"Collection '{collection_fqcn}' has no SKILL.md packages to wrap."
+        )
+
+    plugin_root = (resolved_output / name).resolve()
+    validate_path_containment(plugin_root, resolved_output)
+    plugin_root.mkdir(parents=True, exist_ok=True)
+
+    skills_out = plugin_root / "skills"
+    if skills_out.exists():
+        validate_path_containment(skills_out.resolve(), plugin_root)
+        shutil.rmtree(skills_out)
+    skills_out.mkdir(parents=True)
+    validate_path_containment(skills_out.resolve(), plugin_root)
+
+    packaged: list[str] = []
+    if has_collection_skill:
+        dest = skills_out / collection_dir_name
+        dest.mkdir(parents=True, exist_ok=True)
+        validate_path_containment(dest.resolve(), plugin_root)
+        shutil.copy2(collection_skill_md, dest / "SKILL.md")
+        packaged.append(collection_dir_name)
+
+    for entry in nested_skill_dirs:
+        try:
+            dest = skills_out / entry.name
+            _copy_skill_tree(entry, dest, plugin_root)
+            packaged.append(entry.name)
+        except OSError as exc:
+            logger.warning("Skipping unreadable skill dir %s: %s", entry.name, exc)
+            continue
+
+    if not packaged:
+        raise FileNotFoundError(
+            f"Collection '{collection_fqcn}' has no SKILL.md packages to wrap."
+        )
+
+    description = ""
+    if collection_skill_md.is_file():
+        try:
+            description = extract_skill_description(collection_skill_md)
+        except OSError as exc:
+            logger.warning("Could not read collection skill description: %s", exc)
+
+    plugin_json_path: str | None = None
+    plugin_json_file = plugin_root / "plugin.json"
+    if write_plugin_json:
+        plugin_json_path = str(
+            _write_plugin_json(
+                plugin_root,
+                plugin_name=name,
+                collection_fqcn=collection_fqcn,
+                description=description,
+                version=_read_collection_version(collection_dir),
+            )
+        )
+    elif plugin_json_file.is_file():
+        validate_path_containment(plugin_json_file.resolve(), plugin_root)
+        plugin_json_file.unlink()
+
+    mcp_json_path: str | None = None
+    mcp_json_file = plugin_root / "mcp.json"
+    if include_mcp_config:
+        mcp_json_path = str(_write_mcp_json(plugin_root))
+    elif mcp_json_file.is_file():
+        validate_path_containment(mcp_json_file.resolve(), plugin_root)
+        mcp_json_file.unlink()
+
+    logger.info(
+        "Packaged %d skills for %s into Agent Plugin %s",
+        len(packaged),
+        collection_fqcn,
+        plugin_root,
+    )
+    return {
+        "collection": collection_fqcn,
+        "plugin_name": name,
+        "plugin_dir": str(plugin_root),
+        "skill_count": len(packaged),
+        "skills": packaged,
+        "plugin_json": plugin_json_path,
+        "mcp_json": mcp_json_path,
     }

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -38,6 +38,9 @@ from ansible_know.validation import (
 if TYPE_CHECKING:
     from ansible_know.types import (
         AgentMcpConfig,
+        AgentMcpHttpServer,
+        AgentMcpServer,
+        AgentMcpStdioServer,
         AgentPluginManifest,
         CollectionSkillContext,
         LolaMarketYml,
@@ -1089,22 +1092,25 @@ def _write_mcp_json(
 ) -> Path:
     """Write Agent Plugins ``mcp.json`` for know-mcp (stdio or streamable-http)."""
     validate_mcp_transport(mcp_transport)
+    server: AgentMcpServer
     if mcp_transport == "stdio":
-        server: dict[str, Any] = {
+        stdio_server: AgentMcpStdioServer = {
             "type": "stdio",
             "command": "uvx",
             "args": ["ansible-know-mcp"],
         }
+        server = stdio_server
     else:
         if not mcp_url:
             raise ValidationError(
                 "mcp_url is required when mcp_transport is 'streamable-http'."
             )
         validate_mcp_server_url(mcp_url)
-        server = {
+        http_server: AgentMcpHttpServer = {
             "type": "streamable-http",
             "url": mcp_url,
         }
+        server = http_server
     payload: AgentMcpConfig = {
         "$schema": MCP_SCHEMA,
         "mcpServers": {

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -953,9 +953,10 @@ MAX_PLUGIN_KEYWORDS = 64
 def default_plugin_name(collection_fqcn: str) -> str:
     """Return the default Agent Plugins ``name`` for a collection FQCN.
 
-    Uses ``ansible-{collection-kebab}``. Fails closed if that value violates
-    Agent Plugins §5.5 (e.g. longer than 64 characters) — callers must pass
-    an explicit ``plugin_name``.
+    Uses ``ansible-{collection-kebab}-agentplugin`` so artifacts are distinct
+    from Galaxy/Pulp collection names and clearly target the Agent Plugins
+    format. Fails closed if that value violates Agent Plugins §5.5 (e.g.
+    longer than 64 characters) — callers must pass an explicit ``plugin_name``.
 
     Contract:
         Preconditions:
@@ -964,7 +965,7 @@ def default_plugin_name(collection_fqcn: str) -> str:
         Raises:
             ValidationError: If the default name fails ``validate_plugin_name``.
     """
-    name = f"ansible-{collection_skill_name(collection_fqcn)}"
+    name = f"ansible-{collection_skill_name(collection_fqcn)}-agentplugin"
     validate_plugin_name(name)
     return name
 

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -1024,6 +1024,40 @@ def _build_plugin_keywords(
     return sorted(keywords)[:MAX_PLUGIN_KEYWORDS]
 
 
+_PLUGIN_ROOT_ENTRIES = frozenset({"plugin.json", "mcp.json", "skills"})
+
+
+def _is_direct_child(path: Path, parent: Path) -> bool:
+    """Return True if *path* is a direct child of *parent* (no symlink follow)."""
+    try:
+        return path.parent.resolve() == parent.resolve()
+    except OSError:
+        return False
+
+
+def _unlink_symlink_or_file(path: Path, parent: Path) -> None:
+    """Unlink a direct-child file or symlink without following the target."""
+    if not _is_direct_child(path, parent):
+        raise ValidationError("Path escapes the allowed directory.")
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+
+
+def _prepare_regular_file(path: Path, parent: Path) -> Path:
+    """Ensure *path* is a writable regular file path under *parent*.
+
+    Unlinks an existing symlink first so later writes cannot redirect through
+    an in-tree link target.
+    """
+    if not _is_direct_child(path, parent):
+        raise ValidationError("Path escapes the allowed directory.")
+    if path.is_symlink():
+        path.unlink()
+    elif path.exists() and path.is_dir():
+        raise ValidationError(f"Expected a file path, found a directory: {path.name}")
+    return path
+
+
 def _write_plugin_json(
     plugin_root: Path,
     *,
@@ -1042,8 +1076,7 @@ def _write_plugin_json(
         or f"Ansible skills for the {collection_fqcn} collection",
         "keywords": _build_plugin_keywords(collection_fqcn, skill_names),
     }
-    plugin_json_path = plugin_root / "plugin.json"
-    validate_path_containment(plugin_json_path.resolve(), plugin_root)
+    plugin_json_path = _prepare_regular_file(plugin_root / "plugin.json", plugin_root)
     plugin_json_path.write_text(json.dumps(payload, indent=2) + "\n")
     return plugin_json_path
 
@@ -1078,13 +1111,9 @@ def _write_mcp_json(
             "ansible-know": server,
         },
     }
-    mcp_json_path = plugin_root / "mcp.json"
-    validate_path_containment(mcp_json_path.resolve(), plugin_root)
+    mcp_json_path = _prepare_regular_file(plugin_root / "mcp.json", plugin_root)
     mcp_json_path.write_text(json.dumps(payload, indent=2) + "\n")
     return mcp_json_path
-
-
-_PLUGIN_ROOT_ENTRIES = frozenset({"plugin.json", "mcp.json", "skills"})
 
 
 def _tar_safe_filter(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo | None:
@@ -1101,17 +1130,21 @@ def _scrub_plugin_root(plugin_root: Path) -> None:
 
     Containment checks the directory entry under *plugin_root* without
     following symlink targets (absolute links must still be removable).
+    Allowlisted names that are symlinks are also removed so later writes
+    cannot redirect through them.
     """
     root = plugin_root.resolve()
     for entry in list(plugin_root.iterdir()):
-        if entry.name in _PLUGIN_ROOT_ENTRIES:
-            continue
         try:
             if entry.parent.resolve() != root:
                 logger.warning(
                     "Skipping unexpected non-child entry under plugin root: %s",
                     entry.name,
                 )
+                continue
+            if entry.name in _PLUGIN_ROOT_ENTRIES:
+                if entry.is_symlink():
+                    entry.unlink()
                 continue
             if entry.is_symlink() or entry.is_file():
                 entry.unlink()
@@ -1122,14 +1155,16 @@ def _scrub_plugin_root(plugin_root: Path) -> None:
 
 
 def _remove_plugin_archives(output_dir: Path, plugin_name: str) -> None:
-    """Remove ``{plugin_name}-*.tar.gz`` artifacts under *output_dir*."""
+    """Remove ``{plugin_name}-*.tar.gz`` files and symlinks under *output_dir*."""
+    out = output_dir.resolve()
     for archive in sorted(output_dir.glob(f"{plugin_name}-*.tar.gz")):
         try:
-            resolved = archive.resolve()
-            validate_path_containment(resolved, output_dir)
-            if archive.is_symlink() or not archive.is_file():
+            if not _is_direct_child(archive, out):
                 continue
-            archive.unlink()
+            # Unlink the directory entry itself (including symlinks) so writes
+            # cannot follow an in-tree redirect into another output_dir file.
+            if archive.is_symlink() or archive.is_file():
+                archive.unlink()
         except (OSError, ValidationError) as exc:
             logger.warning("Could not remove stale archive %s: %s", archive.name, exc)
 
@@ -1144,13 +1179,14 @@ def _write_plugin_tarball(
     """Write ``{plugin_name}-{version}.tar.gz`` beside the plugin directory.
 
     Archives only allowlisted members (``plugin.json``, ``mcp.json``,
-    ``skills/``) and filters out symlink/hardlink members.
+    ``skills/``) and filters out symlink/hardlink members. The archive path
+    is opened as a literal child of *output_dir* after removing any prior
+    file or symlink with that name.
     """
     _scrub_plugin_root(plugin_root)
     _remove_plugin_archives(output_dir, plugin_name)
     archive_name = f"{plugin_name}-{_archive_version(version)}.tar.gz"
-    archive_path = (output_dir / archive_name).resolve()
-    validate_path_containment(archive_path, output_dir)
+    archive_path = _prepare_regular_file(output_dir / archive_name, output_dir)
     with tarfile.open(archive_path, "w:gz") as archive:
         for member_name in sorted(_PLUGIN_ROOT_ENTRIES):
             src = plugin_root / member_name
@@ -1206,11 +1242,14 @@ def package_as_agent_plugin(
             - When *include_mcp_config* is true, *mcp_transport* must be
               ``stdio`` or ``streamable-http``; *mcp_url* is required for
               ``streamable-http``.
+            - *write_tarball* requires *write_plugin_json* (distribution
+              artifacts must include required ``plugin.json``).
         Raises:
             FileNotFoundError: If the collection has no generated skills, or
                 none of those skills contain a ``SKILL.md``.
             ValidationError: On path escape, invalid plugin name, invalid MCP
-                transport/URL (including when the default name exceeds §5.5).
+                transport/URL, or ``write_tarball`` without ``write_plugin_json``
+                (including when the default name exceeds §5.5).
             OSError: On filesystem permission or I/O errors during mkdir,
                 copy, or manifest write (not silenced).
         Silences:
@@ -1225,6 +1264,11 @@ def package_as_agent_plugin(
     else:
         name = plugin_name
         validate_plugin_name(name)
+    if write_tarball and not write_plugin_json:
+        raise ValidationError(
+            "write_tarball requires write_plugin_json=True "
+            "(Agent Plugins packages must include plugin.json)."
+        )
     if include_mcp_config:
         validate_mcp_transport(mcp_transport)
         if mcp_transport == "streamable-http":
@@ -1249,7 +1293,9 @@ def package_as_agent_plugin(
     plugin_root.mkdir(parents=True, exist_ok=True)
 
     skills_out = plugin_root / "skills"
-    if skills_out.exists():
+    if skills_out.is_symlink():
+        _unlink_symlink_or_file(skills_out, plugin_root)
+    elif skills_out.exists():
         validate_path_containment(skills_out.resolve(), plugin_root)
         shutil.rmtree(skills_out)
     skills_out.mkdir(parents=True)
@@ -1299,9 +1345,8 @@ def package_as_agent_plugin(
                 skill_names=packaged,
             )
         )
-    elif plugin_json_file.is_file():
-        validate_path_containment(plugin_json_file.resolve(), plugin_root)
-        plugin_json_file.unlink()
+    elif plugin_json_file.is_symlink() or plugin_json_file.exists():
+        _unlink_symlink_or_file(plugin_json_file, plugin_root)
 
     mcp_json_path: str | None = None
     mcp_json_file = plugin_root / "mcp.json"
@@ -1313,9 +1358,8 @@ def package_as_agent_plugin(
                 mcp_url=mcp_url,
             )
         )
-    elif mcp_json_file.is_file():
-        validate_path_containment(mcp_json_file.resolve(), plugin_root)
-        mcp_json_file.unlink()
+    elif mcp_json_file.is_symlink() or mcp_json_file.exists():
+        _unlink_symlink_or_file(mcp_json_file, plugin_root)
 
     archive_path: str | None = None
     if write_tarball:

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -12,6 +12,7 @@ import logging
 import re
 import shutil
 import stat
+import tarfile
 import threading
 from collections import Counter
 from collections.abc import Sequence
@@ -21,12 +22,15 @@ from typing import TYPE_CHECKING, Any
 import yaml
 
 from ansible_know.config import TEMPLATE_DIR
+from ansible_know.errors import ValidationError
 from ansible_know.tagging import derive_tags
 from ansible_know.validation import (
     split_collection_fqcn,
     truncate_response,
     validate_install_path,
     validate_lola_module_name,
+    validate_mcp_server_url,
+    validate_mcp_transport,
     validate_path_containment,
     validate_plugin_name,
 )
@@ -942,6 +946,8 @@ def package_collection_for_lola(
 
 PLUGIN_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
 MCP_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json"
+_ARCHIVE_VERSION_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
+MAX_PLUGIN_KEYWORDS = 64
 
 
 def default_plugin_name(collection_fqcn: str) -> str:
@@ -988,6 +994,35 @@ def _plan_packable_skill_dirs(collection_dir: Path) -> tuple[bool, list[Path]]:
     return has_collection_skill, nested_skill_dirs
 
 
+def _archive_version(version: str | None) -> str:
+    """Return a filesystem-safe version segment for ``{name}-{version}.tar.gz``."""
+    if version and _ARCHIVE_VERSION_RE.match(version):
+        return version
+    return "0.0.0"
+
+
+def _build_plugin_keywords(
+    collection_fqcn: str,
+    skill_names: Sequence[str],
+) -> list[str]:
+    """Build registry-oriented keywords for ``plugin.json``.
+
+    Includes ``ansible`` / ``automation``, namespace, collection kebab, collection
+    FQCN, and packaged skill directory names (capped for manifest size).
+    """
+    namespace, collection_name = split_collection_fqcn(collection_fqcn)
+    keywords: set[str] = {
+        "ansible",
+        "automation",
+        namespace.lower(),
+        collection_name.replace("_", "-").lower(),
+        collection_fqcn.lower(),
+    }
+    for skill in skill_names:
+        keywords.add(skill.lower())
+    return sorted(keywords)[:MAX_PLUGIN_KEYWORDS]
+
+
 def _write_plugin_json(
     plugin_root: Path,
     *,
@@ -995,20 +1030,16 @@ def _write_plugin_json(
     collection_fqcn: str,
     description: str,
     version: str | None,
+    skill_names: Sequence[str],
 ) -> Path:
     """Write closed-schema ``plugin.json`` under the plugin root."""
-    namespace, collection_name = split_collection_fqcn(collection_fqcn)
     payload: AgentPluginManifest = {
         "$schema": PLUGIN_SCHEMA,
         "name": plugin_name,
         "version": version or "0.0.0",
         "description": description
         or f"Ansible skills for the {collection_fqcn} collection",
-        "keywords": sorted({
-            "ansible",
-            namespace.lower(),
-            collection_name.replace("_", "-").lower(),
-        }),
+        "keywords": _build_plugin_keywords(collection_fqcn, skill_names),
     }
     plugin_json_path = plugin_root / "plugin.json"
     validate_path_containment(plugin_json_path.resolve(), plugin_root)
@@ -1016,22 +1047,58 @@ def _write_plugin_json(
     return plugin_json_path
 
 
-def _write_mcp_json(plugin_root: Path) -> Path:
-    """Write Agent Plugins ``mcp.json`` pointing at know-mcp via uvx stdio."""
+def _write_mcp_json(
+    plugin_root: Path,
+    *,
+    mcp_transport: str = "stdio",
+    mcp_url: str | None = None,
+) -> Path:
+    """Write Agent Plugins ``mcp.json`` for know-mcp (stdio or streamable-http)."""
+    validate_mcp_transport(mcp_transport)
+    if mcp_transport == "stdio":
+        server: dict[str, Any] = {
+            "type": "stdio",
+            "command": "uvx",
+            "args": ["ansible-know-mcp"],
+        }
+    else:
+        if not mcp_url:
+            raise ValidationError(
+                "mcp_url is required when mcp_transport is 'streamable-http'."
+            )
+        validate_mcp_server_url(mcp_url)
+        server = {
+            "type": "streamable-http",
+            "url": mcp_url,
+        }
     payload: AgentMcpConfig = {
         "$schema": MCP_SCHEMA,
         "mcpServers": {
-            "ansible-know": {
-                "type": "stdio",
-                "command": "uvx",
-                "args": ["ansible-know-mcp"],
-            },
+            "ansible-know": server,
         },
     }
     mcp_json_path = plugin_root / "mcp.json"
     validate_path_containment(mcp_json_path.resolve(), plugin_root)
     mcp_json_path.write_text(json.dumps(payload, indent=2) + "\n")
     return mcp_json_path
+
+
+def _write_plugin_tarball(
+    plugin_root: Path,
+    output_dir: Path,
+    *,
+    plugin_name: str,
+    version: str | None,
+) -> Path:
+    """Write ``{plugin_name}-{version}.tar.gz`` beside the plugin directory."""
+    archive_name = f"{plugin_name}-{_archive_version(version)}.tar.gz"
+    archive_path = (output_dir / archive_name).resolve()
+    validate_path_containment(archive_path, output_dir)
+    if archive_path.exists():
+        archive_path.unlink()
+    with tarfile.open(archive_path, "w:gz") as archive:
+        archive.add(plugin_root, arcname=plugin_name)
+    return archive_path
 
 
 def package_as_agent_plugin(
@@ -1042,6 +1109,9 @@ def package_as_agent_plugin(
     plugin_name: str | None = None,
     include_mcp_config: bool = True,
     write_plugin_json: bool = True,
+    write_tarball: bool = True,
+    mcp_transport: str = "stdio",
+    mcp_url: str | None = None,
 ) -> PackageAsPluginResult:
     """Wrap generated collection skills into an Agent Plugins directory.
 
@@ -1054,6 +1124,7 @@ def package_as_agent_plugin(
         {output_dir}/{plugin_name}/plugin.json
         {output_dir}/{plugin_name}/mcp.json          # optional
         {output_dir}/{plugin_name}/skills/{skill}/SKILL.md
+        {output_dir}/{plugin_name}-{version}.tar.gz  # optional artifact
 
     Nested skill directories that contain ``SKILL.md`` are copied with supporting
     files (symlink members are skipped). A collection-level ``SKILL.md`` is
@@ -1069,11 +1140,14 @@ def package_as_agent_plugin(
             - When *plugin_name* is not ``None``, it must already satisfy
               Agent Plugins §5.5 (or it is validated here). Empty string is
               invalid — pass ``None`` for the default name.
+            - When *include_mcp_config* is true, *mcp_transport* must be
+              ``stdio`` or ``streamable-http``; *mcp_url* is required for
+              ``streamable-http``.
         Raises:
             FileNotFoundError: If the collection has no generated skills, or
                 none of those skills contain a ``SKILL.md``.
-            ValidationError: On path escape or invalid plugin name (including
-                when the default name exceeds §5.5 limits).
+            ValidationError: On path escape, invalid plugin name, invalid MCP
+                transport/URL (including when the default name exceeds §5.5).
             OSError: On filesystem permission or I/O errors during mkdir,
                 copy, or manifest write (not silenced).
         Silences:
@@ -1088,6 +1162,14 @@ def package_as_agent_plugin(
     else:
         name = plugin_name
         validate_plugin_name(name)
+    if include_mcp_config:
+        validate_mcp_transport(mcp_transport)
+        if mcp_transport == "streamable-http":
+            if not mcp_url:
+                raise ValidationError(
+                    "mcp_url is required when mcp_transport is 'streamable-http'."
+                )
+            validate_mcp_server_url(mcp_url)
 
     collection_dir = resolve_collection_skills_dir(skills_dirs, collection_fqcn)
     collection_dir_name = collection_dir.name
@@ -1139,6 +1221,8 @@ def package_as_agent_plugin(
         except OSError as exc:
             logger.warning("Could not read collection skill description: %s", exc)
 
+    version = _read_collection_version(collection_dir)
+
     plugin_json_path: str | None = None
     plugin_json_file = plugin_root / "plugin.json"
     if write_plugin_json:
@@ -1148,7 +1232,8 @@ def package_as_agent_plugin(
                 plugin_name=name,
                 collection_fqcn=collection_fqcn,
                 description=description,
-                version=_read_collection_version(collection_dir),
+                version=version,
+                skill_names=packaged,
             )
         )
     elif plugin_json_file.is_file():
@@ -1158,10 +1243,33 @@ def package_as_agent_plugin(
     mcp_json_path: str | None = None
     mcp_json_file = plugin_root / "mcp.json"
     if include_mcp_config:
-        mcp_json_path = str(_write_mcp_json(plugin_root))
+        mcp_json_path = str(
+            _write_mcp_json(
+                plugin_root,
+                mcp_transport=mcp_transport,
+                mcp_url=mcp_url,
+            )
+        )
     elif mcp_json_file.is_file():
         validate_path_containment(mcp_json_file.resolve(), plugin_root)
         mcp_json_file.unlink()
+
+    archive_path: str | None = None
+    archive_file = (
+        resolved_output / f"{name}-{_archive_version(version)}.tar.gz"
+    ).resolve()
+    if write_tarball:
+        archive_path = str(
+            _write_plugin_tarball(
+                plugin_root,
+                resolved_output,
+                plugin_name=name,
+                version=version,
+            )
+        )
+    elif archive_file.is_file():
+        validate_path_containment(archive_file, resolved_output)
+        archive_file.unlink()
 
     logger.info(
         "Packaged %d skills for %s into Agent Plugin %s",
@@ -1177,4 +1285,5 @@ def package_as_agent_plugin(
         "skills": packaged,
         "plugin_json": plugin_json_path,
         "mcp_json": mcp_json_path,
+        "archive": archive_path,
     }

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -754,9 +754,9 @@ def _ignore_symlinks(directory: str, names: list[str]) -> list[str]:
     return [name for name in names if (base / name).is_symlink()]
 
 
-def _copy_skill_tree(src: Path, dest: Path, module_root: Path) -> None:
-    """Copy one skill directory into the Lola module, replacing any prior copy."""
-    validate_path_containment(dest.resolve(), module_root)
+def _copy_skill_tree(src: Path, dest: Path, package_root: Path) -> None:
+    """Copy one skill directory into a packaging root, replacing any prior copy."""
+    validate_path_containment(dest.resolve(), package_root)
     if dest.exists():
         shutil.rmtree(dest)
     shutil.copytree(src, dest, symlinks=False, ignore=_ignore_symlinks)
@@ -1084,6 +1084,56 @@ def _write_mcp_json(
     return mcp_json_path
 
 
+_PLUGIN_ROOT_ENTRIES = frozenset({"plugin.json", "mcp.json", "skills"})
+
+
+def _tar_safe_filter(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo | None:
+    """Omit symlink/hardlink members and path-escape attempts from archives."""
+    if tarinfo.issym() or tarinfo.islnk():
+        return None
+    if ".." in Path(tarinfo.name).parts:
+        return None
+    return tarinfo
+
+
+def _scrub_plugin_root(plugin_root: Path) -> None:
+    """Remove unexpected top-level entries before archiving a plugin root.
+
+    Containment checks the directory entry under *plugin_root* without
+    following symlink targets (absolute links must still be removable).
+    """
+    root = plugin_root.resolve()
+    for entry in list(plugin_root.iterdir()):
+        if entry.name in _PLUGIN_ROOT_ENTRIES:
+            continue
+        try:
+            if entry.parent.resolve() != root:
+                logger.warning(
+                    "Skipping unexpected non-child entry under plugin root: %s",
+                    entry.name,
+                )
+                continue
+            if entry.is_symlink() or entry.is_file():
+                entry.unlink()
+            elif entry.is_dir():
+                shutil.rmtree(entry)
+        except OSError as exc:
+            logger.warning("Could not scrub plugin root entry %s: %s", entry.name, exc)
+
+
+def _remove_plugin_archives(output_dir: Path, plugin_name: str) -> None:
+    """Remove ``{plugin_name}-*.tar.gz`` artifacts under *output_dir*."""
+    for archive in sorted(output_dir.glob(f"{plugin_name}-*.tar.gz")):
+        try:
+            resolved = archive.resolve()
+            validate_path_containment(resolved, output_dir)
+            if archive.is_symlink() or not archive.is_file():
+                continue
+            archive.unlink()
+        except (OSError, ValidationError) as exc:
+            logger.warning("Could not remove stale archive %s: %s", archive.name, exc)
+
+
 def _write_plugin_tarball(
     plugin_root: Path,
     output_dir: Path,
@@ -1091,14 +1141,26 @@ def _write_plugin_tarball(
     plugin_name: str,
     version: str | None,
 ) -> Path:
-    """Write ``{plugin_name}-{version}.tar.gz`` beside the plugin directory."""
+    """Write ``{plugin_name}-{version}.tar.gz`` beside the plugin directory.
+
+    Archives only allowlisted members (``plugin.json``, ``mcp.json``,
+    ``skills/``) and filters out symlink/hardlink members.
+    """
+    _scrub_plugin_root(plugin_root)
+    _remove_plugin_archives(output_dir, plugin_name)
     archive_name = f"{plugin_name}-{_archive_version(version)}.tar.gz"
     archive_path = (output_dir / archive_name).resolve()
     validate_path_containment(archive_path, output_dir)
-    if archive_path.exists():
-        archive_path.unlink()
     with tarfile.open(archive_path, "w:gz") as archive:
-        archive.add(plugin_root, arcname=plugin_name)
+        for member_name in sorted(_PLUGIN_ROOT_ENTRIES):
+            src = plugin_root / member_name
+            if not src.exists() or src.is_symlink():
+                continue
+            archive.add(
+                src,
+                arcname=f"{plugin_name}/{member_name}",
+                filter=_tar_safe_filter,
+            )
     return archive_path
 
 
@@ -1256,9 +1318,6 @@ def package_as_agent_plugin(
         mcp_json_file.unlink()
 
     archive_path: str | None = None
-    archive_file = (
-        resolved_output / f"{name}-{_archive_version(version)}.tar.gz"
-    ).resolve()
     if write_tarball:
         archive_path = str(
             _write_plugin_tarball(
@@ -1268,9 +1327,9 @@ def package_as_agent_plugin(
                 version=version,
             )
         )
-    elif archive_file.is_file():
-        validate_path_containment(archive_file, resolved_output)
-        archive_file.unlink()
+    else:
+        _remove_plugin_archives(resolved_output, name)
+        _scrub_plugin_root(plugin_root)
 
     logger.info(
         "Packaged %d skills for %s into Agent Plugin %s",

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -388,6 +388,7 @@ class PackageAsPluginResult(TypedDict):
     skills: list[str]
     plugin_json: str | None
     mcp_json: str | None
+    archive: str | None
 
 
 AgentPluginManifest = TypedDict(

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 if sys.version_info >= (3, 12):
     from typing import TypedDict
@@ -404,11 +404,30 @@ AgentPluginManifest = TypedDict(
 """Closed-schema ``plugin.json`` payload (Agent Plugins v1.0.0)."""
 
 
+class AgentMcpStdioServer(TypedDict):
+    """stdio MCP server entry in Agent Plugins ``mcp.json``."""
+
+    type: Literal["stdio"]
+    command: str
+    args: list[str]
+
+
+class AgentMcpHttpServer(TypedDict):
+    """streamable-http MCP server entry in Agent Plugins ``mcp.json``."""
+
+    type: Literal["streamable-http"]
+    url: str
+
+
+AgentMcpServer = AgentMcpStdioServer | AgentMcpHttpServer
+"""Discriminated MCP server entry for ``mcpServers`` values."""
+
+
 AgentMcpConfig = TypedDict(
     "AgentMcpConfig",
     {
         "$schema": str,
-        "mcpServers": dict[str, dict[str, Any]],
+        "mcpServers": dict[str, AgentMcpServer],
     },
 )
 """Top-level ``mcp.json`` payload (Agent Plugins v1.0.0)."""

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -378,6 +378,41 @@ class LolaMarketYml(TypedDict):
     tags: list[str]
 
 
+class PackageAsPluginResult(TypedDict):
+    """Result of package_as_plugin tool / package_as_agent_plugin."""
+
+    collection: str
+    plugin_name: str
+    plugin_dir: str
+    skill_count: int
+    skills: list[str]
+    plugin_json: str | None
+    mcp_json: str | None
+
+
+AgentPluginManifest = TypedDict(
+    "AgentPluginManifest",
+    {
+        "$schema": str,
+        "name": str,
+        "version": str,
+        "description": str,
+        "keywords": list[str],
+    },
+)
+"""Closed-schema ``plugin.json`` payload (Agent Plugins v1.0.0)."""
+
+
+AgentMcpConfig = TypedDict(
+    "AgentMcpConfig",
+    {
+        "$schema": str,
+        "mcpServers": dict[str, dict[str, Any]],
+    },
+)
+"""Top-level ``mcp.json`` payload (Agent Plugins v1.0.0)."""
+
+
 class _CollectionDocsResultBase(TypedDict):
     """Required fields for batch collection docs result."""
 

--- a/src/ansible_know/validation.py
+++ b/src/ansible_know/validation.py
@@ -23,6 +23,7 @@ __all__ = [
     "validate_lola_module_name",
     "validate_namespace",
     "validate_path_containment",
+    "validate_plugin_name",
     "validate_plugin_type",
     "validate_query",
     "validate_skill_name",
@@ -44,10 +45,13 @@ _SKILL_NAME_RE = re.compile(r"^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)?$")
 _VERSION_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 _TAGS_RE = re.compile(r"^[a-zA-Z0-9_,-]+$")
 _LOLA_MODULE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+# Agent Plugins §5.5: lowercase alphanumeric, hyphen, period; no "--" / "..".
+_PLUGIN_NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9.-]{0,62}[a-z0-9])?$")
 _SENSITIVE_PREFIXES = ("/etc", "/usr", "/bin", "/sbin", "/boot", "/proc", "/sys", "/dev")
 _PATH_RE = re.compile(r"/(?:home|tmp|usr|etc|var|opt)/\S+")
 # Allow "ansible-" + full kebab collection name (namespace max is 128).
 MAX_LOLA_MODULE_NAME_LENGTH = MAX_NAMESPACE_LENGTH + len("ansible-")
+MAX_PLUGIN_NAME_LENGTH = 64
 
 
 def validate_fqcn(name: str) -> None:
@@ -104,6 +108,36 @@ def validate_lola_module_name(name: str) -> None:
             "Invalid Lola module name: use 1-"
             f"{MAX_LOLA_MODULE_NAME_LENGTH} alphanumeric characters, "
             "dots, underscores, or hyphens (no path separators)."
+        )
+
+
+def validate_plugin_name(name: str) -> None:
+    """Validate an Agent Plugins ``plugin.json`` ``name`` field (§5.5).
+
+    Contract:
+        Preconditions:
+            - ``name`` length is 1–``MAX_PLUGIN_NAME_LENGTH`` (64).
+            - Character set is lowercase ``a-z``, ``0-9``, ``-``, ``.`` only.
+            - First and last characters are alphanumeric.
+            - No consecutive ``--`` or ``..``.
+            - No path separators (``/``, ``\\``).
+        Raises:
+            ValidationError: If any precondition fails (explicit check).
+    """
+    if (
+        not name
+        or len(name) > MAX_PLUGIN_NAME_LENGTH
+        or "/" in name
+        or "\\" in name
+        or "--" in name
+        or ".." in name
+        or not _PLUGIN_NAME_RE.match(name)
+    ):
+        raise ValidationError(
+            "Invalid plugin name: use 1-"
+            f"{MAX_PLUGIN_NAME_LENGTH} lowercase alphanumeric characters, "
+            "hyphens, or periods; must start and end alphanumeric; "
+            "no '--' or '..' (Agent Plugins §5.5)."
         )
 
 

--- a/src/ansible_know/validation.py
+++ b/src/ansible_know/validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import re
 import warnings
 from pathlib import Path
@@ -11,6 +12,7 @@ from ansible_know.errors import ValidationError
 
 __all__ = [
     "ALLOWED_DOC_HOSTS",
+    "VALID_MCP_TRANSPORTS",
     "extract_collection_fqcn",
     "extract_namespace",
     "split_collection_fqcn",
@@ -21,6 +23,8 @@ __all__ = [
     "validate_install_path",
     "validate_keyword",
     "validate_lola_module_name",
+    "validate_mcp_server_url",
+    "validate_mcp_transport",
     "validate_namespace",
     "validate_path_containment",
     "validate_plugin_name",
@@ -247,6 +251,65 @@ def validate_plugin_type(plugin_type: str) -> None:
 
 
 ALLOWED_DOC_HOSTS = frozenset({"docs.ansible.com", "docs.redhat.com"})
+VALID_MCP_TRANSPORTS = frozenset({"stdio", "streamable-http"})
+
+
+def validate_mcp_transport(transport: str) -> None:
+    """Validate an Agent Plugins ``mcp.json`` transport type.
+
+    Contract:
+        Preconditions:
+            - ``transport`` must be ``stdio`` or ``streamable-http``.
+        Raises:
+            ValidationError: If the transport is unsupported.
+    """
+    if transport not in VALID_MCP_TRANSPORTS:
+        raise ValidationError(
+            "Invalid MCP transport: use 'stdio' or 'streamable-http'."
+        )
+
+
+def validate_mcp_server_url(url: str) -> None:
+    """Validate an Agent Plugins remote MCP URL (§7.2.1).
+
+    Absolute HTTP(S) URL, no userinfo or fragment. Non-loopback hosts MUST
+    use HTTPS; HTTP is allowed only for ``localhost`` or loopback IPs.
+
+    Contract:
+        Preconditions:
+            - Non-empty URL under ``MAX_URL_LENGTH``.
+            - Scheme ``https``, or ``http`` only for loopback.
+            - No username/password/fragment.
+        Raises:
+            ValidationError: If any precondition fails.
+    """
+    if not url or len(url) > MAX_URL_LENGTH:
+        raise ValidationError(
+            f"MCP URL must be non-empty and under {MAX_URL_LENGTH} characters."
+        )
+    try:
+        parsed = urlparse(url)
+    except ValueError as exc:
+        raise ValidationError(f"Invalid MCP URL format: {exc}") from exc
+    if parsed.scheme not in ("http", "https"):
+        raise ValidationError("MCP URL must use http or https.")
+    if parsed.username is not None or parsed.password is not None or parsed.fragment:
+        raise ValidationError("MCP URL must not include userinfo or a fragment.")
+    host = parsed.hostname
+    if not host:
+        raise ValidationError("MCP URL must include a host.")
+    if parsed.scheme == "http":
+        if host == "localhost":
+            return
+        try:
+            if not ipaddress.ip_address(host).is_loopback:
+                raise ValidationError(
+                    "HTTP MCP URLs are only allowed for localhost or loopback IPs."
+                )
+        except ValueError as exc:
+            raise ValidationError(
+                "HTTP MCP URLs are only allowed for localhost or loopback IPs."
+            ) from exc
 
 
 def validate_doc_url(url: str) -> None:

--- a/src/ansible_know/validation.py
+++ b/src/ansible_know/validation.py
@@ -287,6 +287,10 @@ def validate_mcp_server_url(url: str) -> None:
         raise ValidationError(
             f"MCP URL must be non-empty and under {MAX_URL_LENGTH} characters."
         )
+    if url != url.strip() or any(ch.isspace() or ord(ch) < 32 for ch in url):
+        raise ValidationError(
+            "MCP URL must not contain whitespace or control characters."
+        )
     try:
         parsed = urlparse(url)
     except ValueError as exc:

--- a/tests/test_agent_plugin_packaging.py
+++ b/tests/test_agent_plugin_packaging.py
@@ -201,7 +201,11 @@ class TestPackageAsAgentPlugin:
         _write_skill_tree(skills, "netbox-netbox")
 
         result = package_as_agent_plugin(
-            skills, "netbox.netbox", out, write_plugin_json=False,
+            skills,
+            "netbox.netbox",
+            out,
+            write_plugin_json=False,
+            write_tarball=False,
         )
         assert result["plugin_json"] is None
         assert not (Path(result["plugin_dir"]) / "plugin.json").exists()
@@ -260,6 +264,56 @@ class TestPackageAsAgentPlugin:
         )
         assert result["archive"] is None
         assert not list(out.glob("*.tar.gz"))
+
+    def test_tarball_requires_plugin_json(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        _write_skill_tree(skills, "netbox-netbox")
+        with pytest.raises(ValidationError, match="write_tarball requires write_plugin_json"):
+            package_as_agent_plugin(
+                skills,
+                "netbox.netbox",
+                tmp_path / "out",
+                write_plugin_json=False,
+                write_tarball=True,
+            )
+
+    def test_archive_symlink_does_not_overwrite_sibling(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        out.mkdir()
+        _write_skill_tree(skills, "netbox-netbox")
+        victim = out / "victim.txt"
+        victim.write_text("keep-me\n")
+        archive_link = out / "ansible-netbox-netbox-agentplugin-3.2.0.tar.gz"
+        archive_link.symlink_to(victim)
+
+        result = package_as_agent_plugin(skills, "netbox.netbox", out)
+        archive = Path(result["archive"] or "")
+        assert archive.is_file()
+        assert not archive.is_symlink()
+        assert victim.read_text() == "keep-me\n"
+        assert tarfile.is_tarfile(archive)
+
+    def test_manifest_symlink_does_not_redirect_write(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+        plugin_dir = out / "ansible-netbox-netbox-agentplugin"
+        plugin_dir.mkdir(parents=True)
+        outside = tmp_path / "outside-plugin.json"
+        outside.write_text("original\n")
+        (plugin_dir / "plugin.json").symlink_to(outside)
+        (plugin_dir / "mcp.json").symlink_to(outside)
+
+        result = package_as_agent_plugin(
+            skills, "netbox.netbox", out, write_tarball=False,
+        )
+        plugin_json = Path(result["plugin_json"] or "")
+        mcp_json = Path(result["mcp_json"] or "")
+        assert plugin_json.is_file() and not plugin_json.is_symlink()
+        assert mcp_json.is_file() and not mcp_json.is_symlink()
+        assert outside.read_text() == "original\n"
+        assert '"$schema"' in plugin_json.read_text()
 
     def test_tarball_excludes_leftover_symlinks_and_junk(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"

--- a/tests/test_agent_plugin_packaging.py
+++ b/tests/test_agent_plugin_packaging.py
@@ -1,0 +1,256 @@
+"""Tests for Agent Plugins packaging helper (issue #223)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ansible_know.errors import ValidationError
+from ansible_know.skills import (
+    MCP_SCHEMA,
+    PLUGIN_SCHEMA,
+    default_plugin_name,
+    package_as_agent_plugin,
+)
+from ansible_know.validation import validate_plugin_name
+
+
+def _write_skill_tree(skills_root: Path, collection_kebab: str) -> Path:
+    """Create a minimal generated-skills tree for packaging tests."""
+    collection_dir = skills_root / collection_kebab
+    collection_dir.mkdir(parents=True)
+    (collection_dir / "SKILL.md").write_text(
+        "---\nname: netbox-netbox\ndescription: Collection overview\n---\n# Collection\n"
+    )
+    (collection_dir / "MANIFEST.json").write_text(
+        json.dumps({
+            "collection": "netbox.netbox",
+            "collection_version": "3.2.0",
+            "module_count": 1,
+        })
+    )
+    module_dir = collection_dir / "netbox-device"
+    module_dir.mkdir()
+    (module_dir / "SKILL.md").write_text(
+        "---\nname: netbox-device\ndescription: Manage devices\n---\n# Device\n"
+    )
+    scripts = module_dir / "scripts"
+    scripts.mkdir()
+    (scripts / "run.sh").write_text("#!/bin/sh\necho hi\n")
+    plugin_dir = collection_dir / "lookup-nb-lookup"
+    plugin_dir.mkdir()
+    (plugin_dir / "SKILL.md").write_text(
+        "---\nname: lookup-nb-lookup\ndescription: Lookup helper\n---\n# Lookup\n"
+    )
+    return collection_dir
+
+
+class TestValidatePluginName:
+    def test_accepts_kebab_name(self) -> None:
+        validate_plugin_name("ansible-netbox-netbox")
+
+    def test_accepts_single_char(self) -> None:
+        validate_plugin_name("a")
+
+    def test_accepts_period(self) -> None:
+        validate_plugin_name("acme.tools")
+
+    def test_rejects_uppercase(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid plugin name"):
+            validate_plugin_name("My-Plugin")
+
+    def test_rejects_leading_hyphen(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid plugin name"):
+            validate_plugin_name("-start")
+
+    def test_rejects_double_hyphen(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid plugin name"):
+            validate_plugin_name("has--double")
+
+    def test_rejects_double_period(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid plugin name"):
+            validate_plugin_name("too.many..dots")
+
+    def test_rejects_length_65(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid plugin name"):
+            validate_plugin_name("a" * 65)
+
+    def test_accepts_length_64(self) -> None:
+        validate_plugin_name("a" * 64)
+
+    def test_rejects_underscore(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid plugin name"):
+            validate_plugin_name("bad_name")
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid plugin name"):
+            validate_plugin_name("")
+
+
+class TestDefaultPluginName:
+    def test_prefixes_ansible(self) -> None:
+        assert default_plugin_name("netbox.netbox") == "ansible-netbox-netbox"
+
+    def test_overlong_fails_closed(self) -> None:
+        # ansible- (8) + 60-char ns + "-" + 1 = already past 64 when long enough
+        long_ns = "n" * 40
+        long_coll = "c" * 40
+        with pytest.raises(ValidationError, match="Invalid plugin name"):
+            default_plugin_name(f"{long_ns}.{long_coll}")
+
+
+class TestPackageAsAgentPlugin:
+    def test_wraps_skills_into_plugin_layout(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+
+        result = package_as_agent_plugin(skills, "netbox.netbox", out)
+
+        plugin_dir = Path(result["plugin_dir"])
+        assert result["plugin_name"] == "ansible-netbox-netbox"
+        assert result["skill_count"] == 3
+        assert set(result["skills"]) == {
+            "netbox-netbox",
+            "netbox-device",
+            "lookup-nb-lookup",
+        }
+        assert (plugin_dir / "skills" / "netbox-device" / "SKILL.md").is_file()
+        assert (plugin_dir / "skills" / "netbox-device" / "scripts" / "run.sh").is_file()
+        assert (plugin_dir / "skills" / "netbox-netbox" / "SKILL.md").is_file()
+        # Flat layout — no nested collection/module under skills/
+        assert not (plugin_dir / "skills" / "netbox-netbox" / "netbox-device").exists()
+        assert not (plugin_dir / "MANIFEST.json").exists()
+
+        plugin_json = json.loads((plugin_dir / "plugin.json").read_text())
+        assert plugin_json["$schema"] == PLUGIN_SCHEMA
+        assert plugin_json["name"] == "ansible-netbox-netbox"
+        assert plugin_json["version"] == "3.2.0"
+        assert plugin_json["description"] == "Collection overview"
+        assert "ansible" in plugin_json["keywords"]
+        assert set(plugin_json.keys()) <= {
+            "$schema", "name", "version", "description", "author",
+            "homepage", "repository", "license", "keywords", "extensions",
+        }
+
+        mcp_json = json.loads((plugin_dir / "mcp.json").read_text())
+        assert mcp_json["$schema"] == MCP_SCHEMA
+        assert mcp_json["mcpServers"]["ansible-know"]["type"] == "stdio"
+        assert mcp_json["mcpServers"]["ansible-know"]["command"] == "uvx"
+        assert mcp_json["mcpServers"]["ansible-know"]["args"] == ["ansible-know-mcp"]
+        assert result["plugin_json"] == str(plugin_dir / "plugin.json")
+        assert result["mcp_json"] == str(plugin_dir / "mcp.json")
+
+    def test_skips_plugin_json_when_disabled(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+
+        result = package_as_agent_plugin(
+            skills, "netbox.netbox", out, write_plugin_json=False,
+        )
+        assert result["plugin_json"] is None
+        assert not (Path(result["plugin_dir"]) / "plugin.json").exists()
+        assert (Path(result["plugin_dir"]) / "mcp.json").is_file()
+
+    def test_skips_mcp_json_when_disabled(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+
+        result = package_as_agent_plugin(
+            skills, "netbox.netbox", out, include_mcp_config=False,
+        )
+        assert result["mcp_json"] is None
+        assert not (Path(result["plugin_dir"]) / "mcp.json").exists()
+        assert (Path(result["plugin_dir"]) / "plugin.json").is_file()
+
+    def test_removes_stale_manifests_when_disabled(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+
+        first = package_as_agent_plugin(skills, "netbox.netbox", out)
+        plugin_dir = Path(first["plugin_dir"])
+        assert (plugin_dir / "plugin.json").is_file()
+        assert (plugin_dir / "mcp.json").is_file()
+
+        second = package_as_agent_plugin(
+            skills,
+            "netbox.netbox",
+            out,
+            write_plugin_json=False,
+            include_mcp_config=False,
+        )
+        assert second["plugin_json"] is None
+        assert second["mcp_json"] is None
+        assert not (plugin_dir / "plugin.json").exists()
+        assert not (plugin_dir / "mcp.json").exists()
+
+    def test_custom_plugin_name(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        _write_skill_tree(skills, "netbox-netbox")
+        result = package_as_agent_plugin(
+            skills, "netbox.netbox", tmp_path / "out", plugin_name="netbox.skills",
+        )
+        assert result["plugin_name"] == "netbox.skills"
+        assert Path(result["plugin_dir"]).name == "netbox.skills"
+
+    def test_invalid_plugin_name(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        _write_skill_tree(skills, "netbox-netbox")
+        with pytest.raises(ValidationError, match="Invalid plugin name"):
+            package_as_agent_plugin(
+                skills, "netbox.netbox", tmp_path / "out", plugin_name="Bad_Name",
+            )
+
+    def test_missing_skills_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="No generated skills"):
+            package_as_agent_plugin(tmp_path, "netbox.netbox", tmp_path / "out")
+
+    def test_idempotent_replace_skills(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+        first = package_as_agent_plugin(skills, "netbox.netbox", out)
+        stale = Path(first["plugin_dir"]) / "skills" / "stale-skill"
+        stale.mkdir()
+        (stale / "SKILL.md").write_text("---\nname: stale\ndescription: x\n---\n")
+
+        second = package_as_agent_plugin(skills, "netbox.netbox", out)
+        assert "stale-skill" not in second["skills"]
+        assert not stale.exists()
+
+
+class TestPackageAsPluginTool:
+    @pytest.mark.asyncio
+    async def test_package_as_plugin_tool(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+        monkeypatch.setenv("ANSIBLE_KNOW_SKILLS_DIR", str(skills))
+
+        from ansible_know.server import package_as_plugin
+
+        result = await package_as_plugin(
+            collection="netbox.netbox",
+            output_dir=str(out),
+            source_dir=str(skills),
+        )
+        assert "error" not in result
+        assert result["skill_count"] == 3
+        assert Path(result["plugin_dir"]).is_dir()
+
+    @pytest.mark.asyncio
+    async def test_package_as_plugin_validation_error(self) -> None:
+        from ansible_know.server import package_as_plugin
+
+        result = await package_as_plugin(
+            collection="not a namespace",
+            output_dir="/tmp/out",
+        )
+        assert "error" in result

--- a/tests/test_agent_plugin_packaging.py
+++ b/tests/test_agent_plugin_packaging.py
@@ -54,7 +54,7 @@ def _write_skill_tree(skills_root: Path, collection_kebab: str) -> Path:
 
 class TestValidatePluginName:
     def test_accepts_kebab_name(self) -> None:
-        validate_plugin_name("ansible-netbox-netbox")
+        validate_plugin_name("ansible-netbox-netbox-agentplugin")
 
     def test_accepts_single_char(self) -> None:
         validate_plugin_name("a")
@@ -96,7 +96,7 @@ class TestValidatePluginName:
 
 class TestDefaultPluginName:
     def test_prefixes_ansible(self) -> None:
-        assert default_plugin_name("netbox.netbox") == "ansible-netbox-netbox"
+        assert default_plugin_name("netbox.netbox") == "ansible-netbox-netbox-agentplugin"
 
     def test_overlong_fails_closed(self) -> None:
         # ansible- (8) + 60-char ns + "-" + 1 = already past 64 when long enough
@@ -139,7 +139,7 @@ class TestPackageAsAgentPlugin:
         result = package_as_agent_plugin(skills, "netbox.netbox", out)
 
         plugin_dir = Path(result["plugin_dir"])
-        assert result["plugin_name"] == "ansible-netbox-netbox"
+        assert result["plugin_name"] == "ansible-netbox-netbox-agentplugin"
         assert result["skill_count"] == 3
         assert set(result["skills"]) == {
             "netbox-netbox",
@@ -155,7 +155,7 @@ class TestPackageAsAgentPlugin:
 
         plugin_json = json.loads((plugin_dir / "plugin.json").read_text())
         assert plugin_json["$schema"] == PLUGIN_SCHEMA
-        assert plugin_json["name"] == "ansible-netbox-netbox"
+        assert plugin_json["name"] == "ansible-netbox-netbox-agentplugin"
         assert plugin_json["version"] == "3.2.0"
         assert plugin_json["description"] == "Collection overview"
         assert "ansible" in plugin_json["keywords"]
@@ -176,12 +176,12 @@ class TestPackageAsAgentPlugin:
         assert result["mcp_json"] == str(plugin_dir / "mcp.json")
 
         archive = Path(result["archive"] or "")
-        assert archive.name == "ansible-netbox-netbox-3.2.0.tar.gz"
+        assert archive.name == "ansible-netbox-netbox-agentplugin-3.2.0.tar.gz"
         assert archive.is_file()
         with tarfile.open(archive, "r:gz") as tf:
             names = tf.getnames()
-        assert "ansible-netbox-netbox/plugin.json" in names
-        assert "ansible-netbox-netbox/skills/netbox-device/SKILL.md" in names
+        assert "ansible-netbox-netbox-agentplugin/plugin.json" in names
+        assert "ansible-netbox-netbox-agentplugin/skills/netbox-device/SKILL.md" in names
 
     def test_skips_plugin_json_when_disabled(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"

--- a/tests/test_agent_plugin_packaging.py
+++ b/tests/test_agent_plugin_packaging.py
@@ -129,6 +129,18 @@ class TestValidateMcpTransportAndUrl:
         with pytest.raises(ValidationError, match="userinfo|fragment"):
             validate_mcp_server_url("https://user:pass@aap.example.com/mcp")
 
+    def test_rejects_fragment(self) -> None:
+        with pytest.raises(ValidationError, match="userinfo|fragment"):
+            validate_mcp_server_url("https://aap.example.com/mcp#frag")
+
+    def test_rejects_whitespace_and_controls(self) -> None:
+        with pytest.raises(ValidationError, match="whitespace|control"):
+            validate_mcp_server_url(" https://aap.example.com/mcp")
+        with pytest.raises(ValidationError, match="whitespace|control"):
+            validate_mcp_server_url("https://aap.example.com/mcp\nX")
+        with pytest.raises(ValidationError, match="whitespace|control"):
+            validate_mcp_server_url("https://aap.example.com/mcp with space")
+
 
 class TestPackageAsAgentPlugin:
     def test_wraps_skills_into_plugin_layout(self, tmp_path: Path) -> None:
@@ -248,6 +260,45 @@ class TestPackageAsAgentPlugin:
         )
         assert result["archive"] is None
         assert not list(out.glob("*.tar.gz"))
+
+    def test_tarball_excludes_leftover_symlinks_and_junk(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+        plugin_dir = out / "ansible-netbox-netbox-agentplugin"
+        plugin_dir.mkdir(parents=True)
+        secret = tmp_path / "secret"
+        secret.write_text("leak\n")
+        (plugin_dir / "leak").symlink_to(secret)
+        (plugin_dir / "extra.txt").write_text("junk\n")
+
+        result = package_as_agent_plugin(skills, "netbox.netbox", out)
+        assert not (plugin_dir / "leak").exists()
+        assert not (plugin_dir / "extra.txt").exists()
+        with tarfile.open(result["archive"] or "", "r:gz") as tf:
+            names = set(tf.getnames())
+            members = tf.getmembers()
+        assert "ansible-netbox-netbox-agentplugin/plugin.json" in names
+        assert "ansible-netbox-netbox-agentplugin/extra.txt" not in names
+        assert "ansible-netbox-netbox-agentplugin/leak" not in names
+        assert all(not m.issym() and not m.islnk() for m in members)
+
+    def test_removes_stale_versioned_archives(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+        first = package_as_agent_plugin(skills, "netbox.netbox", out)
+        stale = out / "ansible-netbox-netbox-agentplugin-9.9.9.tar.gz"
+        stale.write_bytes(Path(first["archive"] or "").read_bytes())
+
+        second = package_as_agent_plugin(skills, "netbox.netbox", out)
+        assert Path(second["archive"] or "").name == (
+            "ansible-netbox-netbox-agentplugin-3.2.0.tar.gz"
+        )
+        assert not stale.exists()
+        assert {
+            p.name for p in out.glob("ansible-netbox-netbox-agentplugin-*.tar.gz")
+        } == {"ansible-netbox-netbox-agentplugin-3.2.0.tar.gz"}
 
     def test_removes_stale_manifests_when_disabled(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"

--- a/tests/test_agent_plugin_packaging.py
+++ b/tests/test_agent_plugin_packaging.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import tarfile
 from pathlib import Path
 
 import pytest
@@ -14,7 +15,11 @@ from ansible_know.skills import (
     default_plugin_name,
     package_as_agent_plugin,
 )
-from ansible_know.validation import validate_plugin_name
+from ansible_know.validation import (
+    validate_mcp_server_url,
+    validate_mcp_transport,
+    validate_plugin_name,
+)
 
 
 def _write_skill_tree(skills_root: Path, collection_kebab: str) -> Path:
@@ -101,6 +106,30 @@ class TestDefaultPluginName:
             default_plugin_name(f"{long_ns}.{long_coll}")
 
 
+class TestValidateMcpTransportAndUrl:
+    def test_accepts_stdio_and_streamable_http(self) -> None:
+        validate_mcp_transport("stdio")
+        validate_mcp_transport("streamable-http")
+
+    def test_rejects_unknown_transport(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid MCP transport"):
+            validate_mcp_transport("sse")
+
+    def test_accepts_https_url(self) -> None:
+        validate_mcp_server_url("https://aap.example.com/mcp/skills/")
+
+    def test_accepts_localhost_http(self) -> None:
+        validate_mcp_server_url("http://localhost:8080/mcp")
+
+    def test_rejects_plain_http_remote(self) -> None:
+        with pytest.raises(ValidationError, match="loopback"):
+            validate_mcp_server_url("http://aap.example.com/mcp")
+
+    def test_rejects_userinfo(self) -> None:
+        with pytest.raises(ValidationError, match="userinfo|fragment"):
+            validate_mcp_server_url("https://user:pass@aap.example.com/mcp")
+
+
 class TestPackageAsAgentPlugin:
     def test_wraps_skills_into_plugin_layout(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"
@@ -130,6 +159,9 @@ class TestPackageAsAgentPlugin:
         assert plugin_json["version"] == "3.2.0"
         assert plugin_json["description"] == "Collection overview"
         assert "ansible" in plugin_json["keywords"]
+        assert "automation" in plugin_json["keywords"]
+        assert "netbox.netbox" in plugin_json["keywords"]
+        assert "netbox-device" in plugin_json["keywords"]
         assert set(plugin_json.keys()) <= {
             "$schema", "name", "version", "description", "author",
             "homepage", "repository", "license", "keywords", "extensions",
@@ -142,6 +174,14 @@ class TestPackageAsAgentPlugin:
         assert mcp_json["mcpServers"]["ansible-know"]["args"] == ["ansible-know-mcp"]
         assert result["plugin_json"] == str(plugin_dir / "plugin.json")
         assert result["mcp_json"] == str(plugin_dir / "mcp.json")
+
+        archive = Path(result["archive"] or "")
+        assert archive.name == "ansible-netbox-netbox-3.2.0.tar.gz"
+        assert archive.is_file()
+        with tarfile.open(archive, "r:gz") as tf:
+            names = tf.getnames()
+        assert "ansible-netbox-netbox/plugin.json" in names
+        assert "ansible-netbox-netbox/skills/netbox-device/SKILL.md" in names
 
     def test_skips_plugin_json_when_disabled(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"
@@ -167,6 +207,48 @@ class TestPackageAsAgentPlugin:
         assert not (Path(result["plugin_dir"]) / "mcp.json").exists()
         assert (Path(result["plugin_dir"]) / "plugin.json").is_file()
 
+    def test_streamable_http_mcp_config(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+        url = "https://aap.example.com/mcp/skills/"
+
+        result = package_as_agent_plugin(
+            skills,
+            "netbox.netbox",
+            out,
+            mcp_transport="streamable-http",
+            mcp_url=url,
+            write_tarball=False,
+        )
+        mcp_json = json.loads(Path(result["mcp_json"] or "").read_text())
+        assert mcp_json["mcpServers"]["ansible-know"] == {
+            "type": "streamable-http",
+            "url": url,
+        }
+        assert result["archive"] is None
+
+    def test_streamable_http_requires_url(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        _write_skill_tree(skills, "netbox-netbox")
+        with pytest.raises(ValidationError, match="mcp_url is required"):
+            package_as_agent_plugin(
+                skills,
+                "netbox.netbox",
+                tmp_path / "out",
+                mcp_transport="streamable-http",
+            )
+
+    def test_skips_tarball_when_disabled(self, tmp_path: Path) -> None:
+        skills = tmp_path / "skills"
+        out = tmp_path / "out"
+        _write_skill_tree(skills, "netbox-netbox")
+        result = package_as_agent_plugin(
+            skills, "netbox.netbox", out, write_tarball=False,
+        )
+        assert result["archive"] is None
+        assert not list(out.glob("*.tar.gz"))
+
     def test_removes_stale_manifests_when_disabled(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"
         out = tmp_path / "out"
@@ -176,6 +258,7 @@ class TestPackageAsAgentPlugin:
         plugin_dir = Path(first["plugin_dir"])
         assert (plugin_dir / "plugin.json").is_file()
         assert (plugin_dir / "mcp.json").is_file()
+        assert Path(first["archive"] or "").is_file()
 
         second = package_as_agent_plugin(
             skills,
@@ -183,11 +266,14 @@ class TestPackageAsAgentPlugin:
             out,
             write_plugin_json=False,
             include_mcp_config=False,
+            write_tarball=False,
         )
         assert second["plugin_json"] is None
         assert second["mcp_json"] is None
+        assert second["archive"] is None
         assert not (plugin_dir / "plugin.json").exists()
         assert not (plugin_dir / "mcp.json").exists()
+        assert not list(out.glob("*.tar.gz"))
 
     def test_custom_plugin_name(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"

--- a/tests/test_lola_packaging.py
+++ b/tests/test_lola_packaging.py
@@ -288,10 +288,11 @@ class TestPackageForLolaTool:
 
         from ansible_know.server import package_for_lola
 
-        result = await package_for_lola(
-            collection="netbox.netbox",
-            output_dir=str(out),
-        )
+        with pytest.warns(DeprecationWarning, match="package_as_plugin"):
+            result = await package_for_lola(
+                collection="netbox.netbox",
+                output_dir=str(out),
+            )
 
         assert "error" not in result
         assert result["skill_count"] == 3
@@ -304,12 +305,13 @@ class TestPackageForLolaTool:
 
         from ansible_know.server import package_for_lola
 
-        result = await package_for_lola(
-            collection="netbox.netbox",
-            output_dir=str(out),
-            source_dir=str(skills),
-            write_market_yml=False,
-        )
+        with pytest.warns(DeprecationWarning, match="package_as_plugin"):
+            result = await package_for_lola(
+                collection="netbox.netbox",
+                output_dir=str(out),
+                source_dir=str(skills),
+                write_market_yml=False,
+            )
 
         assert result["market_yml"] is None
         assert result["skill_count"] == 3
@@ -317,8 +319,9 @@ class TestPackageForLolaTool:
     async def test_package_for_lola_validation_error(self) -> None:
         from ansible_know.server import package_for_lola
 
-        result = await package_for_lola(
-            collection="not a namespace",
-            output_dir="/tmp/out",
-        )
+        with pytest.warns(DeprecationWarning, match="package_as_plugin"):
+            result = await package_for_lola(
+                collection="not a namespace",
+                output_dir="/tmp/out",
+            )
         assert "error" in result

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,15 @@
 """Tests for ansible_know.types."""
 
 from ansible_know.parser import transform_galaxy_to_ansible_doc_format
-from ansible_know.types import AnsibleDocEntry, AnsibleDocPayload, ManifestPluginEntry, PluginMetadata
+from ansible_know.types import (
+    AgentMcpConfig,
+    AgentMcpHttpServer,
+    AgentMcpStdioServer,
+    AnsibleDocEntry,
+    AnsibleDocPayload,
+    ManifestPluginEntry,
+    PluginMetadata,
+)
 
 
 class TestAnsibleDocEntry:
@@ -57,3 +65,28 @@ class TestPluginTypes:
             "has_skill": False,
         }
         assert entry["plugin_type"] == "lookup"
+
+
+class TestAgentMcpTypes:
+    def test_stdio_server_entry(self) -> None:
+        server: AgentMcpStdioServer = {
+            "type": "stdio",
+            "command": "uvx",
+            "args": ["ansible-know-mcp"],
+        }
+        config: AgentMcpConfig = {
+            "$schema": "https://agentplugins.com/schema/v1/mcp.json",
+            "mcpServers": {"ansible-know": server},
+        }
+        assert config["mcpServers"]["ansible-know"]["type"] == "stdio"
+
+    def test_http_server_entry(self) -> None:
+        server: AgentMcpHttpServer = {
+            "type": "streamable-http",
+            "url": "https://aap.example.com/mcp/skills/",
+        }
+        config: AgentMcpConfig = {
+            "$schema": "https://agentplugins.com/schema/v1/mcp.json",
+            "mcpServers": {"ansible-know": server},
+        }
+        assert config["mcpServers"]["ansible-know"]["type"] == "streamable-http"


### PR DESCRIPTION
## Summary

- Add Domain `package_as_agent_plugin()` and MCP tool `package_as_plugin` that wrap nested `generate_*` skills into an Agent Plugins v1.0.0 directory (`plugin.json`, flat `skills/`, optional `mcp.json` for `uvx ansible-know-mcp`).
- Deprecate `package_for_lola` for one release cycle (warning retained; behavior unchanged).
- Update ADR-0008 Layer 2, add ADR-0009, and sync contracts/README/CLAUDE/strategy docs.

Closes #223

## Changes

- `validation.py`: `validate_plugin_name` (Agent Plugins §5.5)
- `types.py`: `PackageAsPluginResult`, `AgentPluginManifest`, `AgentMcpConfig`
- `skills.py`: `default_plugin_name`, `package_as_agent_plugin`, shared `_plan_packable_skill_dirs`
- `server.py`: `package_as_plugin` tool; deprecate `package_for_lola`
- `tests/test_agent_plugin_packaging.py`: name validation, flatten layout, manifests, MCP tool
- ADRs / service-contracts / project-strategy / README / CLAUDE

## Test plan

- [x] `uv sync --extra dev` in worktree
- [x] `pytest tests/test_agent_plugin_packaging.py tests/test_lola_packaging.py -v` (46 passed)
- [x] `pytest tests/ -v` (1026 passed, 84 skipped)
- [x] `ruff check` on changed Python files
- [ ] CI green on PR

## Review findings addressed

- **Plan review** (`git-plan`): warnings-ok — fail-closed overlong plugin names; Lola-parity Domain/Orchestration contracts; TypedDict for `plugin.json`; export `__all__`; strategy one-liner
- **Implementation review** (`git-implement`): Clean (architecture, code-quality/PEP8, security path containment, skill-compliance)

## Acknowledged debt

- #222 AGENTS.md enrichment for flat layout (out of scope)
- Remove `package_for_lola` after one release cycle

## Stack position

- **Base**: `main`
- **Next**: end of chain (single-issue PR)

Assisted-by: Cursor (Grok 4.5)