### PR TITLE
fix: tokenize Galaxy v1 role search and skip Hub empty-hit failures

### DIFF
--- a/docs/superpowers/specs/2026-08-18-standalone-galaxy-roles-design.md
+++ b/docs/superpowers/specs/2026-08-18-standalone-galaxy-roles-design.md
@@ -301,10 +301,29 @@ that in the tool docstring.
 
 Resolution: query all configured Galaxy servers concurrently (same gather
 pattern as `search_galaxy_collections`). Skip servers that raise (no v1,
-404, timeout). Dedupe on `{username}.{name}`. Rank by `download_count`
-descending. Empty merged results are **success** (`count: 0`). If every
-server fails, **raise** `GalaxyError` (server.py turns it into
-`{"error": ...}`), matching `search_galaxy_collections`.
+404, timeout) — typical Automation Hub / certified / validated endpoints.
+Do **not** restrict search to `galaxy.ansible.com` by URL; private
+galaxy-ng may expose v1. Dedupe on `{username}.{name}`. Rank by
+`download_count` descending (that ranking is the relevance pass — do not
+permute letter-case variants).
+
+Send ``keywords`` as **repeated** query params (Galaxy ``getlist`` AND):
+tokenize on whitespace / hyphen / underscore, lowercase, drop stopwords
+(``role``, ``manage``, ``want``, ``ansible``, …). ``win openssh`` becomes
+``keywords=win&keywords=openssh``, which matches ``win_openssh``. A single
+phrase ``keywords=win openssh`` does **not** match.
+
+If the AND returns zero hits and more than one token remains, retry with
+the **longest** token only (so ``windows openssh`` still finds
+``win_openssh`` via ``openssh``).
+
+Empty merged results are **success** (`count: 0`) whenever **at least one**
+server returned a v1 response. A v1 200 with zero roles plus Hub
+`does not support Galaxy API v1` errors is still success — not
+`All Galaxy servers failed`. Raise `GalaxyError` only when **no** server
+returns a v1 search response. Do not copy `search_galaxy_collections`'
+`if not hits and errors` condition; that treats Hub-only failures plus
+an empty public-Galaxy hit list as total failure.
 
 Result TypedDict `StandaloneRoleSearchResult`:
 
@@ -337,14 +356,18 @@ Read-only. Parameter:
 - `role_name: str` — `validate_standalone_role_name` (new)
 
 Split into `(namespace, name)` on the **first** dot (exactly two segments).
-Lookup via `namespace` + `name`, then `/content/`, then parse.
+Lowercase both segments. Keep namespace hyphens (`ansible-lockdown` is not
+`ansible_lockdown`). For the role name, try the lowercase spelling first,
+then the hyphen/underscore swap (`ssh-hardening` hits immediately;
+`RHEL9-CIS` misses as `rhel9-cis` then hits as `rhel9_cis`). Lookup via
+`namespace` + `name`, then `/content/`, then parse.
 
 Result TypedDict `GetStandaloneRoleDocResult` — same optional fields as
 `GetRoleDocResult` plus standalone extras:
 
 | Field | Notes |
 |-------|--------|
-| `role_name` | Echo the 2-part identifier |
+| `role_name` | Galaxy canonical `{username}.{name}` after lookup, not the raw caller spelling |
 | `content_type` | `"standalone_role"` (not `"role"`) |
 | `doc_source` | `galaxy_v1_readme` or `galaxy_v1_metadata` on success. Do not return a success payload with `unavailable` — that case is `ErrorResponse`. |
 | `short_description`, `entry_points`, `dependencies`, `examples` | From parser when HTML present. If HTML is empty, `short_description` is the v1 `description` field; `dependencies` fall back to `summary_fields.dependencies`. When HTML is present, parser dependencies win; if the parser returns none, still fall back to `summary_fields.dependencies`. |
@@ -363,7 +386,7 @@ No local ansible-doc attempt.
 New `validate_standalone_role_name(name: str) -> None` in `validation.py`.
 
 - Exactly two segments separated by `.`
-- Each segment: `[A-Za-z0-9][A-Za-z0-9_-]*` (hyphen + mixed case)
+- Each segment: `[A-Za-z0-9][A-Za-z0-9_-]*` (hyphen + mixed case accepted; lookup canonicalizes)
 - Length cap: reuse `MAX_NAMESPACE_LENGTH` per segment (128)
 - Reject 3-part FQCNs with an error that points at `get_role_doc`
 - Reject empty / path characters
@@ -420,10 +443,17 @@ and `GalaxyV1ClientFactory`. Do not genericize the v3 helper.
 call resolution → return.
 
 Try servers in configured order for get-doc (first success wins). Search
-queries all servers and merges; **raises** `GalaxyError` when every
-server fails (empty hits are success). Both paths must use
+queries all servers and merges; **raises** `GalaxyError` only when every
+server fails to return a v1 response. Empty hits from a v1-capable
+server are success even if v1-less siblings error. Both paths must use
 `_select_http_client` (do not inject the shared httpx client when
 `validate_certs` is false).
+
+Lookup: lowercase both segments. Try role-name as stored, then hyphen
+swap / underscore swap. Search tokenizes into repeated ``keywords``
+params; empty AND falls back to the longest token. Search does not
+globally replace hyphens in free text (``ansible-lockdown`` as a
+keyword must remain hyphenated until tokenized).
 
 If public Galaxy is disabled (`ANSIBLE_KNOW_NO_PUBLIC_GALAXY=1`) and no
 configured server speaks v1, the tools return the “does not support
@@ -439,7 +469,7 @@ Galaxy catalog.
 | Validation failure | `{"error": str}` |
 | No v1 on any configured server | `{"error": "... does not support standalone roles (Galaxy v1)"}` |
 | Role not found | `{"error": "Standalone role '{name}' not found"}` |
-| HTTP/timeout on a server (search) | Skip server; empty merge is success; if all fail, resolution raises `GalaxyError` → tool `{"error": ...}` |
+| HTTP/timeout / no-v1 on a server (search) | Skip that server; a v1 200 with zero roles is success; raise `GalaxyError` only if **no** server returned v1 |
 | HTTP/timeout on get-doc after all servers | `{"error": ...}` sanitized |
 | Empty README HTML | Success with `doc_source: galaxy_v1_metadata`, v1 description/tags, and `doc_warning` |
 
@@ -454,9 +484,9 @@ Unit tests mock HTTP (no live Galaxy). Integration tests stay opt-in
 
 | File | Coverage |
 |------|----------|
-| `tests/test_galaxy_v1.py` | `keywords` + `order_by=-download_count` + `page_size=10`; `tags` first-segment only; lookup uses `namespace`+`name` **not** `owner__username`; content parse → entry_points; empty HTML → `galaxy_v1_metadata`; 404 on v1 → `GalaxyError`; hyphenated `ansible-lockdown.rhel9_cis`; discovery requires v1 and does **not** require v3 |
+| `tests/test_galaxy_v1.py` | Repeated ``keywords`` AND tokens; stopwords dropped; empty AND falls back to longest token; lookup tries hyphen form then underscore; hyphenated names like ``ssh-hardening`` hit first; namespace underscores are not rewritten to hyphens; ``tags`` first-segment only; lookup uses ``namespace``+``name`` **not** ``owner__username``; content parse → entry_points; empty HTML → ``galaxy_v1_metadata``; 404 on v1 → ``GalaxyError``; discovery requires v1 and does **not** require v3 |
 | `tests/test_validation.py` | Accept hyphens/mixed case; reject 1-part, 3-part, empty, `/` |
-| `tests/test_resolution.py` | Multi-server: v1-less server skipped, v1 server used; all-fail **raises** `GalaxyError`; search dedupe; empty hits succeed |
+| `tests/test_resolution.py` | Multi-server: v1-less server skipped, v1 server used; all-fail **raises** `GalaxyError`; search dedupe; empty hits succeed **including when v1-less siblings error** (the Hub+empty combination; testing skip-with-hits and empty-alone separately is not enough) |
 | `tests/test_server.py` | Both tools success + validation error; `get_role_doc` still requires 3-part FQCN; `clear_cache(scope=galaxy)` also calls `galaxy_v1.clear_cache` |
 | `tests/test_galaxy.py` | Existing v3 tests still pass (no v1 import) |
 | `tests/integration/test_galaxy_api.py` | Optional live `keywords=rhel9_cis` and `get ansible-lockdown.rhel9_cis` |

--- a/src/ansible_know/galaxy_v1.py
+++ b/src/ansible_know/galaxy_v1.py
@@ -54,6 +54,66 @@ def _first_tag(tags: str | None) -> str | None:
     return tags.split(",", 1)[0].strip() or None
 
 
+_TOKEN_SPLIT_RE = re.compile(r"[\s\-_]+")
+MAX_SEARCH_TOKENS = 4
+_SEARCH_STOPWORDS = frozenset({
+    "a", "an", "the", "to", "for", "of", "on", "in", "and", "or",
+    "i", "me", "my", "we", "you",
+    "some", "any", "something", "want", "need", "get", "please",
+    "find", "search", "looking",
+    "role", "roles", "ansible", "galaxy",
+    "manage", "management", "install", "setup", "configure", "config",
+    "with", "from", "that", "this", "is", "be", "how", "can", "use", "using",
+})
+
+
+def _search_tokens(query: str) -> list[str]:
+    """Split a search string into Galaxy v1 ``keywords`` AND tokens.
+
+    Galaxy ``getlist('keywords')`` ANDs each value as a case-sensitive
+    substring of namespace, name, or description. A single ``keywords``
+    with spaces looks for that exact phrase, so ``win openssh`` misses
+    ``win_openssh``.
+    """
+    lowered = query.strip().lower()
+    if not lowered:
+        return []
+    parts = [part for part in _TOKEN_SPLIT_RE.split(lowered) if part]
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for part in parts:
+        if part in _SEARCH_STOPWORDS or len(part) < 2:
+            continue
+        if part not in seen:
+            seen.add(part)
+            tokens.append(part)
+    if not tokens:
+        return [lowered]
+    if len(tokens) > MAX_SEARCH_TOKENS:
+        keep = set(sorted(tokens, key=len, reverse=True)[:MAX_SEARCH_TOKENS])
+        tokens = [token for token in tokens if token in keep]
+    return tokens
+
+
+def _canonicalize_role_parts(namespace: str, name: str) -> tuple[str, str]:
+    """Lowercase a standalone role identifier. Namespace hyphens stay as-is."""
+    return namespace.lower(), name.lower()
+
+
+def _role_name_candidates(name: str) -> list[str]:
+    """Try lowercase name as stored, then hyphen/underscore swap.
+
+    ``ssh-hardening`` and ``rhel9_cis`` both exist; GitHub repos like
+    ``RHEL9-CIS`` are stored with underscores. Do not rewrite on first try.
+    """
+    lowered = name.lower()
+    out = [lowered]
+    for alt in (lowered.replace("-", "_"), lowered.replace("_", "-")):
+        if alt not in out:
+            out.append(alt)
+    return out
+
+
 def _normalize_dependencies(raw: object) -> list[str]:
     if not isinstance(raw, list):
         return []
@@ -358,7 +418,7 @@ class GalaxyV1Client:
     async def _api_get(
         self,
         path: str,
-        params: dict[str, str] | None = None,
+        params: dict[str, str | list[str]] | None = None,
         timeout: httpx.Timeout = TIMEOUT_DEFAULT,
     ) -> dict[str, Any]:
         url = path if path.startswith(("http://", "https://")) else f"{self._base}{path}"
@@ -405,7 +465,7 @@ class GalaxyV1Client:
     async def _safe_api_get(
         self,
         path: str,
-        params: dict[str, str] | None = None,
+        params: dict[str, str | list[str]] | None = None,
         timeout: httpx.Timeout = TIMEOUT_DEFAULT,
     ) -> dict[str, Any]:
         """Wrap _api_get with network error handling."""
@@ -418,35 +478,62 @@ class GalaxyV1Client:
 
     async def search_roles(self, query: str, tags: str | None = None) -> dict[str, Any]:
         await self._discover_api_root()
-        cache_key = (*self._cache_identity(), "search", query, tags or "")
+        tokens = _search_tokens(query)
+        cache_key = (*self._cache_identity(), "search", "\x1f".join(tokens), tags or "")
         cached = _v1_cache.get(cache_key)
         if cached is not None:
-            return cached
-        params = {
-            "keywords": query,
-            "order_by": "-download_count",
-            "page_size": "10",
-        }
-        tag = _first_tag(tags)
-        if tag:
-            params["tags"] = tag
-        data = await self._safe_api_get(self._build_v1_url("roles"), params=params)
-        hits = data.get("results") or []
-        mapped = [_map_search_hit(item) for item in hits if isinstance(item, dict)]
+            cached_out = dict(cached)
+            cached_out["query"] = query
+            return cached_out
+        if not tokens:
+            return {"query": query, "count": 0, "roles": []}
+
+        async def _list(keywords: str | list[str]) -> list[dict[str, Any]]:
+            params: dict[str, str | list[str]] = {
+                "keywords": keywords,
+                "order_by": "-download_count",
+                "page_size": "10",
+            }
+            tag = _first_tag(tags)
+            if tag:
+                params["tags"] = tag
+            data = await self._safe_api_get(
+                self._build_v1_url("roles"), params=params,
+            )
+            hits = data.get("results") or []
+            return [
+                _map_search_hit(item) for item in hits if isinstance(item, dict)
+            ]
+
+        keywords: str | list[str] = tokens[0] if len(tokens) == 1 else tokens
+        mapped = await _list(keywords)
+        if not mapped and len(tokens) > 1:
+            longest = max(tokens, key=len)
+            mapped = await _list(longest)
         result = {"query": query, "count": len(mapped), "roles": mapped}
         _v1_cache.put(cache_key, result)
         return result
 
     async def fetch_role_by_name(self, namespace: str, name: str) -> dict[str, Any]:
         await self._discover_api_root()
-        params = {"namespace": namespace, "name": name, "page_size": "1"}
-        data = await self._safe_api_get(self._build_v1_url("roles"), params=params)
-        results = data.get("results") or []
-        if not results:
-            raise GalaxyError(
-                f"Standalone role '{namespace}.{name}' not found"
+        namespace, name = _canonicalize_role_parts(namespace, name)
+        last_name = name
+        for candidate in _role_name_candidates(name):
+            last_name = candidate
+            params: dict[str, str | list[str]] = {
+                "namespace": namespace,
+                "name": candidate,
+                "page_size": "1",
+            }
+            data = await self._safe_api_get(
+                self._build_v1_url("roles"), params=params,
             )
-        return results[0]
+            results = data.get("results") or []
+            if results:
+                return results[0]
+        raise GalaxyError(
+            f"Standalone role '{namespace}.{last_name}' not found"
+        )
 
     async def fetch_role_content(self, role_id: int) -> dict[str, Any]:
         await self._discover_api_root()
@@ -466,6 +553,7 @@ class GalaxyV1Client:
         from ansible_know.readme_parser import parse_role_readme
 
         namespace, _, name = role_name.partition(".")
+        namespace, name = _canonicalize_role_parts(namespace, name)
         role = await self.fetch_role_by_name(namespace, name)
         content = await self.fetch_role_content(int(role["id"]))
         html = content.get("readme_html") or ""
@@ -496,8 +584,10 @@ class GalaxyV1Client:
                 "description": var.get("description", ""),
                 "aliases": var.get("aliases", []),
             })
+        username = role.get("username") or namespace
+        role_slug = role.get("name") or name
         metadata = {
-            "role_name": role_name,
+            "role_name": f"{username}.{role_slug}",
             "content_type": "standalone_role",
             "short_description": short,
             "entry_points": {

--- a/src/ansible_know/resolution.py
+++ b/src/ansible_know/resolution.py
@@ -510,7 +510,12 @@ async def search_standalone_roles(
     galaxy_servers: list[GalaxyServerConfig] | None = None,
     v1_client_factory: GalaxyV1ClientFactory | None = None,
 ) -> StandaloneRoleSearchResult:
-    """Search all configured Galaxy servers concurrently for standalone roles."""
+    """Search configured Galaxy servers concurrently for standalone roles.
+
+    A successful v1 response with zero roles is success, even if other
+    servers lack v1 (typical Automation Hub) or time out. Raises
+    GalaxyError only when no server returns a v1 search response.
+    """
     from ansible_know.errors import GalaxyError
 
     if v1_client_factory is None:
@@ -531,6 +536,7 @@ async def search_standalone_roles(
     all_roles: list[dict[str, Any]] = []
     seen_role_names: set[str] = set()
     errors: list[str] = []
+    v1_ok = 0
 
     for i, outcome in enumerate(outcomes):
         if isinstance(outcome, Exception):
@@ -540,6 +546,7 @@ async def search_standalone_roles(
             )
             errors.append(f"{servers[i].name}: {outcome}")
             continue
+        v1_ok += 1
         server_name, result = outcome
         for role in result.get("roles", []):
             role_name = role.get("role_name", "")
@@ -548,8 +555,11 @@ async def search_standalone_roles(
                 all_roles.append(role)
                 seen_role_names.add(role_name)
 
-    if not all_roles and errors:
-        raise GalaxyError(f"All Galaxy servers failed: {'; '.join(errors)}")
+    if v1_ok == 0:
+        raise GalaxyError(
+            f"All Galaxy servers failed: {'; '.join(errors)}"
+            if errors else "No Galaxy servers configured"
+        )
 
     all_roles.sort(key=lambda r: r.get("download_count", 0), reverse=True)
 

--- a/tests/test_galaxy_v1.py
+++ b/tests/test_galaxy_v1.py
@@ -27,7 +27,15 @@ SAMPLE_ROLE = {
 SAMPLE_LIST = {"count": 1, "next": None, "previous": None, "results": [SAMPLE_ROLE]}
 
 
-def _mock_http(json_body, status=200):
+@pytest.fixture(autouse=True)
+def _clear_v1_cache():
+    from ansible_know.galaxy_v1 import clear_cache
+    clear_cache()
+    yield
+    clear_cache()
+
+
+def _json_response(json_body, status=200):
     mock_resp = MagicMock()
     mock_resp.json.return_value = json_body
     mock_resp.content = b"{}"
@@ -38,8 +46,20 @@ def _mock_http(json_body, status=200):
         )
     else:
         mock_resp.raise_for_status.return_value = None
+    return mock_resp
+
+
+def _mock_http(json_body, status=200):
     mock_client = AsyncMock()
-    mock_client.get.return_value = mock_resp
+    mock_client.get.return_value = _json_response(json_body, status=status)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+def _mock_http_sequence(json_bodies):
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = [_json_response(body) for body in json_bodies]
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
     return mock_client
@@ -60,7 +80,7 @@ class TestSearchRoles:
             gc = _skip_discovery(GalaxyV1Client())
             result = await gc.search_roles("rhel9_cis")
         params = mock_client.get.call_args.kwargs["params"]
-        assert params["keywords"] == "rhel9_cis"
+        assert params["keywords"] == ["rhel9", "cis"]
         assert params["order_by"] == "-download_count"
         assert params["page_size"] == "10"
         assert "search" not in params
@@ -68,6 +88,64 @@ class TestSearchRoles:
         url = mock_client.get.call_args.args[0]
         assert url.endswith("/api/v1/roles/")
         assert result["roles"][0]["role_name"] == "ansible-lockdown.rhel9_cis"
+
+    @pytest.mark.asyncio
+    async def test_keywords_are_lowercased(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http(SAMPLE_LIST)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            result = await gc.search_roles("RHEL9_CIS")
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["keywords"] == ["rhel9", "cis"]
+        assert result["query"] == "RHEL9_CIS"
+
+    @pytest.mark.asyncio
+    async def test_multi_word_sends_repeated_keywords(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http(SAMPLE_LIST)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            await gc.search_roles("win openssh")
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["keywords"] == ["win", "openssh"]
+
+    @pytest.mark.asyncio
+    async def test_stopwords_are_dropped(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http(SAMPLE_LIST)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            await gc.search_roles("I want some role to manage win openssh")
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["keywords"] == ["win", "openssh"]
+
+    @pytest.mark.asyncio
+    async def test_splits_hyphen_and_underscore(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http(SAMPLE_LIST)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            await gc.search_roles("lockdown RHEL9-CIS")
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["keywords"] == ["lockdown", "rhel9", "cis"]
+
+    @pytest.mark.asyncio
+    async def test_empty_and_retries_longest_token(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http_sequence([
+            {"count": 0, "results": []},
+            SAMPLE_LIST,
+        ])
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            result = await gc.search_roles("win openssh")
+        assert mock_client.get.call_count == 2
+        first = mock_client.get.call_args_list[0].kwargs["params"]["keywords"]
+        second = mock_client.get.call_args_list[1].kwargs["params"]["keywords"]
+        assert first == ["win", "openssh"]
+        assert second == "openssh"
+        assert result["count"] == 1
 
     @pytest.mark.asyncio
     async def test_tags_sends_first_segment_only(self):
@@ -103,6 +181,57 @@ class TestFetchRoleByName:
         assert params["name"] == "rhel9_cis"
         assert "owner__username" not in params
         assert role["id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_lookup_canonicalizes_case_and_role_hyphens(self):
+        """GitHub-style RHEL9-CIS: try hyphen form first, then underscore."""
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http_sequence([
+            {"count": 0, "results": []},
+            SAMPLE_LIST,
+        ])
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            await gc.fetch_role_by_name("Ansible-Lockdown", "RHEL9-CIS")
+        first = mock_client.get.call_args_list[0].kwargs["params"]
+        second = mock_client.get.call_args_list[1].kwargs["params"]
+        assert first["namespace"] == "ansible-lockdown"
+        assert first["name"] == "rhel9-cis"
+        assert second["name"] == "rhel9_cis"
+
+    @pytest.mark.asyncio
+    async def test_lookup_keeps_hyphenated_role_name_on_hit(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        hyphen_role = {
+            **SAMPLE_ROLE,
+            "username": "dev-sec",
+            "name": "ssh-hardening",
+        }
+        mock_client = _mock_http({"count": 1, "results": [hyphen_role]})
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            role = await gc.fetch_role_by_name("dev-sec", "ssh-hardening")
+        assert mock_client.get.call_count == 1
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["namespace"] == "dev-sec"
+        assert params["name"] == "ssh-hardening"
+        assert role["name"] == "ssh-hardening"
+
+    @pytest.mark.asyncio
+    async def test_lookup_does_not_turn_namespace_underscores_into_hyphens(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        mock_client = _mock_http({"count": 0, "results": []})
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            with pytest.raises(GalaxyError, match="not found"):
+                await gc.fetch_role_by_name("ansible_lockdown", "RHEL9_CIS")
+        first = mock_client.get.call_args_list[0].kwargs["params"]
+        assert first["namespace"] == "ansible_lockdown"
+        assert first["name"] == "rhel9_cis"
+        assert all(
+            call.kwargs["params"]["namespace"] == "ansible_lockdown"
+            for call in mock_client.get.call_args_list
+        )
 
     @pytest.mark.asyncio
     async def test_empty_results_raises(self):
@@ -146,6 +275,37 @@ class TestFetchStandaloneRoleDoc:
         assert "main" in meta["entry_points"]
         assert meta["github_branch"] == "devel"
         assert "geerlingguy.repo" in meta["dependencies"] or meta["dependencies"]
+
+    @pytest.mark.asyncio
+    async def test_github_style_identifier_looks_up_canonical_name(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        empty_list = MagicMock()
+        empty_list.json.return_value = {"count": 0, "results": []}
+        empty_list.content = b"{}"
+        empty_list.headers = {}
+        empty_list.raise_for_status.return_value = None
+        list_resp = MagicMock()
+        list_resp.json.return_value = SAMPLE_LIST
+        list_resp.content = b"{}"
+        list_resp.headers = {}
+        list_resp.raise_for_status.return_value = None
+        content_resp = MagicMock()
+        content_resp.json.return_value = {"readme": "README.md", "readme_html": ""}
+        content_resp.content = b"{}"
+        content_resp.headers = {}
+        content_resp.raise_for_status.return_value = None
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [empty_list, list_resp, content_resp]
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            meta, _prov = await gc.fetch_standalone_role_doc(
+                "ansible-lockdown.RHEL9-CIS",
+            )
+        first = mock_client.get.call_args_list[0].kwargs["params"]
+        second = mock_client.get.call_args_list[1].kwargs["params"]
+        assert first["name"] == "rhel9-cis"
+        assert second["name"] == "rhel9_cis"
+        assert meta["role_name"] == "ansible-lockdown.rhel9_cis"
 
     @pytest.mark.asyncio
     async def test_empty_html_is_metadata_success(self):

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -659,6 +659,38 @@ class TestSearchStandaloneRoles:
         assert result == {"query": "zzzz", "count": 0, "roles": []}
 
     @pytest.mark.asyncio
+    async def test_empty_hits_succeed_when_v1_less_siblings_error(self):
+        """Hub v1-less errors must not turn a successful empty Galaxy search
+        into 'All Galaxy servers failed'.
+        """
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import search_standalone_roles
+        certified = GalaxyServerConfig(
+            name="certified", url="https://console.redhat.com/api/automation-hub/",
+        )
+        validated = GalaxyServerConfig(
+            name="validated", url="https://console.redhat.com/api/automation-hub/",
+        )
+        galaxy = GalaxyServerConfig(
+            name="galaxy", url="https://galaxy.ansible.com",
+        )
+        no_v1 = GalaxyError("does not support Galaxy API v1")
+        result = await search_standalone_roles(
+            "lockdown RHEL9-CIS",
+            galaxy_servers=[certified, validated, galaxy],
+            v1_client_factory=_v1_factory_map({
+                "certified": _FakeV1(error=no_v1),
+                "validated": _FakeV1(error=no_v1),
+                "galaxy": _FakeV1(search={"roles": []}),
+            }),
+        )
+        assert result == {
+            "query": "lockdown RHEL9-CIS",
+            "count": 0,
+            "roles": [],
+        }
+
+    @pytest.mark.asyncio
     async def test_all_fail_raises(self):
         from ansible_know.galaxy_config import GalaxyServerConfig
         from ansible_know.resolution import search_standalone_roles


### PR DESCRIPTION
## Summary

- Treat a successful Galaxy v1 search with zero hits as success even when Automation Hub siblings error (no v1 / 401). Raise `All Galaxy servers failed` only when **no** server returns a v1 response.
- Tokenize `keywords` on whitespace / hyphen / underscore, lowercase, drop stopwords, and send repeated query params so phrases like `win openssh` match `win_openssh`.
- On get-doc lookup, lowercase identifiers and try hyphen then underscore for the role **name** only (namespace hyphens stay).

Related to https://github.com/leogallego/ansible-know-mcp/issues/230

## Changes

- `src/ansible_know/resolution.py` — count `v1_ok`; empty merged results are success when at least one server answered v1.
- `src/ansible_know/galaxy_v1.py` — `_search_tokens`, longest-token retry, `_role_name_candidates`, list-valued `keywords` params.
- `tests/test_resolution.py` — Hub v1-less + empty Galaxy regression.
- `tests/test_galaxy_v1.py` — token, stopword, hyphen/underscore lookup coverage; autouse cache clear.
- `docs/superpowers/specs/2026-08-18-standalone-galaxy-roles-design.md` — all-failed vs empty, keywords AND, lookup candidates.

## Test plan

- [x] `pytest tests/test_galaxy_v1.py tests/test_resolution.py tests/test_server.py`
- [x] `ruff check` on touched Python files
- [ ] Live: `search_standalone_roles` with Hub + public Galaxy configured for `win openssh` / `lockdown RHEL9-CIS` / `ssh hardening`
- [ ] Live: `get_standalone_role_doc` for `ansible-lockdown.RHEL9-CIS` and `dev-sec.ssh-hardening`

## Review findings addressed

- **Plan review** (`git-plan`): rejected URL-filter to only `galaxy.ansible.com` (private galaxy-ng may expose v1). Empty v1 hits must not inherit `search_galaxy_collections`' `if not hits and errors` condition.
- **Implementation review** (`git-implement`): merge-logic + tokenized keywords + hyphen/underscore lookup implemented against the spec; full architecture / PEP 8 / security review posted as a follow-up comment on this PR.

## Acknowledged debt

- Typos (`ssh hardeing`) still miss; no fuzzy match.
- Description matching is case-sensitive on Galaxy (`Windows` vs `windows`); longest-token fallback covers many misses.
- `search_galaxy_collections` still uses `if not hits and errors` — out of scope.
- Nested `_list` in `search_roles`; stopword list is heuristic (`config` can drop a useful token).

## Stack position

- **Base**: `main`
- **Next**: end of chain

Assisted-by: Cursor (Grok 4.6)
