### PR TITLE
fix: treat malformed Galaxy payloads as server failure (#234)

### DIFF
--- a/src/ansible_know/galaxy.py
+++ b/src/ansible_know/galaxy.py
@@ -688,16 +688,21 @@ class GalaxyClient:
         parsed = parse_role_readme(readme_html)
 
         options: list[dict[str, Any]] = []
-        for var in parsed.get("variables", []):
-            options.append({
-                "name": var["name"],
-                "type": var.get("type") or "str",
-                "required": bool(var.get("required")),
-                "default": var.get("default"),
-                "choices": var.get("choices"),
-                "description": var.get("description", ""),
-                "aliases": var.get("aliases", []),
-            })
+        try:
+            for var in parsed.get("variables") or []:
+                options.append({
+                    "name": var["name"],
+                    "type": var.get("type") or "str",
+                    "required": bool(var.get("required")),
+                    "default": var.get("default"),
+                    "choices": var.get("choices"),
+                    "description": var.get("description", ""),
+                    "aliases": var.get("aliases", []),
+                })
+        except (KeyError, TypeError, ValueError) as exc:
+            raise GalaxyError(
+                f"Malformed Galaxy payload for role '{role_name}'"
+            ) from exc
 
         role_metadata: dict[str, Any] = {
             "role_name": role_name,

--- a/src/ansible_know/galaxy_v1.py
+++ b/src/ansible_know/galaxy_v1.py
@@ -555,7 +555,14 @@ class GalaxyV1Client:
         namespace, _, name = role_name.partition(".")
         namespace, name = _canonicalize_role_parts(namespace, name)
         role = await self.fetch_role_by_name(namespace, name)
-        content = await self.fetch_role_content(int(role["id"]))
+        try:
+            role_id = int(role["id"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise GalaxyError(
+                f"Malformed Galaxy payload for standalone role "
+                f"'{namespace}.{name}'"
+            ) from exc
+        content = await self.fetch_role_content(role_id)
         html = content.get("readme_html") or ""
         parsed = parse_role_readme(html)
         summary = role.get("summary_fields") or {}
@@ -574,16 +581,22 @@ class GalaxyV1Client:
         tags = [t for t in tags if t]
         short = parsed.get("description") or role.get("description") or ""
         options = []
-        for var in parsed.get("variables") or []:
-            options.append({
-                "name": var["name"],
-                "type": var.get("type") or "str",
-                "required": bool(var.get("required")),
-                "default": var.get("default"),
-                "choices": var.get("choices"),
-                "description": var.get("description", ""),
-                "aliases": var.get("aliases", []),
-            })
+        try:
+            for var in parsed.get("variables") or []:
+                options.append({
+                    "name": var["name"],
+                    "type": var.get("type") or "str",
+                    "required": bool(var.get("required")),
+                    "default": var.get("default"),
+                    "choices": var.get("choices"),
+                    "description": var.get("description", ""),
+                    "aliases": var.get("aliases", []),
+                })
+        except (KeyError, TypeError, ValueError) as exc:
+            raise GalaxyError(
+                f"Malformed Galaxy payload for standalone role "
+                f"'{namespace}.{name}'"
+            ) from exc
         username = role.get("username") or namespace
         role_slug = role.get("name") or name
         metadata = {

--- a/src/ansible_know/resolution.py
+++ b/src/ansible_know/resolution.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     )
 
 from ansible_know.async_utils import run_in_executor
-from ansible_know.errors import AnsibleDocError
+from ansible_know.errors import AnsibleDocError, GalaxyError
 from ansible_know.validation import extract_collection_fqcn, sanitize_error, validate_plugin_type
 
 logger = logging.getLogger("ansible_know")
@@ -54,6 +54,15 @@ def _select_http_client(
     return http_client if server.validate_certs else None
 
 
+def _wrap_galaxy_server_error(exc: BaseException) -> GalaxyError:
+    """Treat parse/shape errors as server failure so later servers still run."""
+    if isinstance(exc, GalaxyError):
+        return exc
+    wrapped = GalaxyError(f"Malformed Galaxy payload: {exc}")
+    wrapped.__cause__ = exc
+    return wrapped
+
+
 async def _try_galaxy_servers(
     servers: list[GalaxyServerConfig],
     operation: Callable[..., Awaitable[Any]],
@@ -63,9 +72,9 @@ async def _try_galaxy_servers(
     """Try an operation across multiple Galaxy servers in priority order.
 
     Returns the first successful result. Raises the last GalaxyError if all fail.
+    KeyError, TypeError, and ValueError from a 200 with a bad JSON body are
+    wrapped as GalaxyError so fallback continues (HTTP/not-found already are).
     """
-    from ansible_know.errors import GalaxyError
-
     last_exc: GalaxyError | None = None
     for server in servers:
         try:
@@ -73,9 +82,9 @@ async def _try_galaxy_servers(
                 server, http_client=_select_http_client(http_client, server),
             ) as client:
                 return await operation(client)
-        except GalaxyError as exc:
-            logger.info("Galaxy server '%s' failed: %s", server.name, exc)
-            last_exc = exc
+        except (GalaxyError, KeyError, TypeError, ValueError) as exc:
+            last_exc = _wrap_galaxy_server_error(exc)
+            logger.info("Galaxy server '%s' failed: %s", server.name, last_exc)
     if last_exc is not None:
         raise last_exc
     raise GalaxyError("No Galaxy servers configured")
@@ -90,9 +99,9 @@ async def _try_v1_servers(
     """Try an operation across multiple Galaxy servers in priority order.
 
     Returns the first successful result. Raises the last GalaxyError if all fail.
+    KeyError, TypeError, and ValueError from a 200 with a bad JSON body are
+    wrapped as GalaxyError so fallback continues (HTTP/not-found already are).
     """
-    from ansible_know.errors import GalaxyError
-
     last_exc: GalaxyError | None = None
     for server in servers:
         try:
@@ -100,9 +109,9 @@ async def _try_v1_servers(
                 server, http_client=_select_http_client(http_client, server),
             ) as client:
                 return await operation(client)
-        except GalaxyError as exc:
-            logger.info("Galaxy server '%s' failed: %s", server.name, exc)
-            last_exc = exc
+        except (GalaxyError, KeyError, TypeError, ValueError) as exc:
+            last_exc = _wrap_galaxy_server_error(exc)
+            logger.info("Galaxy server '%s' failed: %s", server.name, last_exc)
     if last_exc is not None:
         raise last_exc
     raise GalaxyError("No Galaxy servers configured")

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -1670,6 +1670,40 @@ class TestFetchRoleDoc:
         assert role_meta["role_name"] == "some.col.empty_role"
         assert role_meta["entry_points"]["main"]["options"] == []
 
+    @pytest.mark.asyncio
+    async def test_variables_missing_name_raises_galaxy_error(self):
+        blob = {
+            "docs_blob": {
+                "contents": [
+                    {
+                        "content_type": "role",
+                        "content_name": "timesync",
+                        "doc_strings": {},
+                        "readme_html": "<p>x</p>",
+                    },
+                ],
+            },
+        }
+
+        async def mock_api_get(self_client, path, params=None, timeout=None):
+            if "versions/" in path and "docs-blob" not in path:
+                return SAMPLE_VERSIONS_RESPONSE
+            if "docs-blob" in path:
+                return blob
+            return {}
+
+        parsed = {"variables": [{"type": "str", "description": "no name"}]}
+        with _mock_api_get_context(mock_api_get):
+            with patch(
+                "ansible_know.readme_parser.parse_role_readme",
+                return_value=parsed,
+            ):
+                client = GalaxyClient()
+                with pytest.raises(GalaxyError, match="Malformed Galaxy payload"):
+                    await client.fetch_role_doc(
+                        "fedora.linux_system_roles.timesync",
+                    )
+
 
 class TestSearchCollectionsRoleCount:
     @pytest.mark.asyncio

--- a/tests/test_galaxy_v1.py
+++ b/tests/test_galaxy_v1.py
@@ -354,6 +354,40 @@ class TestFetchStandaloneRoleDoc:
         assert params["name"] == "rhel9_cis"
         assert meta["role_name"] == "ansible-lockdown.rhel9_cis"
 
+    @pytest.mark.asyncio
+    async def test_list_payload_missing_id_raises_galaxy_error(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        role = {k: v for k, v in SAMPLE_ROLE.items() if k != "id"}
+        list_payload = {
+            "count": 1, "next": None, "previous": None, "results": [role],
+        }
+        mock_client = _mock_http(list_payload)
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            gc = _skip_discovery(GalaxyV1Client())
+            with pytest.raises(GalaxyError, match="Malformed Galaxy payload"):
+                await gc.fetch_standalone_role_doc("ansible-lockdown.rhel9_cis")
+
+    @pytest.mark.asyncio
+    async def test_variables_missing_name_raises_galaxy_error(self):
+        from ansible_know.galaxy_v1 import GalaxyV1Client
+        list_resp = _json_response(SAMPLE_LIST)
+        content_resp = _json_response({
+            "readme": "README.md", "readme_html": "<p>x</p>",
+        })
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [list_resp, content_resp]
+        parsed = {"variables": [{"type": "str", "description": "no name"}]}
+        with patch("ansible_know.galaxy_v1.httpx.AsyncClient", return_value=mock_client):
+            with patch(
+                "ansible_know.readme_parser.parse_role_readme",
+                return_value=parsed,
+            ):
+                gc = _skip_discovery(GalaxyV1Client())
+                with pytest.raises(GalaxyError, match="Malformed Galaxy payload"):
+                    await gc.fetch_standalone_role_doc(
+                        "ansible-lockdown.rhel9_cis",
+                    )
+
 
 class TestV1Discovery:
     @pytest.mark.asyncio

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -625,6 +625,23 @@ class _FakeV1:
         return self._doc
 
 
+class _FakeGalaxy:
+    def __init__(self, doc=None, error=None):
+        self._doc = doc
+        self._error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return None
+
+    async def fetch_role_doc(self, role_name, version=None):
+        if self._error:
+            raise self._error
+        return self._doc
+
+
 def _v1_factory_map(mapping):
     def _factory(config, http_client=None):
         return mapping[config.name]
@@ -786,3 +803,97 @@ class TestResolveStandaloneRoleDoc:
         )
         assert result == {"error": "Standalone role 'missing.role' not found"}
         assert "doc_source" not in result
+
+    @pytest.mark.asyncio
+    async def test_malformed_payload_falls_through_to_next_server(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import resolve_standalone_role_doc
+        s1 = GalaxyServerConfig(name="hub", url="https://hub.example")
+        s2 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        doc = ({
+            "role_name": "ansible-lockdown.rhel9_cis",
+            "content_type": "standalone_role",
+            "short_description": "CIS",
+            "entry_points": {"main": {"description": "CIS", "options": []}},
+            "dependencies": [],
+            "examples": "",
+        }, {"doc_source": "galaxy_v1_readme", "doc_version": "1.0"})
+        result = await resolve_standalone_role_doc(
+            "ansible-lockdown.rhel9_cis",
+            galaxy_servers=[s1, s2],
+            v1_client_factory=_v1_factory_map({
+                "hub": _FakeV1(error=KeyError("id")),
+                "galaxy": _FakeV1(doc=doc),
+            }),
+        )
+        assert result["doc_source"] == "galaxy_v1_readme"
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_all_malformed_payloads_surface_galaxy_error(self):
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import resolve_standalone_role_doc
+        s1 = GalaxyServerConfig(name="hub", url="https://hub.example")
+        s2 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        result = await resolve_standalone_role_doc(
+            "ansible-lockdown.rhel9_cis",
+            galaxy_servers=[s1, s2],
+            v1_client_factory=_v1_factory_map({
+                "hub": _FakeV1(error=KeyError("id")),
+                "galaxy": _FakeV1(error=TypeError("not a mapping")),
+            }),
+        )
+        assert "error" in result
+        assert "Malformed Galaxy payload" in result["error"]
+        assert "doc_source" not in result
+
+
+class TestResolveRoleDocMalformedPayload:
+    @pytest.mark.asyncio
+    async def test_malformed_payload_falls_through_to_next_server(
+        self, mock_ansible_doc, missing,
+    ):
+        mock_ansible_doc.return_value = "{}"
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import resolve_role_doc
+        s1 = GalaxyServerConfig(name="hub", url="https://hub.example")
+        s2 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        galaxy_role_meta = {
+            "role_name": "fedora.linux_system_roles.timesync",
+            "short_description": "Configure time synchronization",
+            "entry_points": {"main": {"description": "Configure time sync", "options": []}},
+            "dependencies": [], "examples": "",
+        }
+        galaxy_meta = {"doc_source": "galaxy", "doc_version": "1.121.0"}
+        result = await resolve_role_doc(
+            "fedora.linux_system_roles.timesync",
+            galaxy_servers=[s1, s2],
+            client_factory=_v1_factory_map({
+                "hub": _FakeGalaxy(error=KeyError("name")),
+                "galaxy": _FakeGalaxy(doc=(galaxy_role_meta, galaxy_meta)),
+            }),
+            missing_collections=missing,
+        )
+        assert result["doc_source"] == "galaxy_readme"
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_all_malformed_payloads_surface_galaxy_error(
+        self, mock_ansible_doc, missing,
+    ):
+        mock_ansible_doc.return_value = "{}"
+        from ansible_know.galaxy_config import GalaxyServerConfig
+        from ansible_know.resolution import resolve_role_doc
+        s1 = GalaxyServerConfig(name="hub", url="https://hub.example")
+        s2 = GalaxyServerConfig(name="galaxy", url="https://galaxy.ansible.com")
+        result = await resolve_role_doc(
+            "fedora.linux_system_roles.timesync",
+            galaxy_servers=[s1, s2],
+            client_factory=_v1_factory_map({
+                "hub": _FakeGalaxy(error=KeyError("name")),
+                "galaxy": _FakeGalaxy(error=ValueError("invalid id")),
+            }),
+            missing_collections=missing,
+        )
+        assert result["doc_source"] == "unavailable"
+        assert "Malformed Galaxy payload" in result["error"]


### PR DESCRIPTION
## Summary
- Normalize malformed Galaxy JSON (missing role id, missing variable name) to `GalaxyError` in the v1 and v3 role-doc clients so a 200 with a bad body is a server failure.
- Wrap `KeyError`/`TypeError`/`ValueError` in `_try_galaxy_servers` and `_try_v1_servers` so later servers still run. Do not catch bare `Exception` (that is issue 195).
- HTTP 401/timeout/not-found behavior is unchanged (already `GalaxyError`).

Closes #234

## Changes
- `src/ansible_know/galaxy_v1.py`: `fetch_standalone_role_doc` wraps `int(role["id"])` and `var["name"]`.
- `src/ansible_know/galaxy.py`: `fetch_role_doc` wraps the same variable-name mapping.
- `src/ansible_know/resolution.py`: `_try_galaxy_servers` / `_try_v1_servers` treat shape errors as `GalaxyError`.
- `tests/test_galaxy_v1.py`, `tests/test_galaxy.py`, `tests/test_resolution.py`: malformed payloads raise `GalaxyError`; Hub/first-server malformation falls through; all-malformed still surfaces `GalaxyError`.

## Test plan
- [x] `uv run ruff check` on touched files
- [x] `pytest tests/test_galaxy_v1.py tests/test_galaxy.py::TestFetchRoleDoc tests/test_resolution.py`
- [ ] CI green on this PR

## Review findings addressed
- **Plan review** (`git-plan`): skipped (small)
- **Implementation review** (`git-implement`):
  - Architecture (`git-review` vs `docs/architecture/service-contracts.md`, ADR-0004, ADR-0006): **Clean**. No URL-restricted servers, no new search/get_* features, no `except Exception`, no contract contradiction for the `GalaxyError` predicate.
  - Code quality: no criticals. Belt-and-suspenders wrap is issue-faithful, not a try-servers-only shortcut.
  - PEP 8 (`pep8-review`): no errors. Specific exception tuples; `from exc` / `__cause__` chaining.

## Acknowledged debt
None for this PR. v0.9.1 cut (changelog + version bump + tag) is deferred by request.

## Stack position
- **Base**: `main`
- **Next**: end (standalone)

Assisted-by: Cursor (Grok 4.6)