### PR TITLE
chore: sync uv.lock and Unreleased placeholder for v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet.
+
 ## [0.9.0] - 2026-08-18
 
 ### Added

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "ansible-know-mcp"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- Align `uv.lock` package version with `pyproject.toml` `0.9.0` so the lockfile matches the release cut.
- Add an Unreleased `- Nothing yet.` bullet so the empty next-version section is distinct from `[0.9.0]`.

## Changes

- `uv.lock`: local package `ansible-know-mcp` `0.8.0` → `0.9.0`
- `CHANGELOG.md`: placeholder under `[Unreleased]`

## Test plan

- [ ] Confirm `uv.lock` lists `ansible-know-mcp` version `0.9.0`
- [ ] Confirm `[Unreleased]` has a single `- Nothing yet.` bullet above `[0.9.0]`
- [ ] CI green on this PR

## Review findings addressed

- **Plan review** (`git-plan`): skipped (trivial lock/changelog follow-up)
- **Implementation review** (`git-implement`): skipped (two-line chore)

## Acknowledged debt

None.

## Stack position

- **Base**: `main`
- **Next**: end — tag `v0.9.0` after merge

Assisted-by: Cursor (Grok 4.6)