### PR TITLE
fix: emit Agent Plugin tarball members at archive root (#226)

### DIFF
--- a/docs/architecture/adr/0009-agent-plugins-distribution.md
+++ b/docs/architecture/adr/0009-agent-plugins-distribution.md
@@ -53,8 +53,9 @@ Adopt Agent Plugins as the **primary** Layer-2 packaging format.
 
 5. Artifact format is **`.tar.gz`** (not ZIP) for consistency with Ansible
    collections and Pulp. Filename is `{plugin-name}-{version}.tar.gz`.
-   Archives include only allowlisted members (`plugin.json`, `mcp.json`,
-   `skills/`); symlinks are omitted.
+   Archive members are at the **archive root** (`plugin.json`, `mcp.json`,
+   `skills/…`) — not nested under `{plugin-name}/`. Only allowlisted members
+   are included; symlinks are omitted.
 
 6. `mcp.json` supports `stdio` (default `uvx ansible-know-mcp`) and
    `streamable-http` (requires `mcp_url` for AAP-hosted know-mcp).

--- a/docs/architecture/adr/0009-agent-plugins-distribution.md
+++ b/docs/architecture/adr/0009-agent-plugins-distribution.md
@@ -123,3 +123,4 @@ Adopt Agent Plugins as the **primary** Layer-2 packaging format.
 | 2026-08-11 | Leonardo Gallego (Assisted-by: Cursor (Grok 4.5)) | Initial acceptance |
 | 2026-08-11 | Leonardo Gallego (Assisted-by: Cursor (Grok 4.5)) | tar.gz artifact, streamable-http mcp.json, richer keywords; clarify registry/harness out of scope |
 | 2026-08-11 | Leonardo Gallego (Assisted-by: Cursor (Grok 4.5)) | Default plugin name suffix `-agentplugin` to distinguish from collections |
+| 2026-08-11 | Leonardo Gallego (Assisted-by: Cursor (Grok 4.5)) | Clarify tarball members at archive root (not nested under `{plugin-name}/`) |

--- a/src/ansible_know/skills.py
+++ b/src/ansible_know/skills.py
@@ -1225,7 +1225,8 @@ def _write_plugin_tarball(
     """Write ``{plugin_name}-{version}.tar.gz`` beside the plugin directory.
 
     Archives only allowlisted members (``plugin.json``, ``mcp.json``,
-    ``skills/``) and filters out symlink/hardlink members. The archive path
+    ``skills/``) at the **archive root** (no wrapping ``{plugin_name}/``
+    directory) and filters out symlink/hardlink members. The archive path
     is opened as a literal child of *output_dir* after removing any prior
     file or symlink with that name.
     """
@@ -1240,7 +1241,7 @@ def _write_plugin_tarball(
                 continue
             archive.add(
                 src,
-                arcname=f"{plugin_name}/{member_name}",
+                arcname=member_name,
                 filter=_tar_safe_filter,
             )
     return archive_path

--- a/tests/test_agent_plugin_packaging.py
+++ b/tests/test_agent_plugin_packaging.py
@@ -192,8 +192,15 @@ class TestPackageAsAgentPlugin:
         assert archive.is_file()
         with tarfile.open(archive, "r:gz") as tf:
             names = tf.getnames()
-        assert "ansible-netbox-netbox-agentplugin/plugin.json" in names
-        assert "ansible-netbox-netbox-agentplugin/skills/netbox-device/SKILL.md" in names
+        plugin_name = result["plugin_name"]
+        assert "plugin.json" in names
+        assert any(
+            name.startswith("skills/") and name.endswith("/SKILL.md")
+            for name in names
+        )
+        assert "skills/netbox-device/SKILL.md" in names
+        assert not any(name == plugin_name or name.startswith(f"{plugin_name}/")
+                       for name in names)
 
     def test_skips_plugin_json_when_disabled(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"
@@ -332,9 +339,12 @@ class TestPackageAsAgentPlugin:
         with tarfile.open(result["archive"] or "", "r:gz") as tf:
             names = set(tf.getnames())
             members = tf.getmembers()
-        assert "ansible-netbox-netbox-agentplugin/plugin.json" in names
-        assert "ansible-netbox-netbox-agentplugin/extra.txt" not in names
-        assert "ansible-netbox-netbox-agentplugin/leak" not in names
+        plugin_name = result["plugin_name"]
+        assert "plugin.json" in names
+        assert "extra.txt" not in names
+        assert "leak" not in names
+        assert not any(name == plugin_name or name.startswith(f"{plugin_name}/")
+                       for name in names)
         assert all(not m.issym() and not m.islnk() for m in members)
 
     def test_removes_stale_versioned_archives(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- `_write_plugin_tarball` now archives allowlisted members at the **archive root** (`plugin.json`, `skills/…`, optional `mcp.json`) instead of nesting under `{plugin_name}/`.
- Packaging tests open the `.tar.gz` and assert root members + no `{plugin_name}/` prefix; filename remains `{name}-{version}.tar.gz`.
- ADR-0009 clarifies archive-root layout for PAH/Pulp ingest.

Closes #226.

## Changes

- `src/ansible_know/skills.py` — `arcname=member_name` (no `{plugin_name}/` wrap)
- `tests/test_agent_plugin_packaging.py` — assert root-level tar members
- `docs/architecture/adr/0009-agent-plugins-distribution.md` — document archive-root members

## Test plan

- [x] `pytest tests/test_agent_plugin_packaging.py -v` (39 passed)
- [x] `ruff check` on touched Python files
- [x] Manual `tar` member listing shows `plugin.json`, `skills/…` (not `{plugin}/plugin.json`)

## Review findings addressed

- **Plan review** (`git-plan`): n/a (fast-path from issue acceptance criteria)
- **Implementation review** (`git-implement`): Clean — architecture + code-quality; no criticals

## Acknowledged debt

None.

## Stack position

- **Base**: `main`
- **Next**: end of chain (#227 harness install paths remains out of scope)

Assisted-by: Cursor (Grok 4.5)
