### PR TITLE
docs: amend ADR-0006 to upstream-when-ready, drop rename

### DIFF
--- a/docs/architecture/adr/0006-upstream-first-integration.md
+++ b/docs/architecture/adr/0006-upstream-first-integration.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Amended (2026-08-19)
 
 ## Date
 
@@ -15,31 +15,35 @@ server, bundled in the VS Code extension. Over time, both servers have built
 overlapping capabilities: collection search, module/plugin docs for
 uninstalled collections, skill listing, and MCP behavioral annotations.
 
-Maintaining two servers with growing overlap creates confusion for agents
-(which server to call?), duplicated maintenance effort, and a weaker pitch
-to stakeholders.
-
 The next-mcp server excels at developer workflow (linting, execution,
 scaffolding, environment management, task generation). ansible-know-mcp
 excels at knowledge retrieval (structured docs, Galaxy fallback, multi-server
-support, README parsing) and skill generation.
+support, README parsing, standalone Galaxy roles) and skill generation.
 
-The question: should ansible-know-mcp continue as a broad knowledge server,
-or focus on its unique value and contribute the rest upstream?
+The overlap is limited to 7 tools out of 22 (v0.9.0). Running both servers
+simultaneously works well — agents route questions naturally based on tool
+descriptions.
 
 ## Decision
 
-Adopt an upstream-first strategy:
+Adopt an upstream-when-ready strategy:
 
 1. **Contribute** knowledge features to next-mcp where they naturally extend
    existing capabilities. We provide algorithms, patterns, and test cases
    for TypeScript reimplementation — not code drops.
 
-2. **Keep** skill generation as the core value proposition. The generation
-   pipeline (structured docs → Jinja2 templates → SKILL.md packages) is
-   Python/Jinja2 and doesn't fit in a TypeScript server.
+2. **Keep** ansible-know-mcp as a knowledge-and-skills server. The knowledge
+   tools (documentation, search, Galaxy resolution) feed the generation
+   pipeline internally — removing them would create a fragile cross-server
+   dependency for the project's core function.
 
-3. **Drop** overlapping tools as upstream absorbs the features.
+3. **Deprecate** overlapping tools only after upstream proves it absorbed
+   the features. Do not preemptively drop tools or gate scope on upstream's
+   acceptance timeline.
+
+4. **No rename.** The name "know" covers both knowledge retrieval and
+   knowledge packaging (skills). The rename churn (PyPI package, CLI
+   entrypoint, MCP configs, documentation) is not justified.
 
 ### Features to upstream
 
@@ -48,7 +52,8 @@ Adopt an upstream-first strategy:
 | P0 | Multi-server Galaxy via `ansible.cfg` | Enterprise blocker — every enterprise deployment has a private hub |
 | P1 | Structured Galaxy docs fallback | Extends existing `get_galaxy_plugin_doc` with structured JSON output |
 | P1 | Role README HTML parsing | Most Galaxy roles lack `argument_specs`; extends existing role docs |
-| Evaluate | Runtime doc search | Depends on next-mcp team's interest; their Starlight site is hosting, not runtime search |
+| P2 | Galaxy v1 standalone role support | Thousands of Galaxy roles exist only as standalone; next-mcp has no v1 API |
+| Evaluate | Runtime doc search | Depends on next-mcp team's interest |
 
 ### Features to keep
 
@@ -56,43 +61,51 @@ Adopt an upstream-first strategy:
   `generate_collection_skills` — core generation pipeline
 - `get_collection_manifest`, `get_collection_docs` — feed the generation pipeline
 - `list_skills`, `get_skill` — serve generated skills via MCP resources
+- `package_as_plugin` — Agent Plugins packaging (Layer-2 distribution)
+- `search_standalone_roles`, `get_standalone_role_doc` — Galaxy v1 standalone roles
+- `search_docs`, `fetch_doc` — documentation search and retrieval
+- All 5 MCP prompts and 6 MCP resources
 
-### Tools to drop (once upstream absorbs features)
+### Tools to deprecate (only after upstream absorbs the features)
 
 - `search_modules`, `search_plugins` — next-mcp has better relevance scoring
 - `ensure_collection` — next-mcp rebuilds search index after install
-- `search_collections` — multi-server moves upstream
-- `get_module_doc`, `get_plugin_doc`, `get_role_doc` — docs resolution moves upstream
+- `search_collections` — next-mcp covers Galaxy + GitHub orgs
+- `get_module_doc`, `get_plugin_doc`, `get_role_doc` — kept internally for
+  generation pipeline; marked deprecated in public API only after upstream
+  absorbs the feature
 - `clear_cache` — fewer caches with narrower scope
 
 ### Evolution path
 
 ```
-Phase 1-3: ansible-know-mcp → ansible-skill-mcp (community, Python)
-Phase 4:   ansible-skill-mcp → aap-mcp-skills (platform, TypeScript)
+Phase 1 (now):  ansible-know-mcp in ansible-community org
+                Full 22-tool server, upstream contributions when accepted
+
+Phase 2:        Upstream absorbs P0/P1 features
+                Deprecate overlapping public tools, keep internal resolution
 ```
 
 ## Consequences
 
 ### Positive
 
-- **Cleaner story**: "We contributed the knowledge infrastructure. What we
-  kept is the generation engine that turns knowledge into agent-ready skills."
-- **No agent confusion**: one server for knowledge + workflow (next-mcp),
-  one server for skill generation (ansible-skill-mcp). Clear boundary.
-- **Enterprise gap closed**: multi-server Galaxy support lands in the
-  official tooling, not a community add-on.
-- **Reduced maintenance**: fewer tools, narrower scope, less surface area.
+- **Self-contained generation pipeline**: knowledge tools feed generation
+  tools internally — no fragile cross-server dependency for core function.
+- **No forced narrowing**: project scope grows based on community need
+  (e.g., standalone Galaxy roles in v0.9.0), not upstream dependency.
+- **Enterprise gap closed**: multi-server Galaxy support contributed to the
+  official tooling once upstream accepts it.
+- **No rename churn**: PyPI package, CLI entrypoint, MCP configs, and
+  documentation all stay stable.
 
 ### Negative
 
-- **Dependency on next-mcp team**: upstream contributions require their
-  acceptance and reimplementation capacity. Timeline is theirs, not ours.
-- **Transition period**: during Phase 2, both servers have overlapping
-  tools. Agent confusion persists until tools are dropped.
-- **Standalone degradation**: ansible-skill-mcp without next-mcp loses
-  the documentation tools. The remote service model (Layer 3) mitigates
-  this — skill generation still works via Galaxy fallback internally.
+- **Overlap persists longer**: agents see similar tools from both servers
+  until upstream absorbs features. Mitigated by clear tool descriptions
+  that enable natural routing.
+- **Broader maintenance surface**: 22 tools instead of ~10 if we had
+  narrowed. Mitigated by the tools being well-tested and stable.
 
 ### ADR compliance with next-mcp
 
@@ -109,11 +122,14 @@ All contributions must align with next-mcp's ADRs:
   - Multi-server Galaxy via `ansible.cfg`: `galaxy.py`, `config.py`
   - Structured Galaxy docs fallback: `galaxy.py:GalaxyClient._fetch_docs_blob()`
   - Role README HTML parsing: `readme_parser.py`
+  - Galaxy v1 standalone roles: `galaxy_v1.py`
 - **Phase 2** (tool deprecation): mark overlapping tools as deprecated in
-  `server.py`, emit warnings via `ctx.warning()`, remove after one release
-- **Phase 3** (rename): `ansible-know-mcp` → `ansible-skill-mcp` — PyPI
-  package rename, CLI entrypoint, documentation updates
+  `server.py`, emit warnings via `ctx.warning()`. Deprecation begins only
+  after the upstream feature ships and proves stable in production use.
+  Removal follows after minimum one release cycle with the deprecation
+  warning active.
 - **Pitch document**: `docs/research/upstream-integration-proposal-2026-06-26.md`
+- **Latest comparison**: `docs/research/2026-08-19-know-vs-next-mcp-comparison.md`
 
 ## Related Decisions
 
@@ -122,10 +138,13 @@ All contributions must align with next-mcp's ADRs:
 - [ADR-0007](0007-agentskills-spec-compliance.md) — spec compliance is
   required for interoperability with next-mcp's SkillRegistry
 - [ADR-0008](0008-three-layer-distribution.md) — three-layer model defines
-  how ansible-skill-mcp integrates with next-mcp post-upstream
+  how ansible-know-mcp integrates with next-mcp
+- [ADR-0009](0009-agent-plugins-distribution.md) — Agent Plugins packaging
+  for Layer-2 distribution
 
 ## Revision History
 
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-06-26 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Initial proposal |
+| 2026-08-19 | Leonardo Gallego (Assisted-by: Claude Opus 4.6) | Amended: drop rename, upstream-when-ready, add P2 Galaxy v1, keep knowledge tools |

--- a/docs/architecture/project-strategy.md
+++ b/docs/architecture/project-strategy.md
@@ -1,6 +1,6 @@
 # ansible-know-mcp: Project Strategy and Evolution
 
-**Last updated:** 2026-08-03
+**Last updated:** 2026-08-19
 **Status:** Active
 
 ---
@@ -9,49 +9,55 @@
 
 **ansible-know-mcp** is a community MCP server for Ansible knowledge retrieval and AI skill generation.
 
-| Dimension | Current (v0.7.0) |
+| Dimension | Current (v0.9.0) |
 |---|---|
 | Language | Python (FastMCP) |
 | License | GPL-3.0-or-later |
 | Distribution | PyPI (`uvx ansible-know-mcp`) |
-| Tools | 20 |
+| Tools | 22 |
 | Resources | 6 |
 | Prompts | 5 |
-| Tests | 974 collected (unit + integration; integration skipped by default) |
-| Modules | 23 Python source modules |
+| Modules | 25 Python source modules |
 
 ### Core capabilities
 
 | Capability | Purpose |
 |---|---|
 | Module/plugin/role documentation | Structured docs with Galaxy fallback, multi-server support, README parsing |
+| Standalone Galaxy role documentation | Galaxy v1 API search and README fetch for 2-part roles not in collections |
 | Collection discovery | Concurrent multi-server search via `ansible.cfg`, enriched manifests |
 | Skill generation | AI-ready SKILL.md packages from module, plugin, role, and collection metadata |
-| Documentation search | Upstream doc manifests (ansible-core, lint, navigator, builder, creator, molecule) + RTD fallback |
+| Skill packaging | Agent Plugins tarballs for Layer-2 distribution |
+| Documentation search | Upstream doc manifests (ansible-core, lint, navigator, builder, creator, molecule, AAP 2.5/2.6/2.7) + RTD fallback |
 
 ---
 
 ## Strategic Direction
 
-### Upstream-first integration with @ansible/mcp-server (next)
+### Upstream-when-ready integration with @ansible/mcp-server (next)
 
-Rather than maintain two servers that increasingly overlap, contribute knowledge features upstream and focus on what's unique.
+Contribute knowledge features upstream when accepted, but do not gate scope
+or identity on upstream's acceptance timeline. The project remains a
+knowledge-and-skills server.
 
 **Contribute upstream:**
 - P0: Multi-server Galaxy via `ansible.cfg` (enterprise blocker)
 - P1: Structured Galaxy docs fallback (extends existing `get_galaxy_plugin_doc`)
 - P1: Role README HTML parsing (extends existing role docs)
+- P2: Galaxy v1 standalone role support (broadens Galaxy coverage)
 - Evaluate: Runtime doc search (depends on next-mcp team's interest)
 
 **Keep:**
 - Skill generation pipeline (all 4 generation tools + supporting tools)
+- Documentation tools (`search_docs`, `fetch_doc`, role docs, standalone role docs)
+- Agent Plugins packaging (`package_as_plugin`)
 - Skill sharing as team service (remote HTTP/SSE deployment)
 
-**Drop** (once upstream absorbs the features):
+**Deprecate** (only after upstream absorbs and proves stable):
 - `search_modules`, `search_plugins` → next-mcp's `search_ansible_plugins` has better scoring
 - `ensure_collection` → next-mcp's `install_ansible_collection` rebuilds search index
 - `search_collections` → next-mcp covers Galaxy + GitHub orgs
-- `get_module_doc`, `get_plugin_doc`, `get_role_doc` → next-mcp with upstream Galaxy fallback + README parsing
+- `get_module_doc`, `get_plugin_doc`, `get_role_doc` → kept internally for generation pipeline
 - `clear_cache` → fewer caches to manage
 
 See [ADR-0006](adr/0006-upstream-first-integration.md) for the full decision record.
@@ -59,13 +65,13 @@ See [ADR-0006](adr/0006-upstream-first-integration.md) for the full decision rec
 ### Evolution path
 
 ```
-Phase 1-3 (now → mid-term):
-  ansible-know-mcp → ansible-skill-mcp
-  Python, community project, focused on skill generation + distribution
+Phase 1 (now):
+  ansible-know-mcp in ansible-community org
+  Full 22-tool server, upstream contributions when accepted
 
-Phase 4 (future):
-  ansible-skill-mcp → aap-mcp-skills
-  TypeScript, platform component alongside aap-mcp-server
+Phase 2:
+  Upstream absorbs P0/P1 features
+  Deprecate overlapping public tools, keep internal resolution
 ```
 
 ### Three-layer distribution model
@@ -75,7 +81,7 @@ Each layer is additive — same spec-compliant skills at every layer.
 | Layer | When | How | Value |
 |---|---|---|---|
 | **Local** | Now | Paired with next-mcp, shared directory | Real-time generation from locally installed, private hub, and Galaxy collections |
-| **Repository** | Next | Generated skills pushed to GitHub repo | Persistence, sharing, version control, Lola distribution to 40+ agents |
+| **Repository** | Now | Agent Plugins tarball via GitHub/registry source | Persistence, sharing, version control, distribution to 68+ agents |
 | **Remote service** | Future | HTTP/SSE MCP server | On-demand generation for DevSpaces, Ansible Self-Service Portal, enterprise teams |
 
 See [ADR-0008](adr/0008-three-layer-distribution.md) for the full decision record.
@@ -84,13 +90,14 @@ See [ADR-0008](adr/0008-three-layer-distribution.md) for the full decision recor
 
 ## Architecture Decisions
 
-All significant decisions are recorded in [docs/architecture/adr/](adr/). Decisions from the strategy discussion (2026-06-26):
+All significant decisions are recorded in [docs/architecture/adr/](adr/).
 
 | ADR | Title | Status | Summary |
 |---|---|---|---|
-| [0006](adr/0006-upstream-first-integration.md) | Upstream-First Integration with @ansible/mcp-server (next) | Proposed | Contribute knowledge features upstream, keep skill generation |
+| [0006](adr/0006-upstream-first-integration.md) | Upstream-First Integration with @ansible/mcp-server (next) | Amended | Upstream when ready, no rename, keep knowledge tools |
 | [0007](adr/0007-agentskills-spec-compliance.md) | agentskills.io Specification Compliance | Accepted | One output format, spec-compliant; naming and metadata conventions (#148) |
 | [0008](adr/0008-three-layer-distribution.md) | Three-Layer Skill Distribution Model | Proposed | Local → Repository → Remote; Layer 1 AGENTS.md + dual-config (#181/#184) |
+| [0009](adr/0009-agent-plugins-distribution.md) | Agent Plugins Distribution | Accepted | Agent Plugins packaging for Layer-2 (#223) |
 
 Prior decisions:
 
@@ -113,18 +120,20 @@ The Ansible DevTools MCP server, bundled in the VS Code extension. Our primary i
 - **Local copy:** clone of `github.com/ansible/vscode-ansible` (next branch)
 - **Repo:** `github.com/ansible/vscode-ansible`
 - **Version:** 0.0.1 (pre-release)
-- **Relationship:** We upstream knowledge features; they distribute skills via the SkillRegistry
-- **Integration point:** Shared project `skills/` directory (Layer 1 dual-config + `AGENTS.md`; see ADR-0008 / #181) or GitHub/Agent Plugins packaging (#223; Lola wrap #149 deprecated)
-- **Gap:** `_loadLocalSource` scans 1 level; tracked in [#200](https://github.com/leogallego/ansible-know-mcp/issues/200) (upstream later)
+- **Relationship:** We upstream knowledge features when accepted; they distribute skills via the SkillRegistry
+- **Integration point:** Shared project `skills/` directory (Layer 1 dual-config + `AGENTS.md`; see ADR-0008 / #181) or Agent Plugins packaging (#223 / ADR-0009)
+- **Registry pipeline:** know-mcp generates → `package_as_plugin` → publish to HTTP index → next-mcp `SkillRegistry._loadRegistrySource()` consumes
+- **Gap:** `_loadLocalSource` scans 1 level; tracked in [#200](https://github.com/leogallego/ansible-know-mcp/issues/200)
 - **Pitch document:** [upstream-integration-proposal-2026-06-26.md](../research/upstream-integration-proposal-2026-06-26.md)
+- **Latest comparison:** [2026-08-19-know-vs-next-mcp-comparison.md](../research/2026-08-19-know-vs-next-mcp-comparison.md)
 
 ### aap-mcp-server
 
 The AAP platform MCP server for Controller, EDA, and Gateway operations.
 
 - **Repo:** `github.com/ansible/aap-mcp-server`
-- **Relationship:** Future home for `aap-mcp-skills` (Phase 4, TypeScript rewrite)
-- **No current integration** — the platform MCP ecosystem is the long-term direction
+- **Relationship:** Potential future integration
+- **No current integration**
 
 ### Agent Plugins
 
@@ -144,7 +153,7 @@ Cross-agent AI skill package manager by Red Hat Product Security.
 - **Repo:** `github.com/LobsterTrap/lola`
 - **Marketplace:** `github.com/RedHatProductSecurity/lola-market`
 - **Relationship:** Legacy distribution channel. ``package_for_lola`` (#149)
-  is deprecated for one release cycle in favor of Agent Plugins (#223).
+  is deprecated in favor of Agent Plugins (#223).
 - **Not a generation format** — Lola packaging is a post-generate wrap step, not a `generate_*` output mode.
 
 ### agentskills.io
@@ -163,8 +172,10 @@ The standard specification for AI agent skills.
 1. ~~**Finalize issue #148**~~ — **Done** (closed; ADR-0007 Accepted)
 2. ~~**Draft next-mcp scan depth proposal**~~ — **Tracked** as [#200](https://github.com/leogallego/ansible-know-mcp/issues/200)
 3. ~~**#182** — multi-path `list_skills` / `get_skill`~~ (done: `ANSIBLE_KNOW_SKILLS_PATH`)
-4. ~~**#149** — Lola packaging helper (Layer 2)~~ — **Done** (deprecated wrap; prefer [#223](https://github.com/leogallego/ansible-know-mcp/issues/223) / [ADR-0009](adr/0009-agent-plugins-distribution.md))
+4. ~~**#149** — Lola packaging helper (Layer 2)~~ — **Done** (deprecated; prefer [#223](https://github.com/leogallego/ansible-know-mcp/issues/223) / [ADR-0009](adr/0009-agent-plugins-distribution.md))
 5. **#189 / #125** — FastMCP 4 / MCP 2026-07-28 session migration (blocked on stable release)
+6. **#233–#237** — Standalone role hardening (HTTPS, malformed payloads, GitHub README fallback, skill generation, role install)
+7. **#192** — Split server.py (lower barrier for community contributors)
 
 ---
 
@@ -173,6 +184,7 @@ The standard specification for AI agent skills.
 | Document | Purpose |
 |---|---|
 | [upstream-integration-proposal-2026-06-26.md](../research/upstream-integration-proposal-2026-06-26.md) | External pitch to next-mcp team |
-| [comparison-2026-06-26.md](../research/comparison-2026-06-26.md) | Technical feature comparison |
+| [2026-08-19-know-vs-next-mcp-comparison.md](../research/2026-08-19-know-vs-next-mcp-comparison.md) | Latest feature comparison with next-mcp |
+| [comparison-2026-06-26.md](../research/comparison-2026-06-26.md) | Technical feature comparison (historical) |
 | [skills-distribution-strategy-2026-06-26.md](../research/skills-distribution-strategy-2026-06-26.md) | Skills distribution technical details |
 | [service-contracts.md](service-contracts.md) | MCP server contracts and invariants |


### PR DESCRIPTION
## Summary

- Amend ADR-0006 from "upstream-first" to "upstream-when-ready" — no scope gating on next-mcp's acceptance timeline
- Drop the ansible-skill-mcp rename entirely — the name "know" covers both knowledge retrieval and skill generation
- Move aap-mcp-skills to a parked research proposal (local only, gitignored)
- Change "drop tools" to "deprecate tools only after upstream absorbs and proves stable"
- Add P2: Galaxy v1 standalone role support as upstream candidate
- Update project-strategy.md to v0.9.0 baseline (22 tools, 2-phase evolution path)

## Test plan

- [x] No `skill-mcp` / `ansible-skill-mcp` / `aap-mcp-skills` references remain in any ADR or strategy doc
- [x] Phase numbering consistent across ADR-0006 and project-strategy.md
- [x] All cross-references (ADR links, issue numbers) verified
- [x] No other ADRs reference the old rename or Phase 3/4

Assisted-by: Claude Opus 4.6