### PR TITLE
feat: enrich AGENTS.md with per-collection index pointers

### DIFF
--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -397,45 +397,73 @@ def get_skill_sync(skills_dirs: Path | Sequence[Path], skill_name: str) -> str:
     raise FileNotFoundError(f"Skill '{skill_name}' not found.")
 
 
+def _parse_collection_frontmatter(skill_md: Path) -> dict[str, Any]:
+    """Extract metadata from a collection SKILL.md frontmatter block."""
+    try:
+        content = skill_md.read_text()
+    except OSError:
+        return {}
+    if not content.startswith("---"):
+        return {}
+    end = content.find("\n---", 3)
+    if end < 0:
+        return {}
+    try:
+        return yaml.safe_load(content[3:end]) or {}
+    except yaml.YAMLError:
+        return {}
+
+
 def update_agents_md(project_root: Path, skills_dir: Path) -> None:
     """Write or update the managed AGENTS.md section listing generated skills."""
     validate_install_path(str(project_root))
 
-    collections = []
-    example_path = ""
-    example_dir = ""
+    collection_lines: list[str] = []
     if skills_dir.exists():
         for entry in sorted(skills_dir.iterdir()):
             try:
                 if not entry.is_dir() or entry.is_symlink():
                     continue
-                if (entry / "SKILL.md").exists():
-                    fqcn = skill_dir_to_collection_fqcn(entry.name)
-                    collections.append(fqcn)
-                    if not example_path:
-                        for sub in sorted(entry.iterdir()):
-                            if sub.is_dir() and not sub.is_symlink() and (sub / "SKILL.md").exists():
-                                example_path = f"{fqcn}.{skill_dir_to_short_fqcn(sub.name)}"
-                                example_dir = f"skills/{entry.name}/{sub.name}/SKILL.md"
-                                break
+                skill_md = entry / "SKILL.md"
+                if not skill_md.exists():
+                    continue
+                fqcn = skill_dir_to_collection_fqcn(entry.name)
+                fm = _parse_collection_frontmatter(skill_md)
+                meta = fm.get("metadata", {}) or {}
+                version = meta.get("version", "")
+                desc = fm.get("description", "")
+                count_match = re.search(r"Covers (\d+) modules?", desc)
+                module_count = count_match.group(1) if count_match else ""
+
+                detail_parts: list[str] = []
+                if module_count:
+                    detail_parts.append(f"{module_count} modules")
+                if version:
+                    detail_parts.append(f"v{version}")
+                detail = f" ({', '.join(detail_parts)})" if detail_parts else ""
+
+                collection_lines.append(
+                    f"- **{fqcn}**{detail}"
+                    f" → `skills/{entry.name}/SKILL.md`"
+                )
             except OSError:
                 continue
 
-    example_line = ""
-    if example_path:
-        example_line = f"\n(e.g., `{example_path}` → `{example_dir}`)."
+    if collection_lines:
+        coll_block = "\n".join(collection_lines) + "\n"
     else:
-        example_line = "."
+        coll_block = "(none generated yet)\n"
 
     section = (
         f"{_AGENTS_MD_START}\n"
         f"## Ansible Module Skills\n"
         f"\n"
-        f"Generated Ansible module documentation skills are in `skills/`.\n"
-        f"Before writing tasks for a module, check for a SKILL.md in the\n"
-        f"matching collection and module directory{example_line}\n"
+        f"Before writing tasks for any module below, read the collection\n"
+        f"SKILL.md for the full module index, then open the specific module skill.\n"
         f"\n"
-        f"Available collections: {', '.join(collections)}\n"
+        f"### Available collections\n"
+        f"\n"
+        f"{coll_block}"
         f"{_AGENTS_MD_END}\n"
     )
 

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -415,7 +415,13 @@ def _parse_collection_frontmatter(skill_md: Path) -> dict[str, Any]:
 
 
 def update_agents_md(project_root: Path, skills_dir: Path) -> None:
-    """Write or update the managed AGENTS.md section listing generated skills."""
+    """Write or update the managed AGENTS.md section listing generated skills.
+
+    Only directories whose SKILL.md frontmatter declares
+    ``metadata.plugin-type: collection`` are listed. That keeps nested
+    generate output and flat Agent Plugins ``skills/`` trees from treating
+    module/role/plugin skills as collections.
+    """
     validate_install_path(str(project_root))
 
     collection_lines: list[str] = []
@@ -427,9 +433,15 @@ def update_agents_md(project_root: Path, skills_dir: Path) -> None:
                 skill_md = entry / "SKILL.md"
                 if not skill_md.exists():
                     continue
-                fqcn = skill_dir_to_collection_fqcn(entry.name)
                 fm = _parse_collection_frontmatter(skill_md)
                 meta = fm.get("metadata", {}) or {}
+                if meta.get("plugin-type") != "collection":
+                    continue
+                fqcn = (
+                    meta.get("fqcn")
+                    or meta.get("collection")
+                    or skill_dir_to_collection_fqcn(entry.name)
+                )
                 version = meta.get("version", "")
                 desc = fm.get("description", "")
                 count_match = re.search(r"Covers (\d+) modules?", desc)

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import time
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 from unittest.mock import patch as stdlib_patch
 
@@ -217,14 +218,32 @@ SAMPLE_DETAIL_RESPONSE = {
 }
 
 
-def _mock_search_context(mock_api_get_fn):
-    """Patch _api_get for search_collections tests.
+@contextmanager
+def _mock_api_get_context(mock_api_get_fn):
+    """Patch ``_api_get`` and stub API-root discovery for unit tests.
 
-    Since search_collections now uses the GalaxyClient's _get_client method
-    instead of creating its own httpx.AsyncClient, we only need to patch
-    _api_get itself.
+    Production methods call ``_discover_api_root()`` (raw httpx) before
+    ``_api_get``. Patching only ``_api_get`` leaves that handshake on the
+    live network, which flakes when Galaxy is slow or unreachable. This
+    helper closes the mock boundary: discovery is satisfied in-process
+    with a public-Galaxy-shaped root, and v3 HTTP goes through
+    *mock_api_get_fn*.
     """
-    return patch.object(GalaxyClient, "_api_get", mock_api_get_fn)
+    async def _stub_discover(self):
+        if self._api_root is None:
+            self._api_root = "https://galaxy.ansible.com/api"
+            self._v3_path = "v3/"
+
+    with (
+        patch.object(GalaxyClient, "_api_get", mock_api_get_fn),
+        patch.object(GalaxyClient, "_discover_api_root", _stub_discover),
+    ):
+        yield
+
+
+def _mock_search_context(mock_api_get_fn):
+    """Patch Galaxy HTTP for ``search_collections`` unit tests."""
+    return _mock_api_get_context(mock_api_get_fn)
 
 
 class TestSearchCollections:
@@ -498,7 +517,7 @@ class TestFetchModuleDoc:
                 return SAMPLE_DOCS_BLOB
             return {}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             client = GalaxyClient()
             doc, meta = await client.fetch_module_doc("netbox.netbox.netbox_device")
 
@@ -523,7 +542,7 @@ class TestFetchModuleDoc:
                 return SAMPLE_DOCS_BLOB
             return {}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             client = GalaxyClient()
             doc, meta = await client.fetch_module_doc(
                 "netbox.netbox.netbox_device", version="3.20.0",
@@ -541,10 +560,28 @@ class TestFetchModuleDoc:
                 return SAMPLE_DOCS_BLOB
             return {}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             client = GalaxyClient()
             with pytest.raises(GalaxyError, match="not found"):
                 await client.fetch_module_doc("netbox.netbox.nonexistent_module")
+
+    @pytest.mark.asyncio
+    async def test_missing_module_never_opens_live_http_client(self):
+        """Mock boundary must stub discovery — not depend on live Galaxy."""
+        async def mock_api_get(self_client, path, params=None, timeout=None):
+            if "versions/" in path and "docs-blob" not in path:
+                return SAMPLE_VERSIONS_RESPONSE
+            if "docs-blob" in path:
+                return SAMPLE_DOCS_BLOB
+            return {}
+
+        with patch.object(
+            GalaxyClient, "_get_client", side_effect=AssertionError("live HTTP client"),
+        ):
+            with _mock_api_get_context(mock_api_get):
+                client = GalaxyClient()
+                with pytest.raises(GalaxyError, match="not found"):
+                    await client.fetch_module_doc("netbox.netbox.nonexistent_module")
 
     @pytest.mark.asyncio
     async def test_handles_options_already_as_dict(self):
@@ -581,7 +618,7 @@ class TestFetchModuleDoc:
                 return blob_with_dict_options
             return {}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             client = GalaxyClient()
             doc, meta = await client.fetch_module_doc("test.col.some_module")
 
@@ -601,7 +638,7 @@ class TestFetchCollectionDocs:
                 return SAMPLE_DOCS_BLOB
             return {}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             client = GalaxyClient()
             docs, meta = await client.fetch_collection_docs("netbox.netbox")
 
@@ -622,7 +659,7 @@ class TestFetchCollectionDocs:
                 return SAMPLE_DOCS_BLOB
             return {}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             client = GalaxyClient()
             docs, meta = await client.fetch_collection_docs(
                 "netbox.netbox", version="3.20.0",
@@ -646,7 +683,7 @@ class TestFetchCollectionDocs:
                 return empty_blob
             return {}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             client = GalaxyClient()
             docs, meta = await client.fetch_collection_docs("netbox.netbox")
 
@@ -699,7 +736,7 @@ class TestFetchCollectionDocs:
                 return blob_with_bad_module
             return {}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             client = GalaxyClient()
             import logging
             with caplog.at_level(logging.WARNING, logger="ansible_know"):
@@ -721,7 +758,7 @@ class TestListCollectionModules:
                 return SAMPLE_DOCS_BLOB
             return {}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             client = GalaxyClient()
             modules, meta = await client.list_collection_modules("netbox.netbox")
 
@@ -917,7 +954,10 @@ class TestCacheHitPaths:
             _bkey("netbox", "netbox", "3.23.0"), SAMPLE_DOCS_BLOB["docs_blob"],
         )
 
-        with patch.object(GalaxyClient, "_api_get", side_effect=AssertionError("should not call API")):
+        async def boom(*_args, **_kwargs):
+            raise AssertionError("should not call API")
+
+        with _mock_api_get_context(boom):
             client = GalaxyClient()
             doc, meta = await client.fetch_module_doc("netbox.netbox.netbox_device")
 
@@ -1250,7 +1290,7 @@ class TestModuleWithoutDocStrings:
                 return blob
             return {}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             client = GalaxyClient()
             modules, meta = await client.list_collection_modules("test.col")
 
@@ -1464,7 +1504,7 @@ class TestEnrichmentSemaphore:
                 return search_data
             return {"download_count": 100, "highest_version": {"version": "1.0.0"}}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             with patch.object(GalaxyClient, "_get_collection_detail", tracking_detail):
                 client = GalaxyClient()
                 await client.search_collections("test")
@@ -1544,7 +1584,7 @@ class TestListCollectionRoles:
                 return SAMPLE_DOCS_BLOB_WITH_ROLES
             return {}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             client = GalaxyClient()
             roles, meta = await client.list_collection_roles("fedora.linux_system_roles")
 
@@ -1571,7 +1611,7 @@ class TestFetchRoleDoc:
                 return SAMPLE_DOCS_BLOB_WITH_ROLES
             return {}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             client = GalaxyClient()
             role_meta, meta = await client.fetch_role_doc(
                 "fedora.linux_system_roles.timesync",
@@ -1596,7 +1636,7 @@ class TestFetchRoleDoc:
                 return SAMPLE_DOCS_BLOB_WITH_ROLES
             return {}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             client = GalaxyClient()
             with pytest.raises(GalaxyError, match="not found"):
                 await client.fetch_role_doc("fedora.linux_system_roles.nonexistent")
@@ -1623,7 +1663,7 @@ class TestFetchRoleDoc:
                 return blob
             return {}
 
-        with patch.object(GalaxyClient, "_api_get", mock_api_get):
+        with _mock_api_get_context(mock_api_get):
             client = GalaxyClient()
             role_meta, meta = await client.fetch_role_doc("some.col.empty_role")
 
@@ -2248,7 +2288,7 @@ class TestDynamicUrlConstruction:
         gc._api_root = "https://hub.example.com/api/galaxy/content/published"
         gc._v3_path = "v3/"
 
-        with patch.object(GalaxyClient, "_api_get", tracking_api_get):
+        with _mock_api_get_context(tracking_api_get):
             await gc.latest_version("netbox", "netbox")
 
         url = call_urls[0]
@@ -2269,7 +2309,7 @@ class TestDynamicUrlConstruction:
         gc._api_root = "https://hub.example.com"
         gc._v3_path = "v3/"
 
-        with patch.object(GalaxyClient, "_api_get", tracking_api_get):
+        with _mock_api_get_context(tracking_api_get):
             await gc.search_collections("test")
 
         url = call_urls[0]
@@ -2288,7 +2328,7 @@ class TestDynamicUrlConstruction:
         gc._api_root = "https://galaxy.ansible.com/api"
         gc._v3_path = "v3/"
 
-        with patch.object(GalaxyClient, "_api_get", tracking_api_get):
+        with _mock_api_get_context(tracking_api_get):
             await gc.latest_version("ansible", "utils")
 
         url = call_urls[0]

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -23,6 +23,7 @@ from ansible_know.skills import (
     render_role_skill,
     render_skill,
     role_skill_name,
+    skill_dir_to_collection_fqcn,
     update_agents_md,
     write_collection_skill_package,
     write_module_skill_package,
@@ -746,6 +747,7 @@ class TestUpdateAgentsMd:
         """Create a minimal collection skill directory with SKILL.md."""
         coll_dir = skills_dir / name
         coll_dir.mkdir(parents=True)
+        fqcn = skill_dir_to_collection_fqcn(name)
         fm = (
             f"---\n"
             f"name: {name}\n"
@@ -754,8 +756,8 @@ class TestUpdateAgentsMd:
             f"  Covers {module_count} modules (v{version}).\n"
             f"compatibility: Requires ansible-core\n"
             f"metadata:\n"
-            f"  fqcn: test.collection\n"
-            f"  collection: test.collection\n"
+            f"  fqcn: {fqcn}\n"
+            f"  collection: {fqcn}\n"
             f"  plugin-type: collection\n"
             f'  version: "{version}"\n'
             f"---\n"
@@ -875,7 +877,11 @@ class TestUpdateAgentsMd:
         coll_dir = skills_dir / "some-coll"
         coll_dir.mkdir(parents=True)
         (coll_dir / "SKILL.md").write_text(
-            "---\nname: some-coll\ndescription: Covers 10 modules.\n---\n"
+            "---\nname: some-coll\ndescription: Covers 10 modules.\n"
+            "metadata:\n"
+            "  fqcn: some.coll\n"
+            "  plugin-type: collection\n"
+            "---\n"
         )
         update_agents_md(tmp_path, skills_dir)
         agents_md = (tmp_path / "AGENTS.md").read_text()
@@ -888,12 +894,45 @@ class TestUpdateAgentsMd:
         coll_dir.mkdir(parents=True)
         (coll_dir / "SKILL.md").write_text(
             '---\nname: some-coll\ndescription: A collection.\n'
-            'metadata:\n  version: "2.0.0"\n---\n'
+            'metadata:\n'
+            '  fqcn: some.coll\n'
+            '  plugin-type: collection\n'
+            '  version: "2.0.0"\n---\n'
         )
         update_agents_md(tmp_path, skills_dir)
         agents_md = (tmp_path / "AGENTS.md").read_text()
         assert "**some.coll** (v2.0.0)" in agents_md
         assert "symlink.collection" not in agents_md
+
+    def test_skips_non_collection_skills(self, tmp_path):
+        """Flat module/role skills must not appear as collections."""
+        skills_dir = tmp_path / "skills"
+        self._make_collection_skill(
+            skills_dir, "netbox-netbox", module_count=90, version="3.23.0",
+        )
+        module_dir = skills_dir / "dcim-device"
+        module_dir.mkdir(parents=True)
+        (module_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: dcim-device\n"
+            "description: Manage NetBox devices.\n"
+            "metadata:\n"
+            "  fqcn: netbox.netbox.dcim_device\n"
+            "  plugin-type: module\n"
+            "---\n"
+        )
+        role_dir = skills_dir / "some-role"
+        role_dir.mkdir(parents=True)
+        (role_dir / "SKILL.md").write_text(
+            "---\nname: some-role\ndescription: A role.\n---\n"
+        )
+        update_agents_md(tmp_path, skills_dir)
+        agents_md = (tmp_path / "AGENTS.md").read_text()
+        assert "**netbox.netbox** (90 modules, v3.23.0)" in agents_md
+        assert "dcim-device" not in agents_md
+        assert "dcim.device" not in agents_md
+        assert "some.role" not in agents_md
+        assert "some-role" not in agents_md
 
 
 class TestMultiPathSkills:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -740,14 +740,27 @@ class TestCollectionSkillWithPlugins:
 
 
 class TestUpdateAgentsMd:
-    def _make_collection_skill(self, skills_dir, name):
+    def _make_collection_skill(
+        self, skills_dir, name, *, module_count=5, version="1.0.0",
+    ):
         """Create a minimal collection skill directory with SKILL.md."""
         coll_dir = skills_dir / name
         coll_dir.mkdir(parents=True)
-        (coll_dir / "SKILL.md").write_text(
-            "---\nname: test\ndescription: test collection\n---\n"
+        fm = (
+            f"---\n"
+            f"name: {name}\n"
+            f"description: >-\n"
+            f"  Guided playbook development.\n"
+            f"  Covers {module_count} modules (v{version}).\n"
+            f"compatibility: Requires ansible-core\n"
+            f"metadata:\n"
+            f"  fqcn: test.collection\n"
+            f"  collection: test.collection\n"
+            f"  plugin-type: collection\n"
+            f'  version: "{version}"\n'
+            f"---\n"
         )
-        # Add a module-level skill for example path generation
+        (coll_dir / "SKILL.md").write_text(fm)
         mod_dir = coll_dir / "some-module"
         mod_dir.mkdir()
         (mod_dir / "SKILL.md").write_text(
@@ -756,12 +769,14 @@ class TestUpdateAgentsMd:
 
     def test_create_agents_md(self, tmp_path):
         skills_dir = tmp_path / "skills"
-        self._make_collection_skill(skills_dir, "netbox-netbox")
+        self._make_collection_skill(skills_dir, "netbox-netbox", module_count=90, version="3.23.0")
         update_agents_md(tmp_path, skills_dir)
         agents_md = (tmp_path / "AGENTS.md").read_text()
         assert "<!-- ansible-know:skills:start -->" in agents_md
         assert "<!-- ansible-know:skills:end -->" in agents_md
-        assert "netbox.netbox" in agents_md
+        assert "**netbox.netbox** (90 modules, v3.23.0)" in agents_md
+        assert "skills/netbox-netbox/SKILL.md" in agents_md
+        assert "### Available collections" in agents_md
 
     def test_append_to_existing(self, tmp_path):
         skills_dir = tmp_path / "skills"
@@ -772,7 +787,8 @@ class TestUpdateAgentsMd:
         assert agents_md.startswith("# My Project")
         assert "Existing content." in agents_md
         assert "<!-- ansible-know:skills:start -->" in agents_md
-        assert "netbox.netbox" in agents_md
+        assert "**netbox.netbox**" in agents_md
+        assert "skills/netbox-netbox/SKILL.md" in agents_md
 
     def test_replace_between_sentinels(self, tmp_path):
         skills_dir = tmp_path / "skills"
@@ -828,7 +844,7 @@ class TestUpdateAgentsMd:
         skills_dir.mkdir()
         update_agents_md(tmp_path, skills_dir)
         agents_md = (tmp_path / "AGENTS.md").read_text()
-        assert "Available collections:" in agents_md
+        assert "(none generated yet)" in agents_md
 
     def test_skips_symlinks(self, tmp_path):
         skills_dir = tmp_path / "skills"
@@ -836,9 +852,47 @@ class TestUpdateAgentsMd:
         (skills_dir / "symlink-collection").symlink_to(skills_dir / "real-collection")
         update_agents_md(tmp_path, skills_dir)
         agents_md = (tmp_path / "AGENTS.md").read_text()
-        assert "real.collection" in agents_md
-        # Should appear once in collections list, not duplicated by symlink
-        assert "Available collections: real.collection" in agents_md
+        assert "**real.collection**" in agents_md
+        assert agents_md.count("**real.collection**") == 1
+
+    def test_multiple_collections(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        self._make_collection_skill(
+            skills_dir, "ansible-controller", module_count=45, version="4.6.1",
+        )
+        self._make_collection_skill(
+            skills_dir, "netbox-netbox", module_count=90, version="3.23.0",
+        )
+        update_agents_md(tmp_path, skills_dir)
+        agents_md = (tmp_path / "AGENTS.md").read_text()
+        assert "**ansible.controller** (45 modules, v4.6.1)" in agents_md
+        assert "**netbox.netbox** (90 modules, v3.23.0)" in agents_md
+        assert "skills/ansible-controller/SKILL.md" in agents_md
+        assert "skills/netbox-netbox/SKILL.md" in agents_md
+
+    def test_frontmatter_missing_version(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        coll_dir = skills_dir / "some-coll"
+        coll_dir.mkdir(parents=True)
+        (coll_dir / "SKILL.md").write_text(
+            "---\nname: some-coll\ndescription: Covers 10 modules.\n---\n"
+        )
+        update_agents_md(tmp_path, skills_dir)
+        agents_md = (tmp_path / "AGENTS.md").read_text()
+        assert "**some.coll** (10 modules)" in agents_md
+        assert ", v)" not in agents_md
+
+    def test_frontmatter_missing_count(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        coll_dir = skills_dir / "some-coll"
+        coll_dir.mkdir(parents=True)
+        (coll_dir / "SKILL.md").write_text(
+            '---\nname: some-coll\ndescription: A collection.\n'
+            'metadata:\n  version: "2.0.0"\n---\n'
+        )
+        update_agents_md(tmp_path, skills_dir)
+        agents_md = (tmp_path / "AGENTS.md").read_text()
+        assert "**some.coll** (v2.0.0)" in agents_md
         assert "symlink.collection" not in agents_md
 
 


### PR DESCRIPTION
## Summary

- Replace generic "Available collections: X, Y" line in AGENTS.md with per-collection entries showing module count, version, and direct pointer to the collection SKILL.md
- Add `_parse_collection_frontmatter()` to extract metadata from collection SKILL.md files
- Add 3 new tests (multiple collections, missing version, missing count) alongside updated existing tests

## Motivation

AI agents have no hard priority between local SKILL.md files and MCP tools. The current AGENTS.md says "check for a SKILL.md" generically — agents often reach for `get_module_doc` instead. The new format gives a concrete two-hop discovery path (AGENTS.md → collection SKILL.md → module SKILL.md) without burning 90+ lines of context per collection.

**Before:**
```
Available collections: netbox.netbox
```

**After:**
```
### Available collections

- **netbox.netbox** (90 modules, v3.23.0) → `skills/netbox-netbox/SKILL.md`
- **cisco.iosxe** (45 modules, v5.2.0) → `skills/cisco-iosxe/SKILL.md`
```

## Test plan

- [x] All 11 `TestUpdateAgentsMd` tests pass (8 updated + 3 new)
- [x] Full suite: 1006 passed, 0 failures
- [x] ruff clean
- [ ] Generate skills for a collection in a test project and verify AGENTS.md output

Closes #222

Assisted-by: Claude Opus 4.6