### PR TITLE
fix: treat empty collection search hits as success when siblings error (#241)

### DIFF
--- a/src/ansible_know/resolution.py
+++ b/src/ansible_know/resolution.py
@@ -453,7 +453,12 @@ async def search_galaxy_collections(
     galaxy_servers: list[GalaxyServerConfig] | None = None,
     client_factory: GalaxyClientFactory | None = None,
 ) -> dict[str, Any]:
-    """Search all configured Galaxy servers concurrently, merge and dedupe results."""
+    """Search all configured Galaxy servers concurrently, merge and dedupe results.
+
+    A successful search response with zero collections is success, even if
+    other servers error (401, timeout, discovery failure). Raises
+    GalaxyError only when no server returns a search response.
+    """
     from ansible_know.errors import GalaxyError
 
     if client_factory is None:
@@ -474,6 +479,7 @@ async def search_galaxy_collections(
     all_collections: list[dict[str, Any]] = []
     seen_namespaces: set[str] = set()
     errors: list[str] = []
+    search_ok = 0
 
     for i, outcome in enumerate(outcomes):
         if isinstance(outcome, Exception):
@@ -483,6 +489,7 @@ async def search_galaxy_collections(
             )
             errors.append(f"{servers[i].name}: {outcome}")
             continue
+        search_ok += 1
         server_name, result = outcome
         for coll in result.get("collections", []):
             ns = coll.get("namespace", "")
@@ -491,8 +498,11 @@ async def search_galaxy_collections(
                 all_collections.append(coll)
                 seen_namespaces.add(ns)
 
-    if not all_collections and errors:
-        raise GalaxyError(f"All Galaxy servers failed: {'; '.join(errors)}")
+    if search_ok == 0:
+        raise GalaxyError(
+            f"All Galaxy servers failed: {'; '.join(errors)}"
+            if errors else "No Galaxy servers configured"
+        )
 
     all_collections.sort(key=lambda c: c.get("download_count", 0), reverse=True)
 

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -349,6 +349,46 @@ class TestSearchGalaxyCollections:
         assert result["count"] == 1
 
     @pytest.mark.asyncio
+    async def test_empty_hits_succeed_when_siblings_error(self):
+        """Hub errors must not turn a successful empty Galaxy search
+        into 'All Galaxy servers failed'.
+        """
+        from ansible_know.errors import GalaxyError
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import search_galaxy_collections
+
+        certified = GalaxyServerConfig(
+            name="certified", url="https://console.redhat.com/api/automation-hub/",
+        )
+        validated = GalaxyServerConfig(
+            name="validated", url="https://console.redhat.com/api/automation-hub/",
+        )
+        galaxy = GalaxyServerConfig(
+            name="galaxy", url="https://galaxy.ansible.com",
+        )
+        empty_result = {"query": "zzzz", "count": 0, "collections": []}
+        hub_error = GalaxyError("401 Unauthorized")
+
+        with patch("ansible_know.galaxy.GalaxyClient.search_collections") as mock_search:
+            call_count = 0
+
+            async def side_effect(query, tags=None):
+                nonlocal call_count
+                call_count += 1
+                if call_count < 3:
+                    raise hub_error
+                return empty_result
+
+            mock_search.side_effect = side_effect
+            result = await search_galaxy_collections(
+                "zzzz",
+                galaxy_servers=[certified, validated, galaxy],
+                client_factory=FACTORY,
+            )
+
+        assert result == {"query": "zzzz", "count": 0, "collections": []}
+
+    @pytest.mark.asyncio
     async def test_all_servers_fail_raises(self):
         from ansible_know.errors import GalaxyError
         from ansible_know.galaxy_config import GalaxyServerConfig


### PR DESCRIPTION
## Summary

- Raise `All Galaxy servers failed` from `search_galaxy_collections` only when **no** server returns a search response (same `search_ok` / `v1_ok` predicate as `search_standalone_roles` after #240).
- Empty merged hits plus sibling Hub 401/timeout now return `{count: 0}` instead of treating Galaxy as untried.
- Regression test: Hub errors + Galaxy `{collections: []}` → `count: 0`; all-servers-fail still raises.

Closes #241

## Changes

- `src/ansible_know/resolution.py` — count successful search responses; do not use empty hit lists as a failure signal.
- `tests/test_resolution.py` — `test_empty_hits_succeed_when_siblings_error` next to `TestSearchGalaxyCollections`.

No ADR or contract edits: ADR-0004 already requires merging partial search results with partial failures. ADR-0006 maintain-only is respected (bugfix, not a new feature).

## Test plan

- [x] `uv run ruff check src/ansible_know/resolution.py tests/test_resolution.py`
- [x] `uv run pytest tests/test_resolution.py::TestSearchGalaxyCollections -v`
- [x] `uv run pytest tests/ -v` (1092 passed, 1 skipped)
- [ ] CI green on this PR

## Review findings addressed

- **Plan review** (`git-plan`): skipped (small scope)
- **Implementation review** (`git-implement`):
  - Architecture (`git-review`): Clean — Domain still raises `GalaxyError`; Orchestration unchanged; aligns with ADR-0004 partial-merge.
  - Code quality: `search_ok == 0` matches role `v1_ok`; all-fail path kept.
  - Security: n/a (no new I/O or secrets).
  - Skill compliance (PEP 8): no errors; project line-length 120.

## Acknowledged debt

None. Issue 234 (malformed payload as failure) remains out of scope.

## Stack position

- **Base**: `main`
- **Next**: end

Assisted-by: Cursor (Grok 4.6)