### PR TITLE
docs: steer AI agents toward manifest-first collection exploration

### DIFF
--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -656,7 +656,11 @@ async def get_collection_manifest(
     collection_namespace: Annotated[str, "Collection namespace (e.g. 'netbox.netbox')"],
     ctx: Context | None = None,
 ) -> ManifestResult | ErrorResponse:
-    """Get collection-level manifest with per-module summaries.
+    """Get a lightweight collection overview: module/role/plugin names with one-line descriptions.
+
+    Prefer this over get_collection_docs when exploring a collection — it
+    returns a compact summary suitable for deciding which modules to drill
+    into with get_module_doc.
 
     Returns cached MANIFEST.json if available, otherwise generates on-demand
     (metadata extraction only, no skill generation).
@@ -775,7 +779,12 @@ async def get_collection_docs(
     version: Annotated[str | None, "Optional version (e.g. '3.23.0'). If omitted, uses latest."] = None,
     ctx: Context | None = None,
 ) -> CollectionDocsResult | ErrorResponse:
-    """Get full module documentation for all modules in a collection from Galaxy.
+    """Get full parameter-level documentation for every module in a collection from Galaxy.
+
+    WARNING: output can be very large (100 KB+) for collections with many modules.
+    Use get_collection_manifest first for a compact overview, then get_module_doc
+    for the specific modules you need.  Reserve this tool for batch operations
+    that genuinely need all parameter details at once (e.g. skill generation).
 
     Returns all module docs in a single API call without installing the collection.
     Result shape: {"modules": {fqcn: {module_name, short_description, params, examples, is_api_module}, ...},


### PR DESCRIPTION
## Summary

- Updated `get_collection_manifest` docstring to emphasize it's the lightweight starting point for collection exploration
- Added a WARNING to `get_collection_docs` about large output (100KB+) and steered toward manifest-first, then `get_module_doc` for specific modules
- Reserved `get_collection_docs` for batch operations that genuinely need all parameter details (e.g. skill generation)

**Context:** AI agents were calling `get_collection_docs` as their first tool when asked about a collection, producing 100KB+ JSON responses that exceeded inline display limits. The MCP server instructions already had the right workflow order, but the individual tool docstrings didn't steer tool selection.

## Test plan

- [x] All 1049 unit tests pass — docstring-only change, no logic impact
- [ ] Verify AI agents prefer `get_collection_manifest` when exploring collections

Assisted-by: Claude Opus 4.6