### PR TITLE
feat: add standalone Galaxy role search and docs (#230)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ PR / branch architecture review: use portable skill `git-review` (wired via
 
 ```
 src/ansible_know/
-├── server.py              # FastMCP server: 20 tools, 6 resources, 5 prompts (entrypoint)
+├── server.py              # FastMCP server: 22 tools, 6 resources, 5 prompts (entrypoint)
 ├── parser.py              # ansible-doc wrapper — module discovery and metadata extraction
 ├── resolution.py          # local-then-Galaxy doc resolution + multi-server search
 ├── readme_parser.py       # Parse Galaxy role README HTML into structured data
@@ -35,6 +35,7 @@ src/ansible_know/
 ├── docs.py                # multi-manifest documentation client (httpx)
 ├── text_utils.py          # RTD + Red Hat markdown cleaning (Foundation)
 ├── galaxy.py              # Galaxy v3 API client — search, docs-blob, format conversion
+├── galaxy_v1.py           # Galaxy v1 API client — standalone role search and README fetch
 ├── redhat_docs.py         # Red Hat Documentation MCP client — JSON-RPC over Streamable HTTP (External Access)
 ├── tagging.py             # Tag derivation from module metadata (Foundation)
 ├── manifest_builder.py    # Build-time: generate doc manifests from objects.inv/sitemap
@@ -51,6 +52,8 @@ src/ansible_know/
 | `get_module_doc` | read-only | Get full module documentation |
 | `get_plugin_doc` | read-only | Get full plugin documentation |
 | `get_role_doc` | read-only | Get full role documentation (local or Galaxy README) |
+| `search_standalone_roles` | read-only | Search Galaxy standalone (legacy v1) roles by keyword |
+| `get_standalone_role_doc` | read-only | Structured docs for a 2-part `namespace.role` from Galaxy README HTML |
 | `search_docs` | read-only | Search conceptual doc manifests |
 | `fetch_doc` | read-only | Fetch a docs.ansible.com or docs.redhat.com page as clean Markdown |
 | `search_collections` | read-only | Search Galaxy for collections by keyword |

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Together with [Ansible Devtools MCP](https://github.com/ansible/ansible-dev-tool
  | get_module_doc             |  | environment_info         |  | galaxy.*     |
  | get_plugin_doc             |  |                          |  |              |
  | get_role_doc               |  | TEST                     |  |              |
+ | search_standalone_roles    |  |                          |  |              |
+ | get_standalone_role_doc    |  |                          |  |              |
  | get_collection_docs        |  | ansible_lint             |  |              |
  | get_collection_manifest    |  | ansible_navigator        |  |              |
  | search_docs                |  |                          |  |              |
@@ -242,6 +244,8 @@ claude mcp add ansible-know --transport http https://know.ansible.ar/mcp
 | `get_module_doc(module_name)` | Full structured docs: params, examples, API detection. Falls back to Galaxy if not installed locally |
 | `get_plugin_doc(plugin_name, plugin_type)` | Full structured plugin documentation with Galaxy fallback |
 | `get_role_doc(role_name)` | Role documentation with three-tier resolution: local ansible-doc, Galaxy README, or graceful degradation |
+| `search_standalone_roles(query, tags?)` | Search Galaxy standalone (legacy v1) roles by keyword |
+| `get_standalone_role_doc(role_name)` | Structured docs for a 2-part `namespace.role` from Galaxy README HTML |
 | `get_collection_docs(collection_namespace, version?)` | Get all module docs for a collection from Galaxy in a single call |
 | `get_collection_manifest(collection_namespace)` | Collection-level manifest with per-module and per-role summaries |
 | `search_docs(query, source?, topic?, audience?, core_only?)` | Search documentation manifests for conceptual guides (up to 20 matches) |

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -30,8 +30,9 @@ The server follows a 5-layer pipeline architecture adapted for MCP:
 │                    collection_manifest.py, docs.py,      │
 │                    resolution.py                         │
 ├─────────────────────────────────────────────────────────┤
-│  External Access   galaxy.py, collections.py,           │
-│                    readme_parser.py, redhat_docs.py      │
+│  External Access   galaxy.py, galaxy_v1.py,             │
+│                    collections.py, readme_parser.py,     │
+│                    redhat_docs.py                          │
 ├─────────────────────────────────────────────────────────┤
 │  Foundation        async_utils.py, cache.py, config.py,  │
 │                    galaxy_config.py, state.py,            │
@@ -61,6 +62,7 @@ review unless they change contracts/ADRs.
 | `src/ansible_know/resolution.py` | **Domain** |
 | `src/ansible_know/templates/*` | **Domain** (templates) |
 | `src/ansible_know/galaxy.py` | **External Access** |
+| `src/ansible_know/galaxy_v1.py` | **External Access** |
 | `src/ansible_know/collections.py` | **External Access** |
 | `src/ansible_know/readme_parser.py` | **External Access** |
 | `src/ansible_know/redhat_docs.py` | **External Access** |
@@ -97,7 +99,7 @@ decorated tool, resource, and prompt handler functions. FastMCP manages:
 
 | Element | File | Registration |
 |---------|------|--------------|
-| 20 tool handlers | `server.py` | `@mcp.tool(annotations=ToolAnnotations(...))` |
+| 22 tool handlers | `server.py` | `@mcp.tool(annotations=ToolAnnotations(...))` |
 | 6 resource handlers | `server.py` | `@mcp.resource(uri, ...)` |
 | 5 prompt handlers | `server.py` | `@mcp.prompt` |
 | Lifespan hook | `server.py` | `@lifespan` decorator on `app_lifespan()` |
@@ -149,7 +151,7 @@ business logic. Domain modules are imported lazily to avoid loading
 | `collection_manifest` | `generate_manifest()`, `load_cached_manifest()` | `collection_manifest.py` |
 | `docs` | `search_docs()`, `fetch_doc_content()` | `docs.py` |
 | `collections` | `ensure_collection()`, `list_installed()` | `collections.py` |
-| `resolution` | `resolve_module_doc()`, `resolve_role_doc()`, `search_galaxy_collections()`, `clear_missing_namespace()` | `resolution.py` |
+| `resolution` | `resolve_module_doc()`, `resolve_role_doc()`, `search_galaxy_collections()`, `search_standalone_roles()`, `resolve_standalone_role_doc()`, `clear_missing_namespace()` | `resolution.py` |
 
 ### Types Crossing This Boundary
 
@@ -205,8 +207,9 @@ the process boundary: the Galaxy REST API, the `ansible-doc` CLI, the
 | External Access Module | Consumers | File |
 |------------------------|-----------|------|
 | `galaxy.py` (`GalaxyClient`) | `resolution.py` (via `GalaxyDocClient` Protocol) | `galaxy.py` |
+| `galaxy_v1.py` (`GalaxyV1Client`) | `resolution.py` | `galaxy_v1.py` |
 | `collections.py` | `server.py`, `resolution.py` | `collections.py` |
-| `readme_parser.py` | `galaxy.py` | `readme_parser.py` |
+| `readme_parser.py` | `galaxy.py`, `galaxy_v1.py` | `readme_parser.py` |
 | `redhat_docs.py` (`RedHatDocsClient`) | `server.py` (via `SharedState`) | `redhat_docs.py` |
 
 `GalaxyClient` is the primary class in the codebase. It acts as an async HTTP

--- a/docs/superpowers/plans/2026-08-18-standalone-galaxy-roles.md
+++ b/docs/superpowers/plans/2026-08-18-standalone-galaxy-roles.md
@@ -1,0 +1,1239 @@
+# Standalone Galaxy Role Search and Documentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `search_standalone_roles` and `get_standalone_role_doc` MCP tools that query Galaxy **v1** standalone roles (`namespace.role`) without changing v3 collection/module/plugin/collection-role paths.
+
+**Architecture:** Dedicated `GalaxyV1Client` in `galaxy_v1.py` (External Access) shares lifespan httpx + `GalaxyServerConfig` auth only. Domain `resolution.py` adds `search_standalone_roles` and `resolve_standalone_role_doc` plus a duplicated `_try_v1_servers` helper. Orchestration in `server.py` validates, injects `_galaxy_v1_factory`, and clears the v1 cache from the existing `clear_cache` tool. Do not import `galaxy_v1` from `galaxy.py`. Do not extend `GalaxyDocClient`.
+
+**Tech Stack:** Python 3.10+, httpx, FastMCP, pytest, asyncio. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-standalone-galaxy-roles-design.md`  
+**Issue:** [#230](https://github.com/leogallego/ansible-know-mcp/issues/230)
+
+## Global Constraints
+
+- Client: separate `GalaxyV1Client` (`src/ansible_know/galaxy_v1.py`), not methods on `GalaxyClient`.
+- Transport only: shared lifespan `httpx.AsyncClient` + `GalaxyServerConfig` auth via `from_config`. Not shared: discovery, URL builders, `_discovery_failed`, v3 caches, `GalaxyDocClient`.
+- Search query param: `keywords` (never `search` / `keyword`). `order_by=-download_count`, `page_size=10`.
+- Exact lookup: `namespace` + `name` only. Never `owner__username` + `name` together.
+- README: `GET /api/v1/roles/{id}/content/` `readme_html` + existing `parse_role_readme()`. No GitHub.
+- Identifier: `{username}.{name}` (Galaxy legacy namespace, not `github_user`).
+- Validator: new 2-part hyphen/mixed-case `validate_standalone_role_name`. Do not reuse `validate_fqcn` / `validate_namespace`.
+- `content_type`: `"standalone_role"`. No local ansible-doc. No skills, install, or GitHub fallback.
+- `galaxy_v1.py` must not import `galaxy.py`. Import `GalaxyError` from `errors.py` only. Duplicate timeout/size constants or read them from `config.py`.
+- List JSON is DRF `{count, results}` — not v3 `{data, meta}`.
+- v1 `tags` filter is a single JSON-contains value: send only the first comma-separated segment.
+- Search all-fail: raise `GalaxyError` (match `search_galaxy_collections`). Empty hits are success (`count: 0`).
+- MCP `clear_cache` (scope `galaxy` or omitted) calls `galaxy_v1.clear_cache()`. `galaxy.clear_cache()` stays v3-only.
+- Multi-server get-doc: new `_try_v1_servers`. Do not reuse `_try_galaxy_servers` / do not extend `GalaxyDocClient`.
+- Both resolution paths must use `_select_http_client` (skip shared httpx when `validate_certs` is false).
+- Tool count 20 → 22. Follow-up issues (GitHub README, skill gen, role install) are out of scope.
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/ansible_know/galaxy_v1.py` | `GalaxyV1Client` + module-level v1 cache |
+| Create | `tests/test_galaxy_v1.py` | HTTP-mocked v1 client + isolation vs `GalaxyClient` |
+| Modify | `src/ansible_know/validation.py` | `validate_standalone_role_name` |
+| Modify | `src/ansible_know/types.py` | TypedDicts + `GalaxyV1ClientFactory` |
+| Modify | `src/ansible_know/resolution.py` | `_try_v1_servers`, search, get-doc |
+| Modify | `src/ansible_know/server.py` | Two tools, factory, instructions, `clear_cache` |
+| Modify | `tests/test_validation.py` | New validator cases |
+| Modify | `tests/test_resolution.py` | Standalone search/get-doc |
+| Modify | `tests/test_server.py` | Tool wiring + cache-clear coupling |
+| Modify | `tests/integration/test_galaxy_api.py` | Opt-in live v1 checks |
+| Modify | `CLAUDE.md`, `README.md`, `docs/architecture/service-contracts.md` | Tool tables, layer map |
+| Unchanged | `src/ansible_know/galaxy.py` | v3 only — do not import v1 |
+
+---
+
+### Task 1: Foundation — validator + TypedDicts
+
+**Files:**
+- Modify: `src/ansible_know/validation.py`
+- Modify: `src/ansible_know/types.py`
+- Modify: `tests/test_validation.py`
+
+**Interfaces:**
+- Consumes: `ValidationError`, `MAX_NAMESPACE_LENGTH` (128)
+- Produces: `validate_standalone_role_name(name: str) -> None`; `StandaloneRoleSearchEntry`, `StandaloneRoleSearchResult`, `GetStandaloneRoleDocResult`, `GalaxyV1ClientFactory`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_validation.py` (import `validate_standalone_role_name`):
+
+```python
+class TestValidateStandaloneRoleName:
+    def test_accepts_hyphenated_namespace(self):
+        validate_standalone_role_name("ansible-lockdown.rhel9_cis")
+
+    def test_accepts_mixed_case(self):
+        validate_standalone_role_name("MindPointGroup.RHEL9_CIS")
+
+    def test_accepts_underscore_role(self):
+        validate_standalone_role_name("geerlingguy.elasticsearch_curator")
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValidationError):
+            validate_standalone_role_name("")
+
+    def test_rejects_one_part(self):
+        with pytest.raises(ValidationError):
+            validate_standalone_role_name("rhel9_cis")
+
+    def test_rejects_three_part_and_points_at_get_role_doc(self):
+        with pytest.raises(ValidationError, match="get_role_doc"):
+            validate_standalone_role_name("fedora.linux_system_roles.timesync")
+
+    def test_rejects_path_slash(self):
+        with pytest.raises(ValidationError):
+            validate_standalone_role_name("foo/bar.role")
+
+    def test_rejects_leading_hyphen_segment(self):
+        with pytest.raises(ValidationError):
+            validate_standalone_role_name("-bad.role")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_validation.py::TestValidateStandaloneRoleName -v`
+
+Expected: FAIL — `ImportError` / `cannot import name 'validate_standalone_role_name'`
+
+- [ ] **Step 3: Implement validator and types**
+
+In `validation.py`, add `"validate_standalone_role_name"` to `__all__` (alphabetically after `validate_skill_name`). After `validate_namespace`, add:
+
+```python
+_STANDALONE_ROLE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+
+
+def validate_standalone_role_name(name: str) -> None:
+    """Validate a Galaxy standalone role identifier ``namespace.role``."""
+    if not name or "/" in name or "\\" in name:
+        raise ValidationError(
+            "Invalid standalone role name: expected format 'namespace.role' "
+            "with alphanumeric, hyphen, or underscore segments."
+        )
+    parts = name.split(".")
+    if len(parts) == 3:
+        raise ValidationError(
+            "Invalid standalone role name: expected 'namespace.role'. "
+            "Collection roles use get_role_doc() with a 3-part FQCN."
+        )
+    if len(parts) != 2:
+        raise ValidationError(
+            "Invalid standalone role name: expected format 'namespace.role' "
+            "with alphanumeric, hyphen, or underscore segments."
+        )
+    for part in parts:
+        if (
+            not part
+            or len(part) > MAX_NAMESPACE_LENGTH
+            or not _STANDALONE_ROLE_SEGMENT_RE.match(part)
+        ):
+            raise ValidationError(
+                "Invalid standalone role name: expected format 'namespace.role' "
+                "with alphanumeric, hyphen, or underscore segments."
+            )
+```
+
+In `types.py`, after `CollectionSearchResult` add:
+
+```python
+class StandaloneRoleSearchEntry(TypedDict, total=False):
+    """Single standalone role from search_standalone_roles."""
+
+    role_name: str
+    description: str
+    tags: list[str]
+    latest_version: str
+    download_count: int
+    github_user: str
+    github_repo: str
+    source: str
+
+
+class StandaloneRoleSearchResult(TypedDict):
+    """Result of search_standalone_roles tool."""
+
+    query: str
+    count: int
+    roles: list[StandaloneRoleSearchEntry]
+
+
+class _GetStandaloneRoleDocResultBase(TypedDict):
+    role_name: str
+    content_type: str
+    doc_source: str
+
+
+class GetStandaloneRoleDocResult(_GetStandaloneRoleDocResultBase, total=False):
+    """Result of get_standalone_role_doc. No ``error`` field — failures are ErrorResponse."""
+
+    short_description: str
+    entry_points: dict[str, EntryPointInfo]
+    dependencies: list[str]
+    examples: str
+    tags: list[str]
+    latest_version: str
+    github_user: str
+    github_repo: str
+    github_branch: str
+    download_count: int
+    doc_version: str
+    doc_warning: str
+    doc_source_server: str
+```
+
+After `GalaxyClientFactory`, add (do **not** change `GalaxyDocClient`):
+
+```python
+class GalaxyV1DocClient(Protocol):
+    """v1 standalone-role client. Not a GalaxyDocClient."""
+
+    async def search_roles(
+        self, query: str, tags: str | None = None,
+    ) -> dict[str, Any]: ...
+
+    async def fetch_standalone_role_doc(
+        self, role_name: str,
+    ) -> tuple[dict[str, Any], DocProvenance]: ...
+
+    async def __aenter__(self) -> GalaxyV1DocClient: ...
+
+    async def __aexit__(self, *exc: object) -> None: ...
+
+
+class GalaxyV1ClientFactory(Protocol):
+    """Factory that creates GalaxyV1DocClient instances from config."""
+
+    def __call__(
+        self,
+        config: GalaxyServerConfig,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> GalaxyV1DocClient: ...
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/test_validation.py::TestValidateStandaloneRoleName tests/test_validation.py::TestValidateFqcn tests/test_validation.py::TestValidateNamespace -v`
+
+Expected: PASS. Existing FQCN/namespace tests still reject hyphens.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ansible_know/validation.py src/ansible_know/types.py tests/test_validation.py
+git commit -m "$(cat <<'EOF'
+feat: add standalone role name validator and result types
+
+Two-part Galaxy v1 identifiers allow hyphens; keep collection FQCN
+validation unchanged.
+
+Assisted-by: Cursor (Grok 4.6)
+EOF
+)"
+```
+
+---
+
+### Task 2: `GalaxyV1Client` — discovery, search, lookup, content, docs
+
+**Files:**
+- Create: `src/ansible_know/galaxy_v1.py`
+- Create: `tests/test_galaxy_v1.py`
+
+**Interfaces:**
+- Consumes: Task 1 types; `GalaxyServerConfig`; `parse_role_readme`; `BoundedCache`; `GalaxyError`
+- Produces: `GalaxyV1Client.from_config`, `search_roles`, `fetch_role_by_name`, `fetch_role_content`, `fetch_standalone_role_doc`, `clear_cache`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_galaxy_v1.py`:
+
+```python
+"""Tests for ansible_know.galaxy_v1."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from ansible_know.errors import GalaxyError
+from tests.conftest import SAMPLE_ROLE_README_HTML
+
+SAMPLE_ROLE = {
+    "id": 42,
+    "username": "ansible-lockdown",
+    "name": "rhel9_cis",
+    "description": "CIS Benchmark for RHEL 9",
+    "github_user": "ansible-lockdown",
+    "github_repo": "RHEL9-CIS",
+    "github_branch": "devel",
+    "download_count": 9000,
+    "summary_fields": {
+        "tags": ["system", "security"],
+        "versions": [{"name": "1.2.3"}],
+        "dependencies": [{"namespace": "geerlingguy", "name": "repo"}],
+    },
+}
+
+SAMPLE_LIST = {"count": 1, "next": None, "previous": None, "results": [SAMPLE_ROLE]}
+
+
+def _mock_http(json_body, status=200):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = json_body
+    mock_resp.content = b"{}"
+    mock_resp.headers = {}
+    if status >= 400:
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "err", request=MagicMock(), response=MagicMock(status_code=status),
+        )
+    else:
+        mock_resp.raise_for_status.return_value = None
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+def _skip_discovery(client):
+    client._api_root = "https://galaxy.ansible.com/api"
+    client._v1_path = "v1/"
+    return client
+
+
+class TestSearchRoles:
+    @pytest.mark.asyncio
+    async def test_uses_keywords_order_by_page_size(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http(SAMPLE_LIST)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            result = await gc.search_roles("rhel9_cis")
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["keywords"] == "rhel9_cis"
+        assert params["order_by"] == "-download_count"
+        assert params["page_size"] == "10"
+        assert "search" not in params
+        assert "keyword" not in params
+        url = mock_client.get.call_args.args[0]
+        assert url.endswith("/api/v1/roles/")
+        assert result["roles"][0]["role_name"] == "ansible-lockdown.rhel9_cis"
+
+    @pytest.mark.asyncio
+    async def test_tags_sends_first_segment_only(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http(SAMPLE_LIST)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            await gc.search_roles("cis", tags="system,security")
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["tags"] == "system"
+
+    @pytest.mark.asyncio
+    async def test_does_not_call_content_during_search(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http(SAMPLE_LIST)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            await gc.search_roles("rhel9_cis")
+        urls = [c.args[0] for c in mock_client.get.call_args_list]
+        assert all("/content/" not in u for u in urls)
+
+
+class TestFetchRoleByName:
+    @pytest.mark.asyncio
+    async def test_lookup_uses_namespace_and_name_not_owner(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http(SAMPLE_LIST)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            role = await gc.fetch_role_by_name("ansible-lockdown", "rhel9_cis")
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["namespace"] == "ansible-lockdown"
+        assert params["name"] == "rhel9_cis"
+        assert "owner__username" not in params
+        assert role["id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_empty_results_raises(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http({"count": 0, "results": []})
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            with pytest.raises(GalaxyError, match="not found"):
+                await gc.fetch_role_by_name("missing", "role")
+
+
+class TestFetchStandaloneRoleDoc:
+    @pytest.mark.asyncio
+    async def test_parses_readme_html(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        list_resp = MagicMock()
+        list_resp.json.return_value = SAMPLE_LIST
+        list_resp.content = b"{}"
+        list_resp.headers = {}
+        list_resp.raise_for_status.return_value = None
+        content_resp = MagicMock()
+        content_resp.json.return_value = {
+            "readme": "README.md",
+            "readme_html": SAMPLE_ROLE_README_HTML,
+        }
+        content_resp.content = b"{}"
+        content_resp.headers = {}
+        content_resp.raise_for_status.return_value = None
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [list_resp, content_resp]
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            meta, prov = await gc.fetch_standalone_role_doc(
+                "ansible-lockdown.rhel9_cis",
+            )
+        content_url = mock_client.get.call_args_list[1].args[0]
+        assert content_url.endswith("/api/v1/roles/42/content/")
+        assert meta["content_type"] == "standalone_role"
+        assert meta["role_name"] == "ansible-lockdown.rhel9_cis"
+        assert prov["doc_source"] == "galaxy_v1_readme"
+        assert "main" in meta["entry_points"]
+        assert meta["github_branch"] == "devel"
+        assert "geerlingguy.repo" in meta["dependencies"] or meta["dependencies"]
+
+    @pytest.mark.asyncio
+    async def test_empty_html_is_metadata_success(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        list_resp = MagicMock()
+        list_resp.json.return_value = SAMPLE_LIST
+        list_resp.content = b"{}"
+        list_resp.headers = {}
+        list_resp.raise_for_status.return_value = None
+        content_resp = MagicMock()
+        content_resp.json.return_value = {"readme": "README.md", "readme_html": ""}
+        content_resp.content = b"{}"
+        content_resp.headers = {}
+        content_resp.raise_for_status.return_value = None
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [list_resp, content_resp]
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            meta, prov = await gc.fetch_standalone_role_doc(
+                "ansible-lockdown.rhel9_cis",
+            )
+        assert prov["doc_source"] == "galaxy_v1_metadata"
+        assert meta["short_description"] == "CIS Benchmark for RHEL 9"
+        assert "doc_warning" in prov
+
+    @pytest.mark.asyncio
+    async def test_hyphenated_name_roundtrip(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        list_resp = MagicMock()
+        list_resp.json.return_value = SAMPLE_LIST
+        list_resp.content = b"{}"
+        list_resp.headers = {}
+        list_resp.raise_for_status.return_value = None
+        content_resp = MagicMock()
+        content_resp.json.return_value = {"readme": "README.md", "readme_html": "<p>x</p>"}
+        content_resp.content = b"{}"
+        content_resp.headers = {}
+        content_resp.raise_for_status.return_value = None
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [list_resp, content_resp]
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            meta, _ = await gc.fetch_standalone_role_doc("ansible-lockdown.rhel9_cis")
+        params = mock_client.get.call_args_list[0].kwargs["params"]
+        assert params["namespace"] == "ansible-lockdown"
+        assert params["name"] == "rhel9_cis"
+        assert meta["role_name"] == "ansible-lockdown.rhel9_cis"
+
+
+class TestV1Discovery:
+    @pytest.mark.asyncio
+    async def test_requires_v1_not_v3(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http({"available_versions": {"v3": "v3/"}})
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = GalaxyV1Client(base_url="https://hub.example")
+            with pytest.raises(GalaxyError, match="v1"):
+                await gc.search_roles("cis")
+
+    @pytest.mark.asyncio
+    async def test_v1_http_404_raises_galaxy_error(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http({}, status=404)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            with pytest.raises(GalaxyError):
+                await gc.search_roles("cis")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_galaxy_v1.py -v`
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'ansible_know.galaxy_v1'`
+
+- [ ] **Step 3: Implement `src/ansible_know/galaxy_v1.py`**
+
+Create the module. Copy transport/auth from `GalaxyClient` in `galaxy.py` (`from_config`, `__aenter__`/`close`/`_get_client`, `_ensure_access_token`, `_resolve_auth_headers`, `_api_get`, `_safe_api_get`) with these substitutions:
+
+- No `enrichment_semaphore`.
+- Discovery requires **`v1` only** (`available_versions["v1"]`). Missing v1 → `GalaxyError` (“does not support Galaxy API v1”). Set `self._discovery_failed` on **this** instance only. Do not touch `GalaxyClient`.
+- Unsafe v1 path: same charset as v3 (`^[a-zA-Z0-9/_-]+/?$`, no `..`).
+- URL builder: `{api_root}/{v1_path}roles/` and `{api_root}/{v1_path}roles/{id}/content/`.
+- Duplicate `TIMEOUT_*`, `MAX_GALAXY_RESPONSE_SIZE`, `MAX_DISCOVERY_RESPONSE_SIZE`, and a `_normalize_cache_base_url` helper. Do **not** `import ansible_know.galaxy`.
+- Module-level `_v1_cache: BoundedCache` max_size 50, ttl 3600, memory-only.
+- `clear_cache()` clears `_v1_cache` only.
+
+Unique methods (do not copy from v3):
+
+```python
+def _first_tag(tags: str | None) -> str | None:
+    if not tags:
+        return None
+    return tags.split(",", 1)[0].strip() or None
+
+
+def _normalize_dependencies(raw: object) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    out: list[str] = []
+    for item in raw:
+        if isinstance(item, str) and item:
+            out.append(item)
+        elif isinstance(item, dict):
+            ns = item.get("namespace") or item.get("username") or ""
+            name = item.get("name") or ""
+            if ns and name:
+                out.append(f"{ns}.{name}")
+            elif name:
+                out.append(str(name))
+    return out
+
+
+def _map_search_hit(item: dict) -> dict:
+    versions = (item.get("summary_fields") or {}).get("versions") or []
+    latest = ""
+    if versions and isinstance(versions[0], dict):
+        latest = versions[0].get("name") or ""
+    tags_raw = (item.get("summary_fields") or {}).get("tags") or []
+    tags: list[str] = []
+    for t in tags_raw:
+        if isinstance(t, str):
+            tags.append(t)
+        elif isinstance(t, dict) and t.get("name"):
+            tags.append(str(t["name"]))
+    username = item.get("username") or ""
+    name = item.get("name") or ""
+    return {
+        "role_name": f"{username}.{name}",
+        "description": item.get("description") or "",
+        "tags": tags,
+        "latest_version": latest,
+        "download_count": item.get("download_count") or 0,
+        "github_user": item.get("github_user") or "",
+        "github_repo": item.get("github_repo") or "",
+    }
+
+
+async def search_roles(self, query: str, tags: str | None = None) -> dict:
+    await self._discover_api_root()
+    cache_key = (*self._cache_identity(), "search", query, tags or "")
+    cached = _v1_cache.get(cache_key)
+    if cached is not None:
+        return cached
+    params = {
+        "keywords": query,
+        "order_by": "-download_count",
+        "page_size": "10",
+    }
+    tag = _first_tag(tags)
+    if tag:
+        params["tags"] = tag
+    data = await self._safe_api_get(self._build_v1_url("roles"), params=params)
+    hits = data.get("results") or []
+    mapped = [_map_search_hit(item) for item in hits if isinstance(item, dict)]
+    result = {"query": query, "count": len(mapped), "roles": mapped}
+    _v1_cache.put(cache_key, result)
+    return result
+
+
+async def fetch_role_by_name(self, namespace: str, name: str) -> dict:
+    await self._discover_api_root()
+    params = {"namespace": namespace, "name": name, "page_size": "1"}
+    data = await self._safe_api_get(self._build_v1_url("roles"), params=params)
+    results = data.get("results") or []
+    if not results:
+        raise GalaxyError(
+            f"Standalone role '{namespace}.{name}' not found"
+        )
+    return results[0]
+
+
+async def fetch_role_content(self, role_id: int) -> dict:
+    await self._discover_api_root()
+    cache_key = (*self._cache_identity(), "content", str(role_id))
+    cached = _v1_cache.get(cache_key)
+    if cached is not None:
+        return cached
+    data = await self._safe_api_get(
+        self._build_v1_url("roles", str(role_id), "content"),
+    )
+    _v1_cache.put(cache_key, data)
+    return data
+
+
+async def fetch_standalone_role_doc(self, role_name: str):
+    from ansible_know.readme_parser import parse_role_readme
+
+    namespace, _, name = role_name.partition(".")
+    role = await self.fetch_role_by_name(namespace, name)
+    content = await self.fetch_role_content(int(role["id"]))
+    html = content.get("readme_html") or ""
+    parsed = parse_role_readme(html)
+    summary = role.get("summary_fields") or {}
+    deps = parsed.get("dependencies") or _normalize_dependencies(
+        summary.get("dependencies"),
+    )
+    versions = summary.get("versions") or []
+    latest = ""
+    if versions and isinstance(versions[0], dict):
+        latest = versions[0].get("name") or ""
+    tags_raw = summary.get("tags") or []
+    tags = [
+        t if isinstance(t, str) else str(t.get("name", ""))
+        for t in tags_raw
+    ]
+    tags = [t for t in tags if t]
+    short = parsed.get("description") or role.get("description") or ""
+    options = []
+    for var in parsed.get("variables") or []:
+        options.append({
+            "name": var["name"],
+            "type": var.get("type") or "str",
+            "required": bool(var.get("required")),
+            "default": var.get("default"),
+            "choices": var.get("choices"),
+            "description": var.get("description", ""),
+            "aliases": var.get("aliases", []),
+        })
+    metadata = {
+        "role_name": role_name,
+        "content_type": "standalone_role",
+        "short_description": short,
+        "entry_points": {
+            "main": {"description": short, "options": options},
+        },
+        "dependencies": deps,
+        "examples": parsed.get("examples") or "",
+        "tags": tags,
+        "latest_version": latest,
+        "github_user": role.get("github_user") or "",
+        "github_repo": role.get("github_repo") or "",
+        "github_branch": role.get("github_branch") or "",
+        "download_count": role.get("download_count") or 0,
+    }
+    has_html = bool(html.strip())
+    provenance = {
+        "doc_source": "galaxy_v1_readme" if has_html else "galaxy_v1_metadata",
+        "doc_version": latest,
+    }
+    if has_html:
+        provenance["doc_warning"] = (
+            "Documentation parsed from Galaxy README (best-effort)."
+        )
+    else:
+        provenance["doc_warning"] = (
+            "Galaxy stored no README HTML for this standalone role; "
+            "returning catalog metadata only."
+        )
+    if self.server_name:
+        provenance["doc_source_server"] = self.server_name
+    return metadata, provenance
+```
+
+Export `GalaxyV1Client` and `clear_cache` in `__all__`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/test_galaxy_v1.py -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ansible_know/galaxy_v1.py tests/test_galaxy_v1.py
+git commit -m "$(cat <<'EOF'
+feat: add Galaxy v1 client for standalone roles
+
+Search uses keywords plus download-count order; lookup uses namespace
+and name so Galaxy download counters are not incremented.
+
+Assisted-by: Cursor (Grok 4.6)
+EOF
+)"
+```
+
+---
+
+### Task 3: Isolation — v1 must not poison v3 discovery
+
+**Files:**
+- Modify: `tests/test_galaxy_v1.py`
+
+**Interfaces:**
+- Consumes: `GalaxyV1Client`, `GalaxyClient` from Task 2 / existing `galaxy.py`
+- Produces: required isolation test
+
+- [ ] **Step 1: Write the failing (or new) isolation test**
+
+Append to `tests/test_galaxy_v1.py`:
+
+```python
+class TestV1DoesNotPoisonV3:
+    @pytest.mark.asyncio
+    async def test_missing_v1_does_not_set_v3_discovery_failed(self):
+        from ansible_know.galaxy import GalaxyClient
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+
+        config = GalaxyServerConfig(
+            name="hub", url="https://hub.example/api",
+        )
+        v3_only = {"available_versions": {"v3": "v3/"}}
+        search_payload = {
+            "data": [],
+            "meta": {"count": 0},
+        }
+
+        def _route(url, **kwargs):
+            resp = MagicMock()
+            resp.content = b"{}"
+            resp.headers = {}
+            resp.raise_for_status.return_value = None
+            if "collection-versions" in str(url) or "search" in str(url):
+                resp.json.return_value = search_payload
+            else:
+                resp.json.return_value = v3_only
+            return resp
+
+        shared = AsyncMock()
+        shared.get.side_effect = _route
+        v3 = GalaxyClient.from_config(config, http_client=shared)
+        v1 = GalaxyV1Client.from_config(config, http_client=shared)
+        with pytest.raises(GalaxyError, match="v1"):
+            await v1.search_roles("cis")
+        assert v3._discovery_failed is False
+        assert v3._v3_path is None
+        result = await v3.search_collections("net")
+        assert result["count"] == 0
+        assert v3._discovery_failed is False
+        assert v3._v3_path == "v3/"
+```
+
+Adjust `_route` if `search_collections` URL matching differs — inspect `GalaxyClient._build_v3_url("plugin", "ansible", "search", "collection-versions")`. Discovery GET hits `config.url` then `{url}/api`. Both should return `v3_only` so v1 fails and v3 succeeds.
+
+- [ ] **Step 2: Run the isolation test**
+
+Run: `pytest tests/test_galaxy_v1.py::TestV1DoesNotPoisonV3 -v`
+
+Expected: PASS after any mock URL tweaks. Must construct **both** clients. Do not “fix” the test by omitting `GalaxyV1Client`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_galaxy_v1.py
+git commit -m "$(cat <<'EOF'
+test: assert v1 discovery failure does not poison GalaxyClient
+
+Assisted-by: Cursor (Grok 4.6)
+EOF
+)"
+```
+
+---
+
+### Task 4: Resolution — multi-server search and get-doc
+
+**Files:**
+- Modify: `src/ansible_know/resolution.py`
+- Modify: `tests/test_resolution.py`
+
+**Interfaces:**
+- Consumes: `GalaxyV1ClientFactory`, `_select_http_client`
+- Produces: `_try_v1_servers`, `search_standalone_roles` (raises `GalaxyError` on all-fail), `resolve_standalone_role_doc` → `GetStandaloneRoleDocResult | ErrorResponse`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_resolution.py`. Reuse `GalaxyServerConfig`. Use a tiny fake factory — do **not** patch `GalaxyClient`:
+
+```python
+class _FakeV1:
+    def __init__(self, search=None, doc=None, error=None):
+        self._search = search
+        self._doc = doc
+        self._error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return None
+
+    async def search_roles(self, query, tags=None):
+        if self._error:
+            raise self._error
+        return self._search
+
+    async def fetch_standalone_role_doc(self, role_name):
+        if self._error:
+            raise self._error
+        return self._doc
+
+
+def _v1_factory_map(mapping):
+    def _factory(config, http_client=None):
+        return mapping[config.name]
+    return _factory
+```
+
+Tests:
+
+```python
+class TestSearchStandaloneRoles:
+    @pytest.mark.asyncio
+    async def test_merges_and_ranks(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import search_standalone_roles
+        s1 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        s2 = GalaxyServerConfig(name="hub", url="https://hub.example")
+        f1 = _FakeV1(search={"roles": [
+            {"role_name": "a.one", "download_count": 10},
+        ]})
+        f2 = _FakeV1(search={"roles": [
+            {"role_name": "b.two", "download_count": 50},
+        ]})
+        result = await search_standalone_roles(
+            "cis", galaxy_servers=[s1, s2],
+            v1_client_factory=_v1_factory_map({"galaxy": f1, "hub": f2}),
+        )
+        assert result["count"] == 2
+        assert result["roles"][0]["role_name"] == "b.two"
+        assert result["roles"][0]["source"] == "hub"
+
+    @pytest.mark.asyncio
+    async def test_dedupes_by_role_name(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import search_standalone_roles
+        s1 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        s2 = GalaxyServerConfig(name="hub", url="https://hub.example")
+        hit = {"role_name": "a.one", "download_count": 1}
+        result = await search_standalone_roles(
+            "cis", galaxy_servers=[s1, s2],
+            v1_client_factory=_v1_factory_map({
+                "galaxy": _FakeV1(search={"roles": [hit]}),
+                "hub": _FakeV1(search={"roles": [hit]}),
+            }),
+        )
+        assert result["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_v1_less_server(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import search_standalone_roles
+        s1 = GalaxyServerConfig(name="hub", url="https://hub.example")
+        s2 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        result = await search_standalone_roles(
+            "cis", galaxy_servers=[s1, s2],
+            v1_client_factory=_v1_factory_map({
+                "hub": _FakeV1(error=GalaxyError("does not support Galaxy API v1")),
+                "galaxy": _FakeV1(search={"roles": [
+                    {"role_name": "a.one", "download_count": 1},
+                ]}),
+            }),
+        )
+        assert result["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_hits_succeed(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import search_standalone_roles
+        s1 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        result = await search_standalone_roles(
+            "zzzz", galaxy_servers=[s1],
+            v1_client_factory=_v1_factory_map({
+                "galaxy": _FakeV1(search={"roles": []}),
+            }),
+        )
+        assert result == {"query": "zzzz", "count": 0, "roles": []}
+
+    @pytest.mark.asyncio
+    async def test_all_fail_raises(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import search_standalone_roles
+        s1 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        with pytest.raises(GalaxyError, match="All Galaxy servers failed"):
+            await search_standalone_roles(
+                "cis", galaxy_servers=[s1],
+                v1_client_factory=_v1_factory_map({
+                    "galaxy": _FakeV1(error=GalaxyError("timeout")),
+                }),
+            )
+
+
+class TestResolveStandaloneRoleDoc:
+    @pytest.mark.asyncio
+    async def test_first_success_wins(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import resolve_standalone_role_doc
+        s1 = GalaxyServerConfig(name="hub", url="https://hub.example")
+        s2 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        doc = ({
+            "role_name": "ansible-lockdown.rhel9_cis",
+            "content_type": "standalone_role",
+            "short_description": "CIS",
+            "entry_points": {"main": {"description": "CIS", "options": []}},
+            "dependencies": [],
+            "examples": "",
+        }, {"doc_source": "galaxy_v1_readme", "doc_version": "1.0"})
+        result = await resolve_standalone_role_doc(
+            "ansible-lockdown.rhel9_cis",
+            galaxy_servers=[s1, s2],
+            v1_client_factory=_v1_factory_map({
+                "hub": _FakeV1(error=GalaxyError("does not support Galaxy API v1")),
+                "galaxy": _FakeV1(doc=doc),
+            }),
+        )
+        assert result["doc_source"] == "galaxy_v1_readme"
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_not_found_is_error_response(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import resolve_standalone_role_doc
+        s1 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        result = await resolve_standalone_role_doc(
+            "missing.role",
+            galaxy_servers=[s1],
+            v1_client_factory=_v1_factory_map({
+                "galaxy": _FakeV1(error=GalaxyError(
+                    "Standalone role 'missing.role' not found"
+                )),
+            }),
+        )
+        assert result == {"error": "Standalone role 'missing.role' not found"}
+        assert "doc_source" not in result
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_resolution.py::TestSearchStandaloneRoles tests/test_resolution.py::TestResolveStandaloneRoleDoc -v`
+
+Expected: FAIL — cannot import `search_standalone_roles`
+
+- [ ] **Step 3: Implement resolution**
+
+Update `resolution.py`:
+
+- Add `search_standalone_roles` and `resolve_standalone_role_doc` to `__all__`.
+- TYPE_CHECKING imports: `GalaxyV1ClientFactory`, `GetStandaloneRoleDocResult`.
+- Duplicate `_try_galaxy_servers` as `_try_v1_servers` with `client_factory: GalaxyV1ClientFactory`. Same body, including `_select_http_client`. Do not change `_try_galaxy_servers`.
+- `search_standalone_roles`: copy `search_galaxy_collections` structure (`asyncio.gather`, skip exceptions, merge). Dedupe on `role_name`. Sort by `download_count`. If `not all_roles and errors: raise GalaxyError("All Galaxy servers failed: ...")`. Return `{"query", "count", "roles"}`. Stamp `source` from server name. Factory kwarg name: `v1_client_factory`. If factory is `None`, raise `GalaxyError("No client factory configured for Galaxy search")`.
+- `resolve_standalone_role_doc`: if factory is `None`, return `{"error": "No Galaxy client configured for standalone roles"}`. Else `_try_v1_servers` calling `fetch_standalone_role_doc`. Merge provenance onto the metadata dict (`doc_source`, `doc_version`, optional `doc_warning` / `doc_source_server`). On `GalaxyError`, return `{"error": sanitize_error(str(exc))}` — never `doc_source: unavailable`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/test_resolution.py -v`
+
+Expected: PASS (existing collection/module/role tests plus new class)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ansible_know/resolution.py tests/test_resolution.py
+git commit -m "$(cat <<'EOF'
+feat: resolve standalone Galaxy roles across configured servers
+
+Search merges like collections and raises when every v1 server fails;
+get-doc uses a dedicated first-success loop so GalaxyDocClient stays v3.
+
+Assisted-by: Cursor (Grok 4.6)
+EOF
+)"
+```
+
+---
+
+### Task 5: MCP tools, factory, and cache-clear coupling
+
+**Files:**
+- Modify: `src/ansible_know/server.py`
+- Modify: `tests/test_server.py`
+
+**Interfaces:**
+- Consumes: `validate_standalone_role_name`, `search_standalone_roles`, `resolve_standalone_role_doc`, `GalaxyV1Client.from_config`
+- Produces: tools `search_standalone_roles`, `get_standalone_role_doc`; `_galaxy_v1_factory`; `clear_cache` also calls `galaxy_v1.clear_cache`
+
+- [ ] **Step 1: Write the failing tool tests**
+
+In `tests/test_server.py`, add (mirror `TestSearchCollectionsTool`):
+
+```python
+class TestSearchStandaloneRolesTool:
+    @pytest.mark.asyncio
+    async def test_returns_results(self):
+        mock_result = {
+            "query": "rhel9_cis",
+            "count": 1,
+            "roles": [{"role_name": "ansible-lockdown.rhel9_cis", "download_count": 9}],
+        }
+        with patch(
+            "ansible_know.resolution.search_standalone_roles",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            from ansible_know.server import search_standalone_roles
+            result = await search_standalone_roles("rhel9_cis")
+        assert result["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_query(self):
+        from ansible_know.server import search_standalone_roles
+        result = await search_standalone_roles("")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_handles_galaxy_error(self):
+        with patch(
+            "ansible_know.resolution.search_standalone_roles",
+            new_callable=AsyncMock,
+            side_effect=GalaxyError("timeout"),
+        ):
+            from ansible_know.server import search_standalone_roles
+            result = await search_standalone_roles("cis")
+        assert "error" in result
+
+
+class TestGetStandaloneRoleDocTool:
+    @pytest.mark.asyncio
+    async def test_returns_doc(self):
+        mock_result = {
+            "role_name": "ansible-lockdown.rhel9_cis",
+            "content_type": "standalone_role",
+            "doc_source": "galaxy_v1_readme",
+            "entry_points": {"main": {"description": "", "options": []}},
+        }
+        with patch(
+            "ansible_know.resolution.resolve_standalone_role_doc",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            from ansible_know.server import get_standalone_role_doc
+            result = await get_standalone_role_doc("ansible-lockdown.rhel9_cis")
+        assert result["content_type"] == "standalone_role"
+
+    @pytest.mark.asyncio
+    async def test_rejects_three_part_fqcn(self):
+        from ansible_know.server import get_standalone_role_doc
+        result = await get_standalone_role_doc(
+            "fedora.linux_system_roles.timesync",
+        )
+        assert "error" in result
+        assert "get_role_doc" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_role_doc_still_requires_three_part(self):
+        from ansible_know.server import get_role_doc
+        result = await get_role_doc("ansible-lockdown.rhel9_cis")
+        assert "error" in result
+```
+
+Update `TestClearCache.test_clear_all` and `test_clear_galaxy_only` to also patch `ansible_know.galaxy_v1.clear_cache` and expect `"galaxy_v1"` in `cleared`. `test_clear_docs_only` must **not** call v1 clear.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_server.py::TestSearchStandaloneRolesTool tests/test_server.py::TestGetStandaloneRoleDocTool tests/test_server.py::TestClearCache -v`
+
+Expected: FAIL — cannot import the new tools / `cleared` list mismatch
+
+- [ ] **Step 3: Wire `server.py`**
+
+1. Module docstring: **22 tools**.
+2. Import `GetStandaloneRoleDocResult`, `StandaloneRoleSearchResult`, `validate_standalone_role_name`.
+3. FastMCP `instructions`: after collection-role workflow, add standalone search/get-doc (2-part `namespace.role`). Collection roles still `search_collections` / `get_role_doc`.
+4. Add `_galaxy_v1_factory(ctx)`:
+
+```python
+def _galaxy_v1_factory(ctx: Context | None = None):
+    from ansible_know.galaxy_v1 import GalaxyV1Client
+
+    def _factory(config, http_client=None):
+        return GalaxyV1Client.from_config(config, http_client=http_client)
+
+    return _factory
+```
+
+No enrichment semaphore.
+
+5. Tools (place after `search_collections` / `get_role_doc` as appropriate), `readOnlyHint=True`:
+
+`search_standalone_roles(query, tags=None, ctx=None) -> StandaloneRoleSearchResult | ErrorResponse`
+
+- Docstring: Galaxy **standalone/legacy** roles; `keywords` search; tags is a **single** Galaxy tag (first comma-separated segment is sent). Collection roles → `search_collections`. If public Galaxy is disabled and no server speaks v1, expect a v1-unsupported error.
+- `validate_query`; `validate_tags` when set; call `resolution.search_standalone_roles(..., v1_client_factory=_galaxy_v1_factory(ctx), http_client=..., galaxy_servers=state.galaxy_servers)`. Catch `Exception` → `{"error": sanitize_error(...)}`.
+
+`get_standalone_role_doc(role_name, ctx=None) -> GetStandaloneRoleDocResult | ErrorResponse`
+
+- Docstring: 2-part identifier from search; not `get_role_doc`.
+- `validate_standalone_role_name`; call `resolution.resolve_standalone_role_doc(..., v1_client_factory=_galaxy_v1_factory(ctx), ...)`.
+- Do **not** call `truncate_response` on the dict.
+
+6. `clear_cache`: when `scope in (None, "galaxy")`, also:
+
+```python
+from ansible_know import galaxy_v1
+galaxy_v1.clear_cache()
+cleared.append("galaxy_v1")
+```
+
+Do not import `galaxy_v1` from `galaxy.py`. Update the tool docstring: Galaxy scope includes standalone-role (v1) cache.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/test_server.py::TestSearchStandaloneRolesTool tests/test_server.py::TestGetStandaloneRoleDocTool tests/test_server.py::TestClearCache tests/test_server.py::TestSearchCollectionsTool -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ansible_know/server.py tests/test_server.py
+git commit -m "$(cat <<'EOF'
+feat: expose standalone Galaxy role search and docs as MCP tools
+
+Keep collection get_role_doc on 3-part FQCNs; clear the v1 cache from
+the existing galaxy cache scope without coupling galaxy.py.
+
+Assisted-by: Cursor (Grok 4.6)
+EOF
+)"
+```
+
+---
+
+### Task 6: Docs, contracts, optional live tests
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+- Modify: `docs/architecture/service-contracts.md`
+- Modify: `tests/integration/test_galaxy_api.py`
+
+**Interfaces:**
+- Consumes: implemented tools from Task 5
+- Produces: accurate tool counts and layer map
+
+- [ ] **Step 1: Update docs**
+
+`CLAUDE.md`: architecture tree add `galaxy_v1.py`; FastMCP line **22 tools**; tool table two rows (read-only).
+
+`README.md` Discovery table, after `get_role_doc`:
+
+| `search_standalone_roles(query, tags?)` | Search Galaxy standalone (legacy v1) roles by keyword |
+| `get_standalone_role_doc(role_name)` | Structured docs for a 2-part `namespace.role` from Galaxy README HTML |
+
+Also add those names to the ASCII “What It Does” tool list.
+
+`docs/architecture/service-contracts.md`:
+
+- Layer map: `src/ansible_know/galaxy_v1.py` → **External Access**
+- External Access table: `galaxy_v1.py` (`GalaxyV1Client`) consumers = `resolution.py`; `readme_parser.py` consumers = `galaxy.py`, `galaxy_v1.py`
+- Orchestration → Domain: add `search_standalone_roles()`, `resolve_standalone_role_doc()`
+- “20 tool handlers” → **22**
+
+- [ ] **Step 2: Optional integration tests**
+
+Append to `tests/integration/test_galaxy_api.py`:
+
+```python
+class TestRealGalaxyAPIV1Roles:
+    @pytest.mark.asyncio
+    async def test_search_standalone_roles_rhel9_cis(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        async with GalaxyV1Client() as client:
+            result = await client.search_roles("rhel9_cis")
+        assert result["count"] >= 1
+        names = [r["role_name"] for r in result["roles"]]
+        assert any("rhel9_cis" in n for n in names)
+
+    @pytest.mark.asyncio
+    async def test_fetch_ansible_lockdown_rhel9_cis(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        async with GalaxyV1Client() as client:
+            meta, prov = await client.fetch_standalone_role_doc(
+                "ansible-lockdown.rhel9_cis",
+            )
+        assert meta["role_name"] == "ansible-lockdown.rhel9_cis"
+        assert meta["content_type"] == "standalone_role"
+        assert prov["doc_source"] in ("galaxy_v1_readme", "galaxy_v1_metadata")
+```
+
+- [ ] **Step 3: Run unit suite + lint**
+
+Run:
+
+```bash
+pytest tests/ -v
+ruff check src/ansible_know/galaxy_v1.py src/ansible_know/validation.py src/ansible_know/types.py src/ansible_know/resolution.py src/ansible_know/server.py tests/test_galaxy_v1.py tests/test_validation.py tests/test_resolution.py tests/test_server.py
+```
+
+Expected: all unit tests PASS; ruff clean. Do not require `--run-integration` for merge.
+
+Confirm `galaxy.py` has no `galaxy_v1` import: `rg galaxy_v1 src/ansible_know/galaxy.py` → no matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md README.md docs/architecture/service-contracts.md tests/integration/test_galaxy_api.py
+git commit -m "$(cat <<'EOF'
+docs: document standalone Galaxy role tools and v1 layer
+
+Assisted-by: Cursor (Grok 4.6)
+EOF
+)"
+```
+
+---
+
+## Self-review (plan vs spec)
+
+| Spec requirement | Task |
+|------------------|------|
+| `search_standalone_roles` / `get_standalone_role_doc` | 5 |
+| `GalaxyV1Client` transport-only share | 2 |
+| `keywords` + `order_by=-download_count` + `page_size=10` | 2 |
+| `namespace`+`name` lookup, never `owner__username`+`name` | 2 |
+| `/content/` + `parse_role_readme` | 2 |
+| `{username}.{name}` identity | 2 |
+| New hyphen validator | 1 |
+| `content_type: standalone_role` | 2, 5 |
+| No local ansible-doc / GitHub / skills / install | Global + no tasks |
+| DRF `results` list | 2 |
+| First-segment `tags` | 2 |
+| Empty HTML → `galaxy_v1_metadata` | 2 |
+| Search all-fail raises; empty hits succeed | 4 |
+| `_try_v1_servers`, not `GalaxyDocClient` | 4 |
+| `clear_cache` in server.py, not `galaxy.py` | 5 |
+| Isolation: v1 must not set `GalaxyClient._discovery_failed` | 3 |
+| `_select_http_client` | 4 |
+| CLAUDE.md / README.md / service-contracts 20→22 | 6 |
+| `galaxy.py` unchanged (no v1 import) | 6 verify |
+| Follow-ups not implemented | Global |
+
+No TBD/TODO placeholders. Type names (`role_name`, `GalaxyV1ClientFactory`, `GetStandaloneRoleDocResult`) are consistent across tasks.

--- a/docs/superpowers/specs/2026-08-18-standalone-galaxy-roles-design.md
+++ b/docs/superpowers/specs/2026-08-18-standalone-galaxy-roles-design.md
@@ -73,10 +73,11 @@ with `GalaxyClient`.
 ```text
 server.py
   search_standalone_roles / get_standalone_role_doc
-    → resolution.resolve_standalone_role_search
+    → resolution.search_standalone_roles
     → resolution.resolve_standalone_role_doc
         → GalaxyV1Client   (v1 only)
             → shared httpx.AsyncClient + GalaxyServerConfig
+            → _select_http_client (skip shared client when validate_certs is false)
 
 GalaxyClient               (v3 only — unchanged)
   via GalaxyDocClient Protocol
@@ -118,6 +119,8 @@ Live-checked against `galaxy.ansible.com`.
 | Versions (unused here) | GET | `/api/v1/roles/{id}/versions/` |
 
 Pagination: `page_size` default 10, max 1000 (`LegacyRolesSetPagination`).
+List JSON is DRF: `{count, next, previous, results: [...]}` — not v3
+`{data, meta}`. Parse `results`.
 
 ### 5.2 Filters that work
 
@@ -126,7 +129,7 @@ and return the full catalog, ~37k roles).
 
 | Param | Behavior |
 |-------|----------|
-| `keywords` | Contains match on namespace name, role name, **or** description. Use this for search. |
+| `keywords` | Case-sensitive `contains` on namespace name, role name, **or** description. Use this for search. |
 | `autocomplete` | Same contains logic as `keywords`. Do not use (redundant). |
 | `namespace` | Exact, case-insensitive (`__iexact`) |
 | `name` | Exact (model field) |
@@ -253,7 +256,8 @@ async def fetch_standalone_role_doc(
 `fetch_standalone_role_doc` maps parsed README to the same metadata keys as
 `GalaxyClient.fetch_role_doc` (`role_name`, `short_description`,
 `entry_points.main.options`, `dependencies`, `examples`), plus v1 fields
-`tags`, `latest_version`, `github_user`, `github_repo`, `download_count`.
+`tags`, `latest_version`, `github_user`, `github_repo`, `github_branch`,
+`download_count`.
 
 Provenance:
 
@@ -273,9 +277,12 @@ A **separate** `BoundedCache` for v1 search/content, keyed by
 `_version_cache` / `_blob_cache`. TTL 3600s. Memory-only is fine (search
 payloads are small; HTML can be large — cap cache entries, e.g. max_size 50).
 
-`clear_cache` in `galaxy.py` should also clear the v1 cache (call a
-`galaxy_v1.clear_cache()` from the existing `clear_cache` tool path) so
-operators have one switch.
+**Operator switch:** the MCP `clear_cache` tool in `server.py` already
+clears `galaxy` and `docs` as two independent modules. When `scope` is
+`galaxy` or omitted, also call `galaxy_v1.clear_cache()`. Do **not**
+import `galaxy_v1` from `galaxy.py` — that would be the only v3→v1
+coupling. `galaxy.clear_cache()` stays v3-only. Add a `galaxy_v1` entry
+to the tool's `cleared` list (e.g. `"galaxy_v1"`).
 
 ---
 
@@ -295,7 +302,9 @@ that in the tool docstring.
 Resolution: query all configured Galaxy servers concurrently (same gather
 pattern as `search_galaxy_collections`). Skip servers that raise (no v1,
 404, timeout). Dedupe on `{username}.{name}`. Rank by `download_count`
-descending. If every server fails, return `{"error": ...}`.
+descending. Empty merged results are **success** (`count: 0`). If every
+server fails, **raise** `GalaxyError` (server.py turns it into
+`{"error": ...}`), matching `search_galaxy_collections`.
 
 Result TypedDict `StandaloneRoleSearchResult`:
 
@@ -305,7 +314,7 @@ Result TypedDict `StandaloneRoleSearchResult`:
     "count": int,
     "roles": [
         {
-            "role": str,              # username.name
+            "role_name": str,         # username.name (same key as get-doc)
             "description": str,
             "tags": list[str],
             "latest_version": str,
@@ -337,14 +346,15 @@ Result TypedDict `GetStandaloneRoleDocResult` — same optional fields as
 |-------|--------|
 | `role_name` | Echo the 2-part identifier |
 | `content_type` | `"standalone_role"` (not `"role"`) |
-| `doc_source` | `galaxy_v1_readme` / `galaxy_v1_metadata` / `unavailable` |
-| `short_description`, `entry_points`, `dependencies`, `examples` | From parser when HTML present |
-| `tags`, `latest_version`, `github_user`, `github_repo` | From list payload |
+| `doc_source` | `galaxy_v1_readme` or `galaxy_v1_metadata` on success. Do not return a success payload with `unavailable` — that case is `ErrorResponse`. |
+| `short_description`, `entry_points`, `dependencies`, `examples` | From parser when HTML present. If HTML is empty, `short_description` is the v1 `description` field; `dependencies` fall back to `summary_fields.dependencies`. When HTML is present, parser dependencies win; if the parser returns none, still fall back to `summary_fields.dependencies`. |
+| `tags`, `latest_version`, `github_user`, `github_repo`, `github_branch` | From list payload |
 | `doc_version`, `doc_warning`, `doc_source_server` | Provenance |
-| `error` | Only when unavailable |
+| `error` | Not used on the success TypedDict. Not-found and all-servers-failed are `ErrorResponse` (`{"error": str}`) only. |
 
-Never return raw `readme_html`. Apply `truncate_response` on the tool
-boundary like other doc tools.
+Never return raw `readme_html`. Do not call `truncate_response` on the
+result dict (it takes `str`; only skill-render tools use it). Structured
+doc tools return the TypedDict as-is.
 
 No local ansible-doc attempt.
 
@@ -367,7 +377,7 @@ Server instructions and tool descriptions must say:
 - Collection roles → `search_collections` / `get_role_doc` (3-part FQCN)
 - Standalone Galaxy roles → these two tools (2-part `namespace.role`)
 
-Update `CLAUDE.md` tool table (counts + two rows). Update
+Update `CLAUDE.md` and `README.md` tool tables (this branch has **20** tools → **22**) and `server.py` module docstring / FastMCP `instructions` (add standalone search/get-doc to the workflow). Update
 `docs/architecture/service-contracts.md` External Access table:
 `galaxy_v1.py` → `resolution.py`; `readme_parser.py` consumers include
 `galaxy_v1.py`. Layer map: `galaxy_v1.py` → External Access.
@@ -385,7 +395,7 @@ async def search_standalone_roles(
     http_client: httpx.AsyncClient | None = None,
     galaxy_servers: list[GalaxyServerConfig] | None = None,
     v1_client_factory: GalaxyV1ClientFactory | None = None,
-) -> dict[str, Any]: ...
+) -> dict[str, Any]: ...  # raises GalaxyError if every server fails
 
 async def resolve_standalone_role_doc(
     role_name: str,
@@ -396,14 +406,29 @@ async def resolve_standalone_role_doc(
 ```
 
 `GalaxyV1ClientFactory` is a Protocol in `types.py` parallel to
-`GalaxyClientFactory`, returning `GalaxyV1Client` (or a small Protocol with
-the three async methods). **Do not** extend `GalaxyDocClient`.
+`GalaxyClientFactory`, returning a context manager with
+`search_roles` and `fetch_standalone_role_doc`. **Do not** extend
+`GalaxyDocClient`.
+
+Do **not** reuse `_try_galaxy_servers` as currently typed
+(`GalaxyClientFactory` → `GalaxyDocClient`). Duplicate a small
+`_try_v1_servers` with the same first-success / last-`GalaxyError` loop
+and `GalaxyV1ClientFactory`. Do not genericize the v3 helper.
 
 `server.py` injects a `_galaxy_v1_factory(ctx)` closure analogous to
-`_galaxy_factory`. Orchestration: validate → call resolution → return.
+`_galaxy_factory` (no enrichment semaphore). Orchestration: validate →
+call resolution → return.
 
 Try servers in configured order for get-doc (first success wins). Search
-queries all servers and merges.
+queries all servers and merges; **raises** `GalaxyError` when every
+server fails (empty hits are success). Both paths must use
+`_select_http_client` (do not inject the shared httpx client when
+`validate_certs` is false).
+
+If public Galaxy is disabled (`ANSIBLE_KNOW_NO_PUBLIC_GALAXY=1`) and no
+configured server speaks v1, the tools return the “does not support
+standalone roles” error. That is expected — standalone roles are a public
+Galaxy catalog.
 
 ---
 
@@ -414,9 +439,9 @@ queries all servers and merges.
 | Validation failure | `{"error": str}` |
 | No v1 on any configured server | `{"error": "... does not support standalone roles (Galaxy v1)"}` |
 | Role not found | `{"error": "Standalone role '{name}' not found"}` |
-| HTTP/timeout on a server (search) | Skip server; if all fail, `{"error": ...}` |
+| HTTP/timeout on a server (search) | Skip server; empty merge is success; if all fail, resolution raises `GalaxyError` → tool `{"error": ...}` |
 | HTTP/timeout on get-doc after all servers | `{"error": ...}` sanitized |
-| Empty README HTML | Success with `doc_source: galaxy_v1_metadata` and `doc_warning` |
+| Empty README HTML | Success with `doc_source: galaxy_v1_metadata`, v1 description/tags, and `doc_warning` |
 
 v1 exceptions must not set `GalaxyClient._discovery_failed`.
 
@@ -431,14 +456,17 @@ Unit tests mock HTTP (no live Galaxy). Integration tests stay opt-in
 |------|----------|
 | `tests/test_galaxy_v1.py` | `keywords` + `order_by=-download_count` + `page_size=10`; `tags` first-segment only; lookup uses `namespace`+`name` **not** `owner__username`; content parse → entry_points; empty HTML → `galaxy_v1_metadata`; 404 on v1 → `GalaxyError`; hyphenated `ansible-lockdown.rhel9_cis`; discovery requires v1 and does **not** require v3 |
 | `tests/test_validation.py` | Accept hyphens/mixed case; reject 1-part, 3-part, empty, `/` |
-| `tests/test_resolution.py` | Multi-server: v1-less server skipped, v1 server used; all-fail → error; search dedupe |
-| `tests/test_server.py` | Both tools success + validation error; `get_role_doc` still requires 3-part FQCN |
-| `tests/test_galaxy.py` | Existing v3 tests still pass; `clear_cache` clears v1 cache too |
+| `tests/test_resolution.py` | Multi-server: v1-less server skipped, v1 server used; all-fail **raises** `GalaxyError`; search dedupe; empty hits succeed |
+| `tests/test_server.py` | Both tools success + validation error; `get_role_doc` still requires 3-part FQCN; `clear_cache(scope=galaxy)` also calls `galaxy_v1.clear_cache` |
+| `tests/test_galaxy.py` | Existing v3 tests still pass (no v1 import) |
 | `tests/integration/test_galaxy_api.py` | Optional live `keywords=rhel9_cis` and `get ansible-lockdown.rhel9_cis` |
 
-**Isolation test (required):** mock v1 404 (or missing `v1` in
-`available_versions`) and assert `GalaxyClient.search_collections` /
-`fetch_module_doc` still succeed with v3 fixtures.
+**Isolation test (required):** construct both clients from the same config +
+httpx mock. A v1 404 / missing `v1` in `available_versions` must not set
+`GalaxyClient._discovery_failed` and must not change `_v3_path`. v3
+`search_collections` / `fetch_module_doc` on that same `GalaxyClient`
+instance must still succeed. A tautological “v3 works in a test that never
+constructs V1Client” is not sufficient.
 
 ---
 
@@ -450,16 +478,15 @@ Unit tests mock HTTP (no live Galaxy). Integration tests stay opt-in
 | `src/ansible_know/validation.py` | Add `validate_standalone_role_name` |
 | `src/ansible_know/types.py` | Search/doc TypedDicts + `GalaxyV1ClientFactory` Protocol |
 | `src/ansible_know/resolution.py` | `search_standalone_roles`, `resolve_standalone_role_doc` |
-| `src/ansible_know/server.py` | Two tools, factory, instructions |
-| `src/ansible_know/galaxy.py` | `clear_cache()` also clears v1 cache (no v1 methods) |
+| `src/ansible_know/server.py` | Two tools, factory, instructions, `clear_cache` also calls `galaxy_v1.clear_cache` |
+| `src/ansible_know/galaxy.py` | **Unchanged** (v3-only; do not import v1) |
 | `tests/test_galaxy_v1.py` | **Create** |
 | `tests/test_validation.py` | New validator cases |
-| `tests/test_resolution.py` | Standalone resolution |
-| `tests/test_server.py` | Tool wiring |
-| `tests/test_galaxy.py` | Cache clear coupling |
+| `tests/test_resolution.py` | **Modify** — standalone search/get-doc resolution |
+| `tests/test_server.py` | Tool wiring + cache-clear coupling |
 | `CLAUDE.md` | Tool table |
 | `docs/architecture/service-contracts.md` | Layer map + External Access row |
-| `README.md` | Tool table (if it lists tools) |
+| `README.md` | Tool table (required — it lists tools) |
 
 No template or `skills.py` changes in this issue.
 
@@ -469,7 +496,7 @@ No template or `skills.py` changes in this issue.
 
 ```text
 search_standalone_roles("rhel9_cis")
-  → {roles: [{role: "ansible-lockdown.rhel9_cis", download_count: ..., ...}]}
+  → {roles: [{role_name: "ansible-lockdown.rhel9_cis", download_count: ..., ...}]}
 
 get_standalone_role_doc("ansible-lockdown.rhel9_cis")
   → {content_type: "standalone_role", doc_source: "galaxy_v1_readme",
@@ -511,3 +538,6 @@ search_collections("timesync") → get_role_doc("fedora.linux_system_roles.times
 | `content_type` | `standalone_role` |
 | Local ansible-doc | No |
 | GitHub / skills / install | Follow-up issues |
+| v3 `clear_cache` | Stays v3-only; MCP tool also clears v1 |
+| Multi-server get-doc | New `_try_v1_servers`; do not extend `GalaxyDocClient` |
+| Search all-fail | Raise `GalaxyError` (match collection search) |

--- a/docs/superpowers/specs/2026-08-18-standalone-galaxy-roles-design.md
+++ b/docs/superpowers/specs/2026-08-18-standalone-galaxy-roles-design.md
@@ -1,0 +1,513 @@
+# Spec: Standalone Galaxy Role Search and Documentation
+
+**Status:** Proposed  
+**Date:** 2026-08-18  
+**Issue:** [#230](https://github.com/leogallego/ansible-know-mcp/issues/230)  
+**Repo:** ansible-know-mcp (`leogallego/ansible-know-mcp`)  
+**Audience:** Implementation session in this repo only
+
+> **For agentic workers:** Use superpowers:writing-plans to create an
+> implementation plan from this spec. Do not implement from this document
+> alone.
+
+---
+
+## 1. Problem
+
+Galaxy **standalone roles** (legacy v1 roles such as
+`ansible-lockdown.rhel9_cis`) are not discoverable through this MCP server.
+
+Existing role tools only cover roles **inside collections**:
+
+| Tool | Identifier | API |
+|------|------------|-----|
+| `search_collections` | collection FQCN | Galaxy **v3** |
+| `get_role_doc` | 3-part FQCN `ns.collection.role` | local ansible-doc → v3 docs-blob `readme_html` |
+| `get_collection_manifest` | `ns.collection` | v3 contents |
+
+Standalone roles live on the Galaxy **v1** API. They have no docs-blob, no
+3-part FQCN, and were explicitly out of scope in
+`docs/superpowers/specs/2026-06-11-role-support-design.md`.
+
+The June spec assumed READMEs existed only on GitHub and would need a GitHub
+API. That is outdated: galaxy-ng stores rendered README HTML at import time
+and serves it at `GET /api/v1/roles/{id}/content/`.
+
+---
+
+## 2. Goals
+
+1. Add `search_standalone_roles` — keyword search of Galaxy standalone roles.
+2. Add `get_standalone_role_doc` — structured docs for one standalone role.
+3. Keep Galaxy **v3** collection/module/plugin/collection-role paths unchanged.
+   A v1 404, 410, or removal must not fail v3 discovery or tools.
+4. Reuse `parse_role_readme()` on Galaxy-stored HTML (same as collection
+   `get_role_doc` Galaxy fallback).
+
+---
+
+## 3. Non-goals (follow-up issues)
+
+Create separate issues after this one lands; do **not** implement here:
+
+| Follow-up | Why deferred |
+|-----------|----------------|
+| GitHub README fallback when `readme_html` is empty | Extra host allowlist; v1 `/content/` is the Galaxy UI path |
+| `generate_standalone_role_skill` | Needs 2-part layout + template copy; ~25–30% extra on top of this spec |
+| `ansible-galaxy role install` / ensure-role | Write path; different from `ensure_collection` |
+
+Also out of scope:
+
+- Extending `search_collections` or `get_role_doc` to accept 2-part names
+- Local `ansible-doc -t role` for standalone roles
+- Skill listing / AGENTS.md / Lola packaging for standalone roles
+- Changing `GalaxyDocClient` / v3 discovery to require v1
+
+---
+
+## 4. Architecture
+
+**Approach B:** a dedicated `GalaxyV1Client` that shares **transport only**
+with `GalaxyClient`.
+
+```text
+server.py
+  search_standalone_roles / get_standalone_role_doc
+    → resolution.resolve_standalone_role_search
+    → resolution.resolve_standalone_role_doc
+        → GalaxyV1Client   (v1 only)
+            → shared httpx.AsyncClient + GalaxyServerConfig
+
+GalaxyClient               (v3 only — unchanged)
+  via GalaxyDocClient Protocol
+```
+
+**Shared (transport):** the lifespan `httpx.AsyncClient`, TLS verify flag, and
+credentials on `GalaxyServerConfig` (token / basic / SSO).
+`GalaxyV1Client.from_config(config, http_client=...)` mirrors
+`GalaxyClient.from_config`.
+
+**Not shared:** API-root discovery, URL builders, `_discovery_failed`,
+v3 caches, `GalaxyDocClient` Protocol.
+
+Prefer a new module `src/ansible_know/galaxy_v1.py` (External Access layer)
+so deleting v1 later is one file plus the two tools and two resolution
+functions. Do not add v1 methods to `GalaxyClient`.
+
+`readme_parser.py` gains a second consumer (`galaxy_v1.py`) in addition to
+`galaxy.py`. No parser API change.
+
+---
+
+## 5. Verified galaxy-ng v1 surface
+
+Source: [ansible/galaxy_ng](https://github.com/ansible/galaxy_ng)
+`galaxy_ng/app/api/v1/` (urls, filtersets, viewsets/roles, serializers).
+Live-checked against `galaxy.ansible.com`.
+
+### 5.1 Routes
+
+`/api/v1/roles/` and `/api/v1/search/roles/` are the **same** list view
+(`LegacyRolesViewSet.list`). Use `/api/v1/roles/` only.
+
+| Operation | Method | Path |
+|-----------|--------|------|
+| Search / list | GET | `/api/v1/roles/` |
+| Exact lookup | GET | `/api/v1/roles/?namespace={ns}&name={name}` |
+| README | GET | `/api/v1/roles/{id}/content/` |
+| Versions (unused here) | GET | `/api/v1/roles/{id}/versions/` |
+
+Pagination: `page_size` default 10, max 1000 (`LegacyRolesSetPagination`).
+
+### 5.2 Filters that work
+
+From `LegacyRoleFilter` — **not** `search=` or `keyword=` (those are ignored
+and return the full catalog, ~37k roles).
+
+| Param | Behavior |
+|-------|----------|
+| `keywords` | Contains match on namespace name, role name, **or** description. Use this for search. |
+| `autocomplete` | Same contains logic as `keywords`. Do not use (redundant). |
+| `namespace` | Exact, case-insensitive (`__iexact`) |
+| `name` | Exact (model field) |
+| `tags` / `tag` | JSON list contains **one** tag string |
+| `github_user` | Namespace name |
+| `owner__username` | Namespace `__iexact` |
+| `order_by` | `name`, `created`, `modified`, `download_count` (prefix `-` for desc) |
+
+**Download-count side effect:** if **both** `owner__username` and `name` are
+present, the list view increments the role's download counter (CLI install
+detection). Exact lookup for docs **must** use `namespace` + `name`, which
+the Galaxy UI uses and which does not increment counts.
+
+### 5.3 Identifiers
+
+Galaxy listing identity is `{username}.{name}` where `username` is the
+**legacy namespace** (`obj.namespace.name`), not `github_user`.
+
+The same GitHub repo can appear twice (e.g. `MindPointGroup.rhel9_cis` and
+`ansible-lockdown.rhel9_cis`). Tools treat those as distinct roles.
+
+Namespaces and role names may contain **hyphens** and mixed case
+(`ansible-lockdown`, `elasticsearch-curator`). Existing `validate_fqcn` /
+`validate_namespace` reject hyphens — do not reuse them.
+
+### 5.4 Content payload
+
+`GET /api/v1/roles/{id}/content/` →
+`{"readme": "README.md", "readme_html": "<h1>..."}` from
+`full_metadata` (`LegacyRoleContentSerializer`). This is the Galaxy UI
+Documentation tab. No GitHub request.
+
+List/detail payloads include `id`, `username`, `name`, `description`,
+`github_user`, `github_repo`, `github_branch`, `download_count`,
+`summary_fields.tags`, `summary_fields.versions`,
+`summary_fields.dependencies`.
+
+---
+
+## 6. Client: `GalaxyV1Client`
+
+File: `src/ansible_know/galaxy_v1.py`
+
+### 6.1 Construction
+
+```python
+class GalaxyV1Client:
+    def __init__(
+        self,
+        base_url: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
+        token: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        verify: bool = True,
+        server_name: str | None = None,
+        auth_url: str | None = None,
+        client_id: str | None = None,
+    ) -> None: ...
+
+    @classmethod
+    def from_config(
+        cls,
+        config: GalaxyServerConfig,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> GalaxyV1Client: ...
+```
+
+Context manager `aclose` of an **owned** client only (same as `GalaxyClient`).
+When `http_client` is injected, do not close it.
+
+Auth header construction may copy the SSO/token/basic pattern from
+`GalaxyClient` (small duplication is acceptable; v1 will not grow). Do not
+import or call `GalaxyClient._discover_api_root`.
+
+### 6.2 Independent v1 discovery
+
+Probe `base_url`, then `base_url + "/api"` if needed, for
+`available_versions`. **Require `v1` only.** Do not inspect or require `v3`.
+Do not set any flag on `GalaxyClient`.
+
+- Missing `v1` → this client raises `GalaxyError` (“server does not support
+  Galaxy API v1”). Resolution skips that server.
+- Unsafe `v1` path (same rules as v3: no `..`, charset `[a-zA-Z0-9/_-]`) →
+  `GalaxyError` for this client only.
+
+URL builder: `{api_root}/{v1_path}roles/` and
+`{api_root}/{v1_path}roles/{id}/content/`.
+
+Do **not** import `galaxy.py` from `galaxy_v1.py` (circular import:
+`galaxy.clear_cache` will lazy-import `galaxy_v1.clear_cache`). Duplicate
+timeout and size-limit constants in `galaxy_v1.py`, or read them from
+`config.py`. Import `GalaxyError` from `errors.py` only.
+
+### 6.3 Methods
+
+```python
+async def search_roles(
+    self, query: str, tags: str | None = None,
+) -> dict[str, Any]:
+    """GET roles/?keywords=&order_by=-download_count&page_size=10."""
+
+async def fetch_role_by_name(
+    self, namespace: str, name: str,
+) -> dict[str, Any]:
+    """GET roles/?namespace=&name=. Return the first result or raise."""
+
+async def fetch_role_content(self, role_id: int) -> dict[str, Any]:
+    """GET roles/{id}/content/. Return {readme, readme_html}."""
+
+async def fetch_standalone_role_doc(
+    self, role_name: str,
+) -> tuple[dict[str, Any], DocProvenance]:
+    """Split role_name, lookup, fetch content, parse_role_readme."""
+```
+
+`search_roles` params:
+
+- `keywords` = query
+- `order_by` = `-download_count`
+- `page_size` = `10` (match v3 collection search `limit=10`)
+- if `tags` is set, pass **one** `tags` value (see §7)
+
+`fetch_standalone_role_doc` maps parsed README to the same metadata keys as
+`GalaxyClient.fetch_role_doc` (`role_name`, `short_description`,
+`entry_points.main.options`, `dependencies`, `examples`), plus v1 fields
+`tags`, `latest_version`, `github_user`, `github_repo`, `download_count`.
+
+Provenance:
+
+- `doc_source`: `"galaxy_v1_readme"` when `readme_html` is non-empty
+- `doc_source`: `"galaxy_v1_metadata"` when HTML is empty (metadata only;
+  warning that README was missing; **no GitHub fetch**)
+- `doc_version`: latest `summary_fields.versions[0].name` when present
+- `doc_source_server`: `server_name` when set
+- `doc_warning`: best-effort README parse note when source is readme
+
+Empty HTML is success, not an exception.
+
+### 6.4 Cache
+
+A **separate** `BoundedCache` for v1 search/content, keyed by
+`(normalized_base_url, server_name, ...)` like v3. Do not write into
+`_version_cache` / `_blob_cache`. TTL 3600s. Memory-only is fine (search
+payloads are small; HTML can be large — cap cache entries, e.g. max_size 50).
+
+`clear_cache` in `galaxy.py` should also clear the v1 cache (call a
+`galaxy_v1.clear_cache()` from the existing `clear_cache` tool path) so
+operators have one switch.
+
+---
+
+## 7. Tools
+
+### 7.1 `search_standalone_roles`
+
+Read-only. Parameters:
+
+- `query: str` — `validate_query`
+- `tags: str | None` — `validate_tags` when set
+
+v1 `tags` is a **single** JSON-contains filter, not comma-AND. If the caller
+passes comma-separated tags, send only the **first** segment to v1. Document
+that in the tool docstring.
+
+Resolution: query all configured Galaxy servers concurrently (same gather
+pattern as `search_galaxy_collections`). Skip servers that raise (no v1,
+404, timeout). Dedupe on `{username}.{name}`. Rank by `download_count`
+descending. If every server fails, return `{"error": ...}`.
+
+Result TypedDict `StandaloneRoleSearchResult`:
+
+```python
+{
+    "query": str,
+    "count": int,
+    "roles": [
+        {
+            "role": str,              # username.name
+            "description": str,
+            "tags": list[str],
+            "latest_version": str,
+            "download_count": int,
+            "github_user": str,
+            "github_repo": str,
+            "source": str,            # optional, server name
+        },
+        ...
+    ],
+}
+```
+
+Do not fetch `/content/` during search.
+
+### 7.2 `get_standalone_role_doc`
+
+Read-only. Parameter:
+
+- `role_name: str` — `validate_standalone_role_name` (new)
+
+Split into `(namespace, name)` on the **first** dot (exactly two segments).
+Lookup via `namespace` + `name`, then `/content/`, then parse.
+
+Result TypedDict `GetStandaloneRoleDocResult` — same optional fields as
+`GetRoleDocResult` plus standalone extras:
+
+| Field | Notes |
+|-------|--------|
+| `role_name` | Echo the 2-part identifier |
+| `content_type` | `"standalone_role"` (not `"role"`) |
+| `doc_source` | `galaxy_v1_readme` / `galaxy_v1_metadata` / `unavailable` |
+| `short_description`, `entry_points`, `dependencies`, `examples` | From parser when HTML present |
+| `tags`, `latest_version`, `github_user`, `github_repo` | From list payload |
+| `doc_version`, `doc_warning`, `doc_source_server` | Provenance |
+| `error` | Only when unavailable |
+
+Never return raw `readme_html`. Apply `truncate_response` on the tool
+boundary like other doc tools.
+
+No local ansible-doc attempt.
+
+### 7.3 Validation
+
+New `validate_standalone_role_name(name: str) -> None` in `validation.py`.
+
+- Exactly two segments separated by `.`
+- Each segment: `[A-Za-z0-9][A-Za-z0-9_-]*` (hyphen + mixed case)
+- Length cap: reuse `MAX_NAMESPACE_LENGTH` per segment (128)
+- Reject 3-part FQCNs with an error that points at `get_role_doc`
+- Reject empty / path characters
+
+Do not change `validate_fqcn` or `validate_namespace`.
+
+### 7.4 Agent-facing copy
+
+Server instructions and tool descriptions must say:
+
+- Collection roles → `search_collections` / `get_role_doc` (3-part FQCN)
+- Standalone Galaxy roles → these two tools (2-part `namespace.role`)
+
+Update `CLAUDE.md` tool table (counts + two rows). Update
+`docs/architecture/service-contracts.md` External Access table:
+`galaxy_v1.py` → `resolution.py`; `readme_parser.py` consumers include
+`galaxy_v1.py`. Layer map: `galaxy_v1.py` → External Access.
+
+---
+
+## 8. Resolution
+
+`resolution.py` (Domain):
+
+```python
+async def search_standalone_roles(
+    query: str,
+    tags: str | None = None,
+    http_client: httpx.AsyncClient | None = None,
+    galaxy_servers: list[GalaxyServerConfig] | None = None,
+    v1_client_factory: GalaxyV1ClientFactory | None = None,
+) -> dict[str, Any]: ...
+
+async def resolve_standalone_role_doc(
+    role_name: str,
+    http_client: httpx.AsyncClient | None = None,
+    galaxy_servers: list[GalaxyServerConfig] | None = None,
+    v1_client_factory: GalaxyV1ClientFactory | None = None,
+) -> GetStandaloneRoleDocResult | ErrorResponse: ...
+```
+
+`GalaxyV1ClientFactory` is a Protocol in `types.py` parallel to
+`GalaxyClientFactory`, returning `GalaxyV1Client` (or a small Protocol with
+the three async methods). **Do not** extend `GalaxyDocClient`.
+
+`server.py` injects a `_galaxy_v1_factory(ctx)` closure analogous to
+`_galaxy_factory`. Orchestration: validate → call resolution → return.
+
+Try servers in configured order for get-doc (first success wins). Search
+queries all servers and merges.
+
+---
+
+## 9. Errors
+
+| Case | Tool result |
+|------|-------------|
+| Validation failure | `{"error": str}` |
+| No v1 on any configured server | `{"error": "... does not support standalone roles (Galaxy v1)"}` |
+| Role not found | `{"error": "Standalone role '{name}' not found"}` |
+| HTTP/timeout on a server (search) | Skip server; if all fail, `{"error": ...}` |
+| HTTP/timeout on get-doc after all servers | `{"error": ...}` sanitized |
+| Empty README HTML | Success with `doc_source: galaxy_v1_metadata` and `doc_warning` |
+
+v1 exceptions must not set `GalaxyClient._discovery_failed`.
+
+---
+
+## 10. Testing
+
+Unit tests mock HTTP (no live Galaxy). Integration tests stay opt-in
+(`--run-integration`).
+
+| File | Coverage |
+|------|----------|
+| `tests/test_galaxy_v1.py` | `keywords` + `order_by=-download_count` + `page_size=10`; `tags` first-segment only; lookup uses `namespace`+`name` **not** `owner__username`; content parse → entry_points; empty HTML → `galaxy_v1_metadata`; 404 on v1 → `GalaxyError`; hyphenated `ansible-lockdown.rhel9_cis`; discovery requires v1 and does **not** require v3 |
+| `tests/test_validation.py` | Accept hyphens/mixed case; reject 1-part, 3-part, empty, `/` |
+| `tests/test_resolution.py` | Multi-server: v1-less server skipped, v1 server used; all-fail → error; search dedupe |
+| `tests/test_server.py` | Both tools success + validation error; `get_role_doc` still requires 3-part FQCN |
+| `tests/test_galaxy.py` | Existing v3 tests still pass; `clear_cache` clears v1 cache too |
+| `tests/integration/test_galaxy_api.py` | Optional live `keywords=rhel9_cis` and `get ansible-lockdown.rhel9_cis` |
+
+**Isolation test (required):** mock v1 404 (or missing `v1` in
+`available_versions`) and assert `GalaxyClient.search_collections` /
+`fetch_module_doc` still succeed with v3 fixtures.
+
+---
+
+## 11. Files
+
+| Path | Change |
+|------|--------|
+| `src/ansible_know/galaxy_v1.py` | **Create** — `GalaxyV1Client` |
+| `src/ansible_know/validation.py` | Add `validate_standalone_role_name` |
+| `src/ansible_know/types.py` | Search/doc TypedDicts + `GalaxyV1ClientFactory` Protocol |
+| `src/ansible_know/resolution.py` | `search_standalone_roles`, `resolve_standalone_role_doc` |
+| `src/ansible_know/server.py` | Two tools, factory, instructions |
+| `src/ansible_know/galaxy.py` | `clear_cache()` also clears v1 cache (no v1 methods) |
+| `tests/test_galaxy_v1.py` | **Create** |
+| `tests/test_validation.py` | New validator cases |
+| `tests/test_resolution.py` | Standalone resolution |
+| `tests/test_server.py` | Tool wiring |
+| `tests/test_galaxy.py` | Cache clear coupling |
+| `CLAUDE.md` | Tool table |
+| `docs/architecture/service-contracts.md` | Layer map + External Access row |
+| `README.md` | Tool table (if it lists tools) |
+
+No template or `skills.py` changes in this issue.
+
+---
+
+## 12. Agent workflow (after implementation)
+
+```text
+search_standalone_roles("rhel9_cis")
+  → {roles: [{role: "ansible-lockdown.rhel9_cis", download_count: ..., ...}]}
+
+get_standalone_role_doc("ansible-lockdown.rhel9_cis")
+  → {content_type: "standalone_role", doc_source: "galaxy_v1_readme",
+     entry_points: {main: {options: [...]}}, ...}
+```
+
+Collection roles remain:
+
+```text
+search_collections("timesync") → get_role_doc("fedora.linux_system_roles.timesync")
+```
+
+---
+
+## 13. Follow-up issues (file after merge, do not implement)
+
+1. **GitHub README fallback** — if `readme_html` is empty, fetch
+   `raw.githubusercontent.com/{github_user}/{github_repo}/{github_branch}/README.md`
+   with host allowlist. Not required for the Galaxy UI path.
+2. **`generate_standalone_role_skill`** — reuse `write_role_skill_package`
+   once get-doc returns `GetRoleDocResult`-shaped metadata; 2-part directory
+   layout and template compatibility line (no collection).
+3. **Standalone role install** — `ansible-galaxy role install`; separate from
+   `ensure_collection`.
+
+---
+
+## 14. Design decisions (locked)
+
+| Decision | Choice |
+|----------|--------|
+| Client | Separate `GalaxyV1Client` (`galaxy_v1.py`), not methods on `GalaxyClient` |
+| Transport | Shared lifespan httpx + `GalaxyServerConfig` auth |
+| Search query param | `keywords` (not `search` / `keyword`) |
+| Exact lookup | `namespace` + `name` (not `owner__username` + `name`) |
+| README | v1 `/content/` `readme_html` + `parse_role_readme` |
+| Identifier | `{username}.{name}` (Galaxy namespace) |
+| Validator | New 2-part hyphen-safe validator |
+| `content_type` | `standalone_role` |
+| Local ansible-doc | No |
+| GitHub / skills / install | Follow-up issues |

--- a/src/ansible_know/galaxy_v1.py
+++ b/src/ansible_know/galaxy_v1.py
@@ -1,0 +1,534 @@
+"""Galaxy v1 API client for standalone roles."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from ansible_know.cache import BoundedCache
+from ansible_know.config import GALAXY_BASE_URL
+from ansible_know.errors import GalaxyError
+
+if TYPE_CHECKING:
+    from ansible_know.galaxy_config import GalaxyServerConfig
+    from ansible_know.types import DocProvenance
+
+logger = logging.getLogger("ansible_know")
+
+MAX_GALAXY_RESPONSE_SIZE = 5_000_000  # 5MB
+CACHE_TTL_SECONDS = 3600
+
+TIMEOUT_FAST = httpx.Timeout(10.0)
+TIMEOUT_DEFAULT = httpx.Timeout(10.0, read=30.0)
+TIMEOUT_SLOW = httpx.Timeout(10.0, read=120.0)
+
+MAX_DISCOVERY_RESPONSE_SIZE = 100_000  # 100KB — discovery payloads are tiny
+
+_SAFE_V1_PATH_RE = re.compile(r"^[a-zA-Z0-9/_-]+/?$")
+
+_v1_cache: BoundedCache[tuple[str, ...], dict[str, Any]] = BoundedCache(
+    max_size=50, ttl=CACHE_TTL_SECONDS,
+)
+
+
+def _normalize_cache_base_url(url: str) -> str:
+    """Normalize a Galaxy/Hub URL for cache partitioning."""
+    base = url.rstrip("/")
+    if base.endswith("/api"):
+        base = base[: -len("/api")].rstrip("/")
+    return base
+
+
+def clear_cache() -> None:
+    """Clear Galaxy v1 standalone role cache (useful for testing)."""
+    _v1_cache.clear()
+
+
+def _first_tag(tags: str | None) -> str | None:
+    if not tags:
+        return None
+    return tags.split(",", 1)[0].strip() or None
+
+
+def _normalize_dependencies(raw: object) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    out: list[str] = []
+    for item in raw:
+        if isinstance(item, str) and item:
+            out.append(item)
+        elif isinstance(item, dict):
+            ns = item.get("namespace") or item.get("username") or ""
+            name = item.get("name") or ""
+            if ns and name:
+                out.append(f"{ns}.{name}")
+            elif name:
+                out.append(str(name))
+    return out
+
+
+def _map_search_hit(item: dict[str, Any]) -> dict[str, Any]:
+    versions = (item.get("summary_fields") or {}).get("versions") or []
+    latest = ""
+    if versions and isinstance(versions[0], dict):
+        latest = versions[0].get("name") or ""
+    tags_raw = (item.get("summary_fields") or {}).get("tags") or []
+    tags: list[str] = []
+    for t in tags_raw:
+        if isinstance(t, str):
+            tags.append(t)
+        elif isinstance(t, dict) and t.get("name"):
+            tags.append(str(t["name"]))
+    username = item.get("username") or ""
+    name = item.get("name") or ""
+    return {
+        "role_name": f"{username}.{name}",
+        "description": item.get("description") or "",
+        "tags": tags,
+        "latest_version": latest,
+        "download_count": item.get("download_count") or 0,
+        "github_user": item.get("github_user") or "",
+        "github_repo": item.get("github_repo") or "",
+    }
+
+
+class GalaxyV1Client:
+    """Async client for the Galaxy v1 API (standalone roles)."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
+        token: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        verify: bool = True,
+        server_name: str | None = None,
+        auth_url: str | None = None,
+        client_id: str | None = None,
+    ):
+        self._base = (base_url or GALAXY_BASE_URL).rstrip("/")
+        self._http_client = http_client
+        self._owned_client: httpx.AsyncClient | None = None
+        self._token = token
+        self._username = username
+        self._password = password
+        self._verify = verify
+        self.server_name = server_name
+        self._auth_url = auth_url
+        self._client_id = client_id
+        self._access_token: str | None = None
+        self._token_lock = asyncio.Lock()
+        self._api_root: str | None = None
+        self._v1_path: str | None = None
+        self._discovery_lock = asyncio.Lock()
+        self._discovery_failed: bool = False
+
+    def _cache_identity(self) -> tuple[str, str, str]:
+        transport_identity = str(
+            id(self._http_client if self._http_client is not None else self._owned_client)
+        )
+        return (
+            _normalize_cache_base_url(self._base),
+            self.server_name or "",
+            transport_identity,
+        )
+
+    @classmethod
+    def from_config(
+        cls,
+        config: GalaxyServerConfig,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> GalaxyV1Client:
+        """Create a GalaxyV1Client from a GalaxyServerConfig."""
+        return cls(
+            base_url=config.url,
+            http_client=http_client,
+            token=config.token,
+            username=config.username,
+            password=config.password,
+            verify=config.validate_certs,
+            server_name=config.name,
+            auth_url=config.auth_url,
+            client_id=config.client_id,
+        )
+
+    async def __aenter__(self) -> GalaxyV1Client:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        """Close the owned httpx client, if any."""
+        if self._owned_client is not None:
+            await self._owned_client.aclose()
+            self._owned_client = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Get the http client to use for requests."""
+        if self._http_client is not None:
+            return self._http_client
+        if self._owned_client is None:
+            self._owned_client = httpx.AsyncClient(
+                timeout=TIMEOUT_SLOW,
+                verify=self._verify,
+                follow_redirects=True,
+            )
+        return self._owned_client
+
+    async def _ensure_access_token(self) -> str:
+        """Exchange offline token for access token via SSO, with caching."""
+        if self._access_token is not None:
+            return self._access_token
+        if self._auth_url is None:
+            raise GalaxyError("Cannot exchange SSO token without auth_url")
+        if not self._auth_url.startswith("https://"):
+            logger.warning(
+                "auth_url for server '%s' is not HTTPS — "
+                "credentials may be sent in cleartext",
+                self.server_name or "default",
+            )
+
+        async with self._token_lock:
+            if self._access_token is not None:
+                return self._access_token
+
+            client = self._get_client()
+            try:
+                resp = await client.post(
+                    self._auth_url,
+                    data={
+                        "grant_type": "refresh_token",
+                        "client_id": self._client_id or "cloud-services",
+                        "refresh_token": self._token,
+                    },
+                    timeout=TIMEOUT_FAST,
+                )
+                resp.raise_for_status()
+                token = resp.json().get("access_token")
+                if not isinstance(token, str) or not token:
+                    raise GalaxyError(
+                        f"SSO token exchange for server "
+                        f"'{self.server_name or 'default'}' returned "
+                        f"invalid access_token"
+                    )
+                self._access_token = token
+                return self._access_token
+            except (httpx.HTTPStatusError, httpx.RequestError, KeyError, ValueError) as exc:
+                raise GalaxyError(
+                    f"SSO token exchange failed for server "
+                    f"'{self.server_name or 'default'}'"
+                ) from exc
+
+    async def _resolve_auth_headers(self) -> dict[str, str]:
+        """Build authentication headers, exchanging SSO token if needed."""
+        headers: dict[str, str] = {"Accept": "application/json"}
+        if self._token and self._auth_url:
+            access_token = await self._ensure_access_token()
+            headers["Authorization"] = f"Bearer {access_token}"
+        elif self._token:
+            headers["Authorization"] = f"Token {self._token}"
+        return headers
+
+    async def _discover_api_root(self) -> None:
+        """Discover API root and v1 path."""
+        if self._api_root is not None:
+            return
+
+        if self._discovery_failed:
+            server_label = self.server_name or "default"
+            raise GalaxyError(
+                f"Galaxy API discovery previously failed for server "
+                f"'{server_label}'. Check the server URL and credentials "
+                f"in ansible.cfg, then restart the MCP server session "
+                f"to retry."
+            )
+
+        async with self._discovery_lock:
+            if self._api_root is not None:
+                return
+            if self._discovery_failed:
+                server_label = self.server_name or "default"
+                raise GalaxyError(
+                    f"Galaxy API discovery previously failed for server "
+                    f"'{server_label}'. Check the server URL and credentials "
+                    f"in ansible.cfg, then restart the MCP server session "
+                    f"to retry."
+                )
+
+            client = self._get_client()
+            headers = await self._resolve_auth_headers()
+            kwargs: dict[str, Any] = {
+                "headers": headers,
+                "timeout": TIMEOUT_FAST,
+            }
+            if not self._token and self._username and self._password:
+                kwargs["auth"] = httpx.BasicAuth(self._username, self._password)
+
+            n_url = self._base
+            data: dict[str, Any] | None = None
+            got_auth_error = False
+
+            try:
+                resp = await client.get(n_url, **kwargs)
+                resp.raise_for_status()
+                if len(resp.content) > MAX_DISCOVERY_RESPONSE_SIZE:
+                    raise GalaxyError("Discovery response too large")
+                data = resp.json()
+            except httpx.HTTPStatusError as exc:
+                logger.debug("Discovery probe %s returned HTTP %s", n_url, exc.response.status_code)
+                if exc.response.status_code in (401, 403):
+                    got_auth_error = True
+            except (httpx.RequestError, ValueError) as exc:
+                logger.debug("Discovery probe %s failed: %s", n_url, exc)
+
+            if data is None or "available_versions" not in data:
+                if not n_url.rstrip("/").endswith("/api"):
+                    n_url = n_url.rstrip("/") + "/api"
+                    try:
+                        resp = await client.get(n_url, **kwargs)
+                        resp.raise_for_status()
+                        if len(resp.content) > MAX_DISCOVERY_RESPONSE_SIZE:
+                            raise GalaxyError("Discovery response too large")
+                        data = resp.json()
+                    except httpx.HTTPStatusError as exc:
+                        logger.debug("Discovery probe %s returned HTTP %s", n_url, exc.response.status_code)
+                        if exc.response.status_code in (401, 403):
+                            got_auth_error = True
+                        data = None
+                    except (httpx.RequestError, ValueError) as exc:
+                        logger.debug("Discovery probe %s failed: %s", n_url, exc)
+                        data = None
+
+            server_label = self.server_name or "default"
+            if data is None or "available_versions" not in data:
+                self._discovery_failed = True
+                if got_auth_error:
+                    raise GalaxyError(
+                        f"Galaxy API root discovery failed for server "
+                        f"'{server_label}' — authentication failed "
+                        f"(HTTP 401/403). "
+                        f"Check token/credentials in ansible.cfg."
+                    )
+                raise GalaxyError(
+                    f"Could not discover Galaxy API root for server "
+                    f"'{server_label}' — "
+                    f"no 'available_versions' found. "
+                    f"Verify the server URL in ansible.cfg."
+                )
+
+            versions = data["available_versions"]
+            if "v1" not in versions:
+                self._discovery_failed = True
+                raise GalaxyError(
+                    f"Galaxy server '{server_label}' does not "
+                    f"support Galaxy API v1 (available: {', '.join(versions.keys())})."
+                )
+
+            v1_path = versions["v1"]
+            if ".." in v1_path or not _SAFE_V1_PATH_RE.match(v1_path):
+                self._discovery_failed = True
+                raise GalaxyError(
+                    f"Galaxy server '{server_label}' returned "
+                    f"unsafe v1 path. Verify the server URL in ansible.cfg."
+                )
+
+            self._api_root = n_url.rstrip("/")
+            self._v1_path = v1_path
+            logger.info(
+                "Discovered Galaxy API root: %s (v1 path: %s)",
+                self._api_root, self._v1_path,
+            )
+
+    def _build_v1_url(self, *segments: str) -> str:
+        """Build a v1 API URL from path segments using the discovered root."""
+        if self._api_root is None:
+            logger.warning("_build_v1_url called before _discover_api_root")
+        parts = [self._api_root or self._base, self._v1_path or ""]
+        parts.extend(segments)
+        return "/".join(
+            p.strip("/") for p in parts if p and p.strip("/")
+        ) + "/"
+
+    async def _api_get(
+        self,
+        path: str,
+        params: dict[str, str] | None = None,
+        timeout: httpx.Timeout = TIMEOUT_DEFAULT,
+    ) -> dict[str, Any]:
+        url = path if path.startswith(("http://", "https://")) else f"{self._base}{path}"
+        client = self._get_client()
+        kwargs: dict[str, Any] = {
+            "params": params,
+            "headers": await self._resolve_auth_headers(),
+            "timeout": timeout,
+        }
+        if not self._token and self._username and self._password:
+            kwargs["auth"] = httpx.BasicAuth(self._username, self._password)
+        resp = await client.get(url, **kwargs)
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 401 and self._auth_url:
+                stale = kwargs["headers"].get("Authorization", "")
+                cur = f"Bearer {self._access_token}" if self._access_token else ""
+                if stale == cur:
+                    self._access_token = None
+                kwargs["headers"] = await self._resolve_auth_headers()
+                resp = await client.get(url, **kwargs)
+                try:
+                    resp.raise_for_status()
+                except httpx.HTTPStatusError as retry_exc:
+                    raise GalaxyError(
+                        f"Galaxy API error (HTTP {retry_exc.response.status_code})"
+                    ) from retry_exc
+            else:
+                raise GalaxyError(
+                    f"Galaxy API error (HTTP {exc.response.status_code})"
+                ) from exc
+        content_length = resp.headers.get("content-length")
+        if content_length:
+            try:
+                if int(content_length) > MAX_GALAXY_RESPONSE_SIZE:
+                    raise GalaxyError("Galaxy API response too large")
+            except (ValueError, OverflowError):
+                pass
+        if len(resp.content) > MAX_GALAXY_RESPONSE_SIZE:
+            raise GalaxyError("Galaxy API response too large")
+        return resp.json()
+
+    async def _safe_api_get(
+        self,
+        path: str,
+        params: dict[str, str] | None = None,
+        timeout: httpx.Timeout = TIMEOUT_DEFAULT,
+    ) -> dict[str, Any]:
+        """Wrap _api_get with network error handling."""
+        try:
+            return await self._api_get(path, params=params, timeout=timeout)
+        except httpx.TimeoutException as exc:
+            raise GalaxyError("Galaxy connection timed out") from exc
+        except httpx.RequestError as exc:
+            raise GalaxyError(f"Galaxy connection error: {type(exc).__name__}") from exc
+
+    async def search_roles(self, query: str, tags: str | None = None) -> dict[str, Any]:
+        await self._discover_api_root()
+        cache_key = (*self._cache_identity(), "search", query, tags or "")
+        cached = _v1_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        params = {
+            "keywords": query,
+            "order_by": "-download_count",
+            "page_size": "10",
+        }
+        tag = _first_tag(tags)
+        if tag:
+            params["tags"] = tag
+        data = await self._safe_api_get(self._build_v1_url("roles"), params=params)
+        hits = data.get("results") or []
+        mapped = [_map_search_hit(item) for item in hits if isinstance(item, dict)]
+        result = {"query": query, "count": len(mapped), "roles": mapped}
+        _v1_cache.put(cache_key, result)
+        return result
+
+    async def fetch_role_by_name(self, namespace: str, name: str) -> dict[str, Any]:
+        await self._discover_api_root()
+        params = {"namespace": namespace, "name": name, "page_size": "1"}
+        data = await self._safe_api_get(self._build_v1_url("roles"), params=params)
+        results = data.get("results") or []
+        if not results:
+            raise GalaxyError(
+                f"Standalone role '{namespace}.{name}' not found"
+            )
+        return results[0]
+
+    async def fetch_role_content(self, role_id: int) -> dict[str, Any]:
+        await self._discover_api_root()
+        cache_key = (*self._cache_identity(), "content", str(role_id))
+        cached = _v1_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        data = await self._safe_api_get(
+            self._build_v1_url("roles", str(role_id), "content"),
+        )
+        _v1_cache.put(cache_key, data)
+        return data
+
+    async def fetch_standalone_role_doc(
+        self, role_name: str,
+    ) -> tuple[dict[str, Any], DocProvenance]:
+        from ansible_know.readme_parser import parse_role_readme
+
+        namespace, _, name = role_name.partition(".")
+        role = await self.fetch_role_by_name(namespace, name)
+        content = await self.fetch_role_content(int(role["id"]))
+        html = content.get("readme_html") or ""
+        parsed = parse_role_readme(html)
+        summary = role.get("summary_fields") or {}
+        deps = parsed.get("dependencies") or _normalize_dependencies(
+            summary.get("dependencies"),
+        )
+        versions = summary.get("versions") or []
+        latest = ""
+        if versions and isinstance(versions[0], dict):
+            latest = versions[0].get("name") or ""
+        tags_raw = summary.get("tags") or []
+        tags = [
+            t if isinstance(t, str) else str(t.get("name", ""))
+            for t in tags_raw
+        ]
+        tags = [t for t in tags if t]
+        short = parsed.get("description") or role.get("description") or ""
+        options = []
+        for var in parsed.get("variables") or []:
+            options.append({
+                "name": var["name"],
+                "type": var.get("type") or "str",
+                "required": bool(var.get("required")),
+                "default": var.get("default"),
+                "choices": var.get("choices"),
+                "description": var.get("description", ""),
+                "aliases": var.get("aliases", []),
+            })
+        metadata = {
+            "role_name": role_name,
+            "content_type": "standalone_role",
+            "short_description": short,
+            "entry_points": {
+                "main": {"description": short, "options": options},
+            },
+            "dependencies": deps,
+            "examples": parsed.get("examples") or "",
+            "tags": tags,
+            "latest_version": latest,
+            "github_user": role.get("github_user") or "",
+            "github_repo": role.get("github_repo") or "",
+            "github_branch": role.get("github_branch") or "",
+            "download_count": role.get("download_count") or 0,
+        }
+        has_html = bool(html.strip())
+        provenance: DocProvenance = {
+            "doc_source": "galaxy_v1_readme" if has_html else "galaxy_v1_metadata",
+            "doc_version": latest,
+        }
+        if has_html:
+            provenance["doc_warning"] = (
+                "Documentation parsed from Galaxy README (best-effort)."
+            )
+        else:
+            provenance["doc_warning"] = (
+                "Galaxy stored no README HTML for this standalone role; "
+                "returning catalog metadata only."
+            )
+        if self.server_name:
+            provenance["doc_source_server"] = self.server_name
+        return metadata, provenance
+
+
+__all__ = ["GalaxyV1Client", "clear_cache"]

--- a/src/ansible_know/resolution.py
+++ b/src/ansible_know/resolution.py
@@ -21,10 +21,10 @@ if TYPE_CHECKING:
         ErrorResponse,
         GalaxyClientFactory,
         GalaxyV1ClientFactory,
-        GetStandaloneRoleDocResult,
         GetModuleDocResult,
         GetPluginDocResult,
         GetRoleDocResult,
+        GetStandaloneRoleDocResult,
         StandaloneRoleSearchResult,
     )
 

--- a/src/ansible_know/resolution.py
+++ b/src/ansible_know/resolution.py
@@ -20,9 +20,12 @@ if TYPE_CHECKING:
         CollectionDocsResult,
         ErrorResponse,
         GalaxyClientFactory,
+        GalaxyV1ClientFactory,
+        GetStandaloneRoleDocResult,
         GetModuleDocResult,
         GetPluginDocResult,
         GetRoleDocResult,
+        StandaloneRoleSearchResult,
     )
 
 from ansible_know.async_utils import run_in_executor
@@ -37,6 +40,8 @@ __all__ = [
     "resolve_module_doc",
     "resolve_plugin_doc",
     "resolve_role_doc",
+    "resolve_standalone_role_doc",
+    "search_standalone_roles",
     "search_galaxy_collections",
 ]
 
@@ -53,6 +58,33 @@ async def _try_galaxy_servers(
     servers: list[GalaxyServerConfig],
     operation: Callable[..., Awaitable[Any]],
     client_factory: GalaxyClientFactory,
+    http_client: httpx.AsyncClient | None = None,
+) -> Any:
+    """Try an operation across multiple Galaxy servers in priority order.
+
+    Returns the first successful result. Raises the last GalaxyError if all fail.
+    """
+    from ansible_know.errors import GalaxyError
+
+    last_exc: GalaxyError | None = None
+    for server in servers:
+        try:
+            async with client_factory(
+                server, http_client=_select_http_client(http_client, server),
+            ) as client:
+                return await operation(client)
+        except GalaxyError as exc:
+            logger.info("Galaxy server '%s' failed: %s", server.name, exc)
+            last_exc = exc
+    if last_exc is not None:
+        raise last_exc
+    raise GalaxyError("No Galaxy servers configured")
+
+
+async def _try_v1_servers(
+    servers: list[GalaxyServerConfig],
+    operation: Callable[..., Awaitable[Any]],
+    client_factory: GalaxyV1ClientFactory,
     http_client: httpx.AsyncClient | None = None,
 ) -> Any:
     """Try an operation across multiple Galaxy servers in priority order.
@@ -469,3 +501,93 @@ async def search_galaxy_collections(
         "count": len(all_collections),
         "collections": all_collections,
     }
+
+
+async def search_standalone_roles(
+    query: str,
+    tags: str | None = None,
+    http_client: httpx.AsyncClient | None = None,
+    galaxy_servers: list[GalaxyServerConfig] | None = None,
+    v1_client_factory: GalaxyV1ClientFactory | None = None,
+) -> StandaloneRoleSearchResult:
+    """Search all configured Galaxy servers concurrently for standalone roles."""
+    from ansible_know.errors import GalaxyError
+
+    if v1_client_factory is None:
+        raise GalaxyError("No client factory configured for Galaxy search")
+
+    servers = _get_servers(galaxy_servers)
+
+    async def _query_server(server):
+        async with v1_client_factory(
+            server, http_client=_select_http_client(http_client, server),
+        ) as client:
+            result = await client.search_roles(query, tags=tags)
+        return server.name, result
+
+    tasks = [_query_server(s) for s in servers]
+    outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+
+    all_roles: list[dict[str, Any]] = []
+    seen_role_names: set[str] = set()
+    errors: list[str] = []
+
+    for i, outcome in enumerate(outcomes):
+        if isinstance(outcome, Exception):
+            logger.info(
+                "search_roles on '%s' failed: %s",
+                servers[i].name, outcome,
+            )
+            errors.append(f"{servers[i].name}: {outcome}")
+            continue
+        server_name, result = outcome
+        for role in result.get("roles", []):
+            role_name = role.get("role_name", "")
+            if role_name not in seen_role_names:
+                role["source"] = server_name
+                all_roles.append(role)
+                seen_role_names.add(role_name)
+
+    if not all_roles and errors:
+        raise GalaxyError(f"All Galaxy servers failed: {'; '.join(errors)}")
+
+    all_roles.sort(key=lambda r: r.get("download_count", 0), reverse=True)
+
+    return {
+        "query": query,
+        "count": len(all_roles),
+        "roles": all_roles,
+    }
+
+
+async def resolve_standalone_role_doc(
+    role_name: str,
+    http_client: httpx.AsyncClient | None = None,
+    galaxy_servers: list[GalaxyServerConfig] | None = None,
+    v1_client_factory: GalaxyV1ClientFactory | None = None,
+) -> GetStandaloneRoleDocResult | ErrorResponse:
+    """Resolve standalone role docs from configured Galaxy v1 servers."""
+    from ansible_know.errors import GalaxyError
+
+    if v1_client_factory is None:
+        return {"error": "No Galaxy client configured for standalone roles"}
+
+    servers = _get_servers(galaxy_servers)
+
+    async def _fetch(client):
+        return await client.fetch_standalone_role_doc(role_name)
+
+    try:
+        role_doc, galaxy_meta = await _try_v1_servers(
+            servers, _fetch, v1_client_factory, http_client,
+        )
+        result = dict(role_doc)
+        result["doc_source"] = galaxy_meta.get("doc_source", "")
+        result["doc_version"] = galaxy_meta.get("doc_version", "")
+        if "doc_warning" in galaxy_meta:
+            result["doc_warning"] = galaxy_meta["doc_warning"]
+        if "doc_source_server" in galaxy_meta:
+            result["doc_source_server"] = galaxy_meta["doc_source_server"]
+        return result
+    except GalaxyError as exc:
+        return {"error": sanitize_error(str(exc))}

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -1,6 +1,6 @@
 """Ansible Know MCP Server.
 
-Provides 20 tools, 6 resources, and 5 prompts for module, role, and plugin discovery,
+Provides 22 tools, 6 resources, and 5 prompts for module, role, and plugin discovery,
 documentation search, Galaxy collection discovery, and skill generation
 via the Model Context Protocol.
 """
@@ -35,6 +35,7 @@ from ansible_know.types import (
     GetModuleDocResult,
     GetPluginDocResult,
     GetRoleDocResult,
+    GetStandaloneRoleDocResult,
     ManifestResult,
     ModuleMetadata,
     PackageAsPluginResult,
@@ -43,6 +44,7 @@ from ansible_know.types import (
     PluginMetadata,
     SearchDocsEntry,
     SkillEntry,
+    StandaloneRoleSearchResult,
     VersionInfo,
 )
 from ansible_know.validation import (
@@ -61,6 +63,7 @@ from ansible_know.validation import (
     validate_plugin_type,
     validate_query,
     validate_skill_name,
+    validate_standalone_role_name,
     validate_tags,
     validate_version,
 )
@@ -172,8 +175,10 @@ mcp = FastMCP(
         "(2) ensure_collection to install one for this session, "
         "(3) search_modules/search_plugins/get_collection_manifest to find content, "
         "(4) get_module_doc, get_role_doc, or get_plugin_doc for structured docs, "
-        "(5) search_docs for conceptual guides, then fetch_doc to retrieve full content, "
-        "(6) generate_skill, generate_role_skill, or generate_plugin_skill for skill packages. "
+        "(5) for standalone/legacy Galaxy roles, use search_standalone_roles then "
+        "get_standalone_role_doc with a 2-part namespace.role identifier, "
+        "(6) search_docs for conceptual guides, then fetch_doc to retrieve full content, "
+        "(7) generate_skill, generate_role_skill, or generate_plugin_skill for skill packages. "
         "Resources: server://version for version and upgrade status, "
         "galaxy://installed for session collections, "
         "docs://sources for configured doc sources, "
@@ -197,6 +202,15 @@ def _galaxy_factory(ctx: Context | None = None):
             config, http_client=http_client,
             enrichment_semaphore=semaphore,
         )
+
+    return _factory
+
+
+def _galaxy_v1_factory(ctx: Context | None = None):
+    from ansible_know.galaxy_v1 import GalaxyV1Client
+
+    def _factory(config, http_client=None):
+        return GalaxyV1Client.from_config(config, http_client=http_client)
 
     return _factory
 
@@ -487,6 +501,42 @@ async def get_role_doc(
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def get_standalone_role_doc(
+    role_name: Annotated[
+        str,
+        "Standalone role identifier from search_standalone_roles (namespace.role).",
+    ],
+    ctx: Context | None = None,
+) -> GetStandaloneRoleDocResult | ErrorResponse:
+    """Get standalone role documentation for a 2-part namespace.role identifier.
+
+    Use this for standalone roles discovered with search_standalone_roles.
+    This tool does not replace get_role_doc for collection roles.
+    """
+    logger.info("get_standalone_role_doc role=%r", role_name)
+    await _maybe_warn_upgrade(ctx)
+    try:
+        validate_standalone_role_name(role_name)
+    except ValidationError as exc:
+        return {"error": str(exc)}
+
+    try:
+        from ansible_know import resolution
+
+        state = await _get_state(ctx)
+        http_client = _get_http_client(ctx)
+        return await resolution.resolve_standalone_role_doc(
+            role_name,
+            v1_client_factory=_galaxy_v1_factory(ctx),
+            http_client=http_client,
+            galaxy_servers=state.galaxy_servers,
+        )
+    except Exception as exc:
+        logger.warning("get_standalone_role_doc failed: %s", exc)
+        return {"error": sanitize_error(str(exc))}
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def get_plugin_doc(
     plugin_name: Annotated[str, "Fully-qualified plugin name (e.g. 'netbox.netbox.nb_lookup')"],
     plugin_type: Annotated[
@@ -648,6 +698,51 @@ async def search_collections(
         )
     except Exception as exc:
         logger.warning("search_collections failed: %s", exc)
+        return {"error": sanitize_error(str(exc))}
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def search_standalone_roles(
+    query: Annotated[str, "Search keyword for Galaxy standalone/legacy roles (keywords search)"],
+    tags: Annotated[
+        str | None,
+        "Optional Galaxy tag filter. If comma-separated, only the first tag segment is used.",
+    ] = None,
+    ctx: Context | None = None,
+) -> StandaloneRoleSearchResult | ErrorResponse:
+    """Search Galaxy standalone/legacy roles by keyword.
+
+    This targets standalone (2-part) roles. Collection roles use
+    search_collections/get_role_doc. tags accepts a single Galaxy tag; if
+    comma-separated values are provided, only the first segment is sent.
+
+    If public Galaxy is disabled and no configured server supports v1 role
+    endpoints, expect a v1-unsupported error.
+    """
+    logger.info("search_standalone_roles query=%r tags=%r", query, tags)
+    await _maybe_warn_upgrade(ctx)
+    try:
+        validate_query(query)
+        if tags:
+            validate_tags(tags)
+    except ValidationError as exc:
+        return {"error": str(exc)}
+
+    try:
+        from ansible_know import resolution
+
+        state = await _get_state(ctx)
+        http_client = _get_http_client(ctx)
+        v1_tags = tags.split(",", 1)[0].strip() if tags else None
+        return await resolution.search_standalone_roles(
+            query,
+            tags=v1_tags,
+            v1_client_factory=_galaxy_v1_factory(ctx),
+            http_client=http_client,
+            galaxy_servers=state.galaxy_servers,
+        )
+    except Exception as exc:
+        logger.warning("search_standalone_roles failed: %s", exc)
         return {"error": sanitize_error(str(exc))}
 
 
@@ -1644,13 +1739,15 @@ _VALID_CACHE_SCOPES = {"galaxy", "docs"}
 async def clear_cache(
     scope: Annotated[
         str | None,
-        "Cache scope to clear: 'galaxy' (version + docs-blob), 'docs' (doc manifests), "
+        "Cache scope to clear: 'galaxy' (version + docs-blob + standalone-role v1), "
+        "'docs' (doc manifests), "
         "or omit to clear all caches.",
     ] = None,
 ) -> ClearCacheResult | ErrorResponse:
     """Clear server caches.
 
-    Clears Galaxy version/docs-blob caches, doc manifest/page caches, or both.
+    Clears Galaxy version/docs-blob caches, standalone-role v1 caches,
+    doc manifest/page caches, or both.
     Useful when cached data becomes stale during long-running sessions.
     """
     logger.info("clear_cache scope=%r", scope)
@@ -1663,6 +1760,9 @@ async def clear_cache(
         from ansible_know import galaxy
         galaxy.clear_cache()
         cleared.extend(["galaxy_versions", "galaxy_blobs"])
+        from ansible_know import galaxy_v1
+        galaxy_v1.clear_cache()
+        cleared.append("galaxy_v1")
 
     if scope in (None, "docs"):
         from ansible_know import docs

--- a/src/ansible_know/server.py
+++ b/src/ansible_know/server.py
@@ -733,6 +733,8 @@ async def search_standalone_roles(
 
         state = await _get_state(ctx)
         http_client = _get_http_client(ctx)
+        # Spec §7.1: tool boundary sends only first tag segment.
+        # GalaxyV1Client._first_tag is defense-in-depth.
         v1_tags = tags.split(",", 1)[0].strip() if tags else None
         return await resolution.search_standalone_roles(
             query,

--- a/src/ansible_know/types.py
+++ b/src/ansible_know/types.py
@@ -256,6 +256,51 @@ class CollectionSearchResult(TypedDict):
     collections: list[CollectionInfo]
 
 
+class StandaloneRoleSearchEntry(TypedDict, total=False):
+    """Single standalone role from search_standalone_roles."""
+
+    role_name: str
+    description: str
+    tags: list[str]
+    latest_version: str
+    download_count: int
+    github_user: str
+    github_repo: str
+    source: str
+
+
+class StandaloneRoleSearchResult(TypedDict):
+    """Result of search_standalone_roles tool."""
+
+    query: str
+    count: int
+    roles: list[StandaloneRoleSearchEntry]
+
+
+class _GetStandaloneRoleDocResultBase(TypedDict):
+    role_name: str
+    content_type: str
+    doc_source: str
+
+
+class GetStandaloneRoleDocResult(_GetStandaloneRoleDocResultBase, total=False):
+    """Result of get_standalone_role_doc. No ``error`` field — failures are ErrorResponse."""
+
+    short_description: str
+    entry_points: dict[str, EntryPointInfo]
+    dependencies: list[str]
+    examples: str
+    tags: list[str]
+    latest_version: str
+    github_user: str
+    github_repo: str
+    github_branch: str
+    download_count: int
+    doc_version: str
+    doc_warning: str
+    doc_source_server: str
+
+
 class _GetModuleDocResultBase(ModuleMetadata):
     """Required fields for get_module_doc tool return."""
 
@@ -493,3 +538,29 @@ class GalaxyClientFactory(Protocol):
         config: GalaxyServerConfig,
         http_client: httpx.AsyncClient | None = None,
     ) -> GalaxyDocClient: ...
+
+
+class GalaxyV1DocClient(Protocol):
+    """v1 standalone-role client. Not a GalaxyDocClient."""
+
+    async def search_roles(
+        self, query: str, tags: str | None = None,
+    ) -> dict[str, Any]: ...
+
+    async def fetch_standalone_role_doc(
+        self, role_name: str,
+    ) -> tuple[dict[str, Any], DocProvenance]: ...
+
+    async def __aenter__(self) -> GalaxyV1DocClient: ...
+
+    async def __aexit__(self, *exc: object) -> None: ...
+
+
+class GalaxyV1ClientFactory(Protocol):
+    """Factory that creates GalaxyV1DocClient instances from config."""
+
+    def __call__(
+        self,
+        config: GalaxyServerConfig,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> GalaxyV1DocClient: ...

--- a/src/ansible_know/validation.py
+++ b/src/ansible_know/validation.py
@@ -31,6 +31,7 @@ __all__ = [
     "validate_plugin_type",
     "validate_query",
     "validate_skill_name",
+    "validate_standalone_role_name",
     "validate_tags",
     "validate_version",
 ]
@@ -83,6 +84,39 @@ def validate_namespace(ns: str) -> None:
             "Invalid collection namespace: expected format 'namespace.collection' "
             "with alphanumeric/underscore segments."
         )
+
+
+_STANDALONE_ROLE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+
+
+def validate_standalone_role_name(name: str) -> None:
+    """Validate a Galaxy standalone role identifier ``namespace.role``."""
+    if not name or "/" in name or "\\" in name:
+        raise ValidationError(
+            "Invalid standalone role name: expected format 'namespace.role' "
+            "with alphanumeric, hyphen, or underscore segments."
+        )
+    parts = name.split(".")
+    if len(parts) == 3:
+        raise ValidationError(
+            "Invalid standalone role name: expected 'namespace.role'. "
+            "Collection roles use get_role_doc() with a 3-part FQCN."
+        )
+    if len(parts) != 2:
+        raise ValidationError(
+            "Invalid standalone role name: expected format 'namespace.role' "
+            "with alphanumeric, hyphen, or underscore segments."
+        )
+    for part in parts:
+        if (
+            not part
+            or len(part) > MAX_NAMESPACE_LENGTH
+            or not _STANDALONE_ROLE_SEGMENT_RE.match(part)
+        ):
+            raise ValidationError(
+                "Invalid standalone role name: expected format 'namespace.role' "
+                "with alphanumeric, hyphen, or underscore segments."
+            )
 
 
 def validate_lola_module_name(name: str) -> None:

--- a/tests/integration/test_galaxy_api.py
+++ b/tests/integration/test_galaxy_api.py
@@ -86,3 +86,25 @@ class TestRealGalaxyAPIRoles:
         if result["count"] > 0:
             first = result["collections"][0]
             assert "role_count" in first
+
+
+class TestRealGalaxyAPIV1Roles:
+    @pytest.mark.asyncio
+    async def test_search_standalone_roles_rhel9_cis(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        async with GalaxyV1Client() as client:
+            result = await client.search_roles("rhel9_cis")
+        assert result["count"] >= 1
+        names = [r["role_name"] for r in result["roles"]]
+        assert any("rhel9_cis" in n for n in names)
+
+    @pytest.mark.asyncio
+    async def test_fetch_ansible_lockdown_rhel9_cis(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        async with GalaxyV1Client() as client:
+            meta, prov = await client.fetch_standalone_role_doc(
+                "ansible-lockdown.rhel9_cis",
+            )
+        assert meta["role_name"] == "ansible-lockdown.rhel9_cis"
+        assert meta["content_type"] == "standalone_role"
+        assert prov["doc_source"] in ("galaxy_v1_readme", "galaxy_v1_metadata")

--- a/tests/test_galaxy_v1.py
+++ b/tests/test_galaxy_v1.py
@@ -213,3 +213,44 @@ class TestV1Discovery:
             gc = _skip_discovery(GalaxyV1Client())
             with pytest.raises(GalaxyError):
                 await gc.search_roles("cis")
+
+
+class TestV1DoesNotPoisonV3:
+    @pytest.mark.asyncio
+    async def test_missing_v1_does_not_set_v3_discovery_failed(self):
+        from ansible_know.galaxy import GalaxyClient
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+
+        config = GalaxyServerConfig(
+            name="hub", url="https://hub.example/api",
+        )
+        v3_only = {"available_versions": {"v3": "v3/"}}
+        search_payload = {
+            "data": [],
+            "meta": {"count": 0},
+        }
+
+        def _route(url, **kwargs):
+            resp = MagicMock()
+            resp.content = b"{}"
+            resp.headers = {}
+            resp.raise_for_status.return_value = None
+            if "collection-versions" in str(url) or "search" in str(url):
+                resp.json.return_value = search_payload
+            else:
+                resp.json.return_value = v3_only
+            return resp
+
+        shared = AsyncMock()
+        shared.get.side_effect = _route
+        v3 = GalaxyClient.from_config(config, http_client=shared)
+        v1 = GalaxyV1Client.from_config(config, http_client=shared)
+        with pytest.raises(GalaxyError, match="v1"):
+            await v1.search_roles("cis")
+        assert v3._discovery_failed is False
+        assert v3._v3_path is None
+        result = await v3.search_collections("net")
+        assert result["count"] == 0
+        assert v3._discovery_failed is False
+        assert v3._v3_path == "v3/"

--- a/tests/test_galaxy_v1.py
+++ b/tests/test_galaxy_v1.py
@@ -1,0 +1,215 @@
+"""Tests for ansible_know.galaxy_v1."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from ansible_know.errors import GalaxyError
+from tests.conftest import SAMPLE_ROLE_README_HTML
+
+SAMPLE_ROLE = {
+    "id": 42,
+    "username": "ansible-lockdown",
+    "name": "rhel9_cis",
+    "description": "CIS Benchmark for RHEL 9",
+    "github_user": "ansible-lockdown",
+    "github_repo": "RHEL9-CIS",
+    "github_branch": "devel",
+    "download_count": 9000,
+    "summary_fields": {
+        "tags": ["system", "security"],
+        "versions": [{"name": "1.2.3"}],
+        "dependencies": [{"namespace": "geerlingguy", "name": "repo"}],
+    },
+}
+
+SAMPLE_LIST = {"count": 1, "next": None, "previous": None, "results": [SAMPLE_ROLE]}
+
+
+def _mock_http(json_body, status=200):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = json_body
+    mock_resp.content = b"{}"
+    mock_resp.headers = {}
+    if status >= 400:
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "err", request=MagicMock(), response=MagicMock(status_code=status),
+        )
+    else:
+        mock_resp.raise_for_status.return_value = None
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+def _skip_discovery(client):
+    client._api_root = "https://galaxy.ansible.com/api"
+    client._v1_path = "v1/"
+    return client
+
+
+class TestSearchRoles:
+    @pytest.mark.asyncio
+    async def test_uses_keywords_order_by_page_size(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http(SAMPLE_LIST)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            result = await gc.search_roles("rhel9_cis")
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["keywords"] == "rhel9_cis"
+        assert params["order_by"] == "-download_count"
+        assert params["page_size"] == "10"
+        assert "search" not in params
+        assert "keyword" not in params
+        url = mock_client.get.call_args.args[0]
+        assert url.endswith("/api/v1/roles/")
+        assert result["roles"][0]["role_name"] == "ansible-lockdown.rhel9_cis"
+
+    @pytest.mark.asyncio
+    async def test_tags_sends_first_segment_only(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http(SAMPLE_LIST)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            await gc.search_roles("cis", tags="system,security")
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["tags"] == "system"
+
+    @pytest.mark.asyncio
+    async def test_does_not_call_content_during_search(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http(SAMPLE_LIST)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            await gc.search_roles("rhel9_cis")
+        urls = [c.args[0] for c in mock_client.get.call_args_list]
+        assert all("/content/" not in u for u in urls)
+
+
+class TestFetchRoleByName:
+    @pytest.mark.asyncio
+    async def test_lookup_uses_namespace_and_name_not_owner(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http(SAMPLE_LIST)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            role = await gc.fetch_role_by_name("ansible-lockdown", "rhel9_cis")
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["namespace"] == "ansible-lockdown"
+        assert params["name"] == "rhel9_cis"
+        assert "owner__username" not in params
+        assert role["id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_empty_results_raises(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http({"count": 0, "results": []})
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            with pytest.raises(GalaxyError, match="not found"):
+                await gc.fetch_role_by_name("missing", "role")
+
+
+class TestFetchStandaloneRoleDoc:
+    @pytest.mark.asyncio
+    async def test_parses_readme_html(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        list_resp = MagicMock()
+        list_resp.json.return_value = SAMPLE_LIST
+        list_resp.content = b"{}"
+        list_resp.headers = {}
+        list_resp.raise_for_status.return_value = None
+        content_resp = MagicMock()
+        content_resp.json.return_value = {
+            "readme": "README.md",
+            "readme_html": SAMPLE_ROLE_README_HTML,
+        }
+        content_resp.content = b"{}"
+        content_resp.headers = {}
+        content_resp.raise_for_status.return_value = None
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [list_resp, content_resp]
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            meta, prov = await gc.fetch_standalone_role_doc(
+                "ansible-lockdown.rhel9_cis",
+            )
+        content_url = mock_client.get.call_args_list[1].args[0]
+        assert content_url.endswith("/api/v1/roles/42/content/")
+        assert meta["content_type"] == "standalone_role"
+        assert meta["role_name"] == "ansible-lockdown.rhel9_cis"
+        assert prov["doc_source"] == "galaxy_v1_readme"
+        assert "main" in meta["entry_points"]
+        assert meta["github_branch"] == "devel"
+        assert "geerlingguy.repo" in meta["dependencies"] or meta["dependencies"]
+
+    @pytest.mark.asyncio
+    async def test_empty_html_is_metadata_success(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        list_resp = MagicMock()
+        list_resp.json.return_value = SAMPLE_LIST
+        list_resp.content = b"{}"
+        list_resp.headers = {}
+        list_resp.raise_for_status.return_value = None
+        content_resp = MagicMock()
+        content_resp.json.return_value = {"readme": "README.md", "readme_html": ""}
+        content_resp.content = b"{}"
+        content_resp.headers = {}
+        content_resp.raise_for_status.return_value = None
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [list_resp, content_resp]
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            meta, prov = await gc.fetch_standalone_role_doc(
+                "ansible-lockdown.rhel9_cis",
+            )
+        assert prov["doc_source"] == "galaxy_v1_metadata"
+        assert meta["short_description"] == "CIS Benchmark for RHEL 9"
+        assert "doc_warning" in prov
+
+    @pytest.mark.asyncio
+    async def test_hyphenated_name_roundtrip(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        list_resp = MagicMock()
+        list_resp.json.return_value = SAMPLE_LIST
+        list_resp.content = b"{}"
+        list_resp.headers = {}
+        list_resp.raise_for_status.return_value = None
+        content_resp = MagicMock()
+        content_resp.json.return_value = {"readme": "README.md", "readme_html": "<p>x</p>"}
+        content_resp.content = b"{}"
+        content_resp.headers = {}
+        content_resp.raise_for_status.return_value = None
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [list_resp, content_resp]
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            meta, _ = await gc.fetch_standalone_role_doc("ansible-lockdown.rhel9_cis")
+        params = mock_client.get.call_args_list[0].kwargs["params"]
+        assert params["namespace"] == "ansible-lockdown"
+        assert params["name"] == "rhel9_cis"
+        assert meta["role_name"] == "ansible-lockdown.rhel9_cis"
+
+
+class TestV1Discovery:
+    @pytest.mark.asyncio
+    async def test_requires_v1_not_v3(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http({"available_versions": {"v3": "v3/"}})
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = GalaxyV1Client(base_url="https://hub.example")
+            with pytest.raises(GalaxyError, match="v1"):
+                await gc.search_roles("cis")
+
+    @pytest.mark.asyncio
+    async def test_v1_http_404_raises_galaxy_error(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http({}, status=404)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            with pytest.raises(GalaxyError):
+                await gc.search_roles("cis")

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -560,3 +560,157 @@ class TestResolveCollectionModuleDocs:
             )
 
         mock_fetch.assert_called_once_with("netbox.netbox", version="3.20.0")
+
+
+class _FakeV1:
+    def __init__(self, search=None, doc=None, error=None):
+        self._search = search
+        self._doc = doc
+        self._error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return None
+
+    async def search_roles(self, query, tags=None):
+        if self._error:
+            raise self._error
+        return self._search
+
+    async def fetch_standalone_role_doc(self, role_name):
+        if self._error:
+            raise self._error
+        return self._doc
+
+
+def _v1_factory_map(mapping):
+    def _factory(config, http_client=None):
+        return mapping[config.name]
+    return _factory
+
+
+class TestSearchStandaloneRoles:
+    @pytest.mark.asyncio
+    async def test_merges_and_ranks(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import search_standalone_roles
+        s1 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        s2 = GalaxyServerConfig(name="hub", url="https://hub.example")
+        f1 = _FakeV1(search={"roles": [
+            {"role_name": "a.one", "download_count": 10},
+        ]})
+        f2 = _FakeV1(search={"roles": [
+            {"role_name": "b.two", "download_count": 50},
+        ]})
+        result = await search_standalone_roles(
+            "cis", galaxy_servers=[s1, s2],
+            v1_client_factory=_v1_factory_map({"galaxy": f1, "hub": f2}),
+        )
+        assert result["count"] == 2
+        assert result["roles"][0]["role_name"] == "b.two"
+        assert result["roles"][0]["source"] == "hub"
+
+    @pytest.mark.asyncio
+    async def test_dedupes_by_role_name(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import search_standalone_roles
+        s1 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        s2 = GalaxyServerConfig(name="hub", url="https://hub.example")
+        hit = {"role_name": "a.one", "download_count": 1}
+        result = await search_standalone_roles(
+            "cis", galaxy_servers=[s1, s2],
+            v1_client_factory=_v1_factory_map({
+                "galaxy": _FakeV1(search={"roles": [hit]}),
+                "hub": _FakeV1(search={"roles": [hit]}),
+            }),
+        )
+        assert result["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_v1_less_server(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import search_standalone_roles
+        s1 = GalaxyServerConfig(name="hub", url="https://hub.example")
+        s2 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        result = await search_standalone_roles(
+            "cis", galaxy_servers=[s1, s2],
+            v1_client_factory=_v1_factory_map({
+                "hub": _FakeV1(error=GalaxyError("does not support Galaxy API v1")),
+                "galaxy": _FakeV1(search={"roles": [
+                    {"role_name": "a.one", "download_count": 1},
+                ]}),
+            }),
+        )
+        assert result["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_hits_succeed(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import search_standalone_roles
+        s1 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        result = await search_standalone_roles(
+            "zzzz", galaxy_servers=[s1],
+            v1_client_factory=_v1_factory_map({
+                "galaxy": _FakeV1(search={"roles": []}),
+            }),
+        )
+        assert result == {"query": "zzzz", "count": 0, "roles": []}
+
+    @pytest.mark.asyncio
+    async def test_all_fail_raises(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import search_standalone_roles
+        s1 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        with pytest.raises(GalaxyError, match="All Galaxy servers failed"):
+            await search_standalone_roles(
+                "cis", galaxy_servers=[s1],
+                v1_client_factory=_v1_factory_map({
+                    "galaxy": _FakeV1(error=GalaxyError("timeout")),
+                }),
+            )
+
+
+class TestResolveStandaloneRoleDoc:
+    @pytest.mark.asyncio
+    async def test_first_success_wins(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import resolve_standalone_role_doc
+        s1 = GalaxyServerConfig(name="hub", url="https://hub.example")
+        s2 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        doc = ({
+            "role_name": "ansible-lockdown.rhel9_cis",
+            "content_type": "standalone_role",
+            "short_description": "CIS",
+            "entry_points": {"main": {"description": "CIS", "options": []}},
+            "dependencies": [],
+            "examples": "",
+        }, {"doc_source": "galaxy_v1_readme", "doc_version": "1.0"})
+        result = await resolve_standalone_role_doc(
+            "ansible-lockdown.rhel9_cis",
+            galaxy_servers=[s1, s2],
+            v1_client_factory=_v1_factory_map({
+                "hub": _FakeV1(error=GalaxyError("does not support Galaxy API v1")),
+                "galaxy": _FakeV1(doc=doc),
+            }),
+        )
+        assert result["doc_source"] == "galaxy_v1_readme"
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_not_found_is_error_response(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import resolve_standalone_role_doc
+        s1 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        result = await resolve_standalone_role_doc(
+            "missing.role",
+            galaxy_servers=[s1],
+            v1_client_factory=_v1_factory_map({
+                "galaxy": _FakeV1(error=GalaxyError(
+                    "Standalone role 'missing.role' not found"
+                )),
+            }),
+        )
+        assert result == {"error": "Standalone role 'missing.role' not found"}
+        assert "doc_source" not in result

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1753,6 +1753,76 @@ class TestSearchCollectionsTool:
         assert "error" in result
 
 
+class TestSearchStandaloneRolesTool:
+    @pytest.mark.asyncio
+    async def test_returns_results(self):
+        mock_result = {
+            "query": "rhel9_cis",
+            "count": 1,
+            "roles": [{"role_name": "ansible-lockdown.rhel9_cis", "download_count": 9}],
+        }
+        with patch(
+            "ansible_know.resolution.search_standalone_roles",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            from ansible_know.server import search_standalone_roles
+            result = await search_standalone_roles("rhel9_cis")
+        assert result["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_query(self):
+        from ansible_know.server import search_standalone_roles
+        result = await search_standalone_roles("")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_handles_galaxy_error(self):
+        from ansible_know.errors import GalaxyError
+        with patch(
+            "ansible_know.resolution.search_standalone_roles",
+            new_callable=AsyncMock,
+            side_effect=GalaxyError("timeout"),
+        ):
+            from ansible_know.server import search_standalone_roles
+            result = await search_standalone_roles("cis")
+        assert "error" in result
+
+
+class TestGetStandaloneRoleDocTool:
+    @pytest.mark.asyncio
+    async def test_returns_doc(self):
+        mock_result = {
+            "role_name": "ansible-lockdown.rhel9_cis",
+            "content_type": "standalone_role",
+            "doc_source": "galaxy_v1_readme",
+            "entry_points": {"main": {"description": "", "options": []}},
+        }
+        with patch(
+            "ansible_know.resolution.resolve_standalone_role_doc",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            from ansible_know.server import get_standalone_role_doc
+            result = await get_standalone_role_doc("ansible-lockdown.rhel9_cis")
+        assert result["content_type"] == "standalone_role"
+
+    @pytest.mark.asyncio
+    async def test_rejects_three_part_fqcn(self):
+        from ansible_know.server import get_standalone_role_doc
+        result = await get_standalone_role_doc(
+            "fedora.linux_system_roles.timesync",
+        )
+        assert "error" in result
+        assert "get_role_doc" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_role_doc_still_requires_three_part(self):
+        from ansible_know.server import get_role_doc
+        result = await get_role_doc("ansible-lockdown.rhel9_cis")
+        assert "error" in result
+
+
 class TestLifespanHttpClient:
     @pytest.mark.asyncio
     async def test_get_module_doc_passes_lifespan_http_client(self, mock_ansible_doc):
@@ -2337,11 +2407,13 @@ class TestClearCache:
         from ansible_know.server import clear_cache
 
         with patch("ansible_know.galaxy.clear_cache") as mock_galaxy, \
+             patch("ansible_know.galaxy_v1.clear_cache") as mock_galaxy_v1, \
              patch("ansible_know.docs.clear_cache") as mock_docs:
             result = await clear_cache()
 
-        assert result == {"cleared": ["galaxy_versions", "galaxy_blobs", "doc_manifests", "doc_pages"]}
+        assert result == {"cleared": ["galaxy_versions", "galaxy_blobs", "galaxy_v1", "doc_manifests", "doc_pages"]}
         mock_galaxy.assert_called_once()
+        mock_galaxy_v1.assert_called_once()
         mock_docs.assert_called_once()
 
     @pytest.mark.asyncio
@@ -2349,11 +2421,13 @@ class TestClearCache:
         from ansible_know.server import clear_cache
 
         with patch("ansible_know.galaxy.clear_cache") as mock_galaxy, \
+             patch("ansible_know.galaxy_v1.clear_cache") as mock_galaxy_v1, \
              patch("ansible_know.docs.clear_cache") as mock_docs:
             result = await clear_cache(scope="galaxy")
 
-        assert result == {"cleared": ["galaxy_versions", "galaxy_blobs"]}
+        assert result == {"cleared": ["galaxy_versions", "galaxy_blobs", "galaxy_v1"]}
         mock_galaxy.assert_called_once()
+        mock_galaxy_v1.assert_called_once()
         mock_docs.assert_not_called()
 
     @pytest.mark.asyncio
@@ -2361,11 +2435,13 @@ class TestClearCache:
         from ansible_know.server import clear_cache
 
         with patch("ansible_know.galaxy.clear_cache") as mock_galaxy, \
+             patch("ansible_know.galaxy_v1.clear_cache") as mock_galaxy_v1, \
              patch("ansible_know.docs.clear_cache") as mock_docs:
             result = await clear_cache(scope="docs")
 
         assert result == {"cleared": ["doc_manifests", "doc_pages"]}
         mock_galaxy.assert_not_called()
+        mock_galaxy_v1.assert_not_called()
         mock_docs.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -26,6 +26,7 @@ from ansible_know.validation import (
     validate_path_containment,
     validate_query,
     validate_skill_name,
+    validate_standalone_role_name,
     validate_tags,
     validate_version,
 )
@@ -85,6 +86,37 @@ class TestValidateFqcn:
     def test_rejects_empty_segments(self):
         with pytest.raises(ValidationError):
             validate_fqcn("a..c")
+
+
+class TestValidateStandaloneRoleName:
+    def test_accepts_hyphenated_namespace(self):
+        validate_standalone_role_name("ansible-lockdown.rhel9_cis")
+
+    def test_accepts_mixed_case(self):
+        validate_standalone_role_name("MindPointGroup.RHEL9_CIS")
+
+    def test_accepts_underscore_role(self):
+        validate_standalone_role_name("geerlingguy.elasticsearch_curator")
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValidationError):
+            validate_standalone_role_name("")
+
+    def test_rejects_one_part(self):
+        with pytest.raises(ValidationError):
+            validate_standalone_role_name("rhel9_cis")
+
+    def test_rejects_three_part_and_points_at_get_role_doc(self):
+        with pytest.raises(ValidationError, match="get_role_doc"):
+            validate_standalone_role_name("fedora.linux_system_roles.timesync")
+
+    def test_rejects_path_slash(self):
+        with pytest.raises(ValidationError):
+            validate_standalone_role_name("foo/bar.role")
+
+    def test_rejects_leading_hyphen_segment(self):
+        with pytest.raises(ValidationError):
+            validate_standalone_role_name("-bad.role")
 
 
 class TestValidateNamespace:


### PR DESCRIPTION
## Summary

- Add Galaxy v1 `search_standalone_roles` and `get_standalone_role_doc` MCP tools for 2-part `namespace.role` identifiers (hyphens allowed).
- Keep collection v3 paths unchanged: `GalaxyV1Client` shares transport/auth only; `galaxy.py` does not import v1.
- README comes from Galaxy `/api/v1/roles/{id}/content/` `readme_html` via existing `parse_role_readme()` (no GitHub fetch in this PR).

Closes #230

## Changes

- `src/ansible_know/galaxy_v1.py` — new `GalaxyV1Client` (keywords search, namespace+name lookup, content parse, separate v1 cache).
- `src/ansible_know/validation.py` — `validate_standalone_role_name`.
- `src/ansible_know/types.py` — search/doc TypedDicts + `GalaxyV1ClientFactory` (does not extend `GalaxyDocClient`).
- `src/ansible_know/resolution.py` — `search_standalone_roles`, `resolve_standalone_role_doc`, `_try_v1_servers`.
- `src/ansible_know/server.py` — two read-only tools, `_galaxy_v1_factory`, `clear_cache` also clears v1.
- Tests: `tests/test_galaxy_v1.py`, plus validation/resolution/server and opt-in integration cases.
- Docs: CLAUDE.md, README.md, `docs/architecture/service-contracts.md` (20→22 tools); spec+plan under `docs/superpowers/`.

## Test plan

- [ ] `pytest tests/ -v` (unit; no ansible-core required)
- [ ] `ruff check src/ tests/`
- [ ] Confirm `rg galaxy_v1 src/ansible_know/galaxy.py` has no matches
- [ ] `get_role_doc` still rejects 2-part names; `get_standalone_role_doc` rejects 3-part FQCNs
- [ ] Optional: `pytest tests/ --run-integration` for live v1 `rhel9_cis` checks

## Review findings addressed

- **Plan review** (`git-plan`): spec/plan locked on this branch before implementation (Approach B: dedicated v1 client).
- **Implementation review** (`git-implement`): per-task spec+quality gates plus whole-branch review; tags-split comment added at the tool boundary.

## Acknowledged debt

- `_try_v1_servers` duplicates `_try_galaxy_servers` on purpose (spec: do not genericize GalaxyDocClient). Not an RFE.
- RFE https://github.com/leogallego/ansible-know-mcp/issues/233 : require HTTPS for SSO `auth_url` in `GalaxyClient` and `GalaxyV1Client` (today both warn and continue).
- RFE https://github.com/leogallego/ansible-know-mcp/issues/234 : malformed Galaxy payloads should become `GalaxyError` so the next server is tried.
- Spec follow-ups: GitHub README fallback (#235), `generate_standalone_role_skill` (#236), `ansible-galaxy role install` (#237).
- Minor tests not filed: backslash/empty-segment validator cases; isolation HTTP 404; tautological dependencies assertion (plan-mandated).
- Related to #233, #234, #235, #236, #237.

## Stack position

- **Base**: `main`
- **Next**: end of chain

Assisted-by: Cursor (Grok 4.6)
