### PR TITLE
release: v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet.
 
+## [0.9.1] - 2026-08-19
+
+### Fixed
+
+- `search_standalone_roles` empty v1 hits + Hub errors is success (#240)
+- `search_collections` same empty-hits + sibling-error merge (#241)
+- Malformed Galaxy payloads are server failure so multi-server fallback continues (#234)
+
 ## [0.9.0] - 2026-08-18
 
 ### Added
@@ -263,6 +271,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OWASP security hardening: FQCN input validation, path traversal protection, error sanitization, output size limits, audit logging
 - 77 tests covering tools, parser, skills, docs, collection manifests, and security
 
+[0.9.1]: https://github.com/leogallego/ansible-know-mcp/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/leogallego/ansible-know-mcp/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/leogallego/ansible-know-mcp/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/leogallego/ansible-know-mcp/compare/v0.6.1...v0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ansible-know-mcp"
-version = "0.9.0"
+version = "0.9.1"
 description = "Ansible Knowledge MCP Server — module and role discovery, documentation, and skill generation for AI agents"
 requires-python = ">=3.10"
 license = "GPL-3.0-or-later"

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "ansible-know-mcp"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- Cut v0.9.1 with changelog Fixed entries for #240, #241, and #234.
- Bump `pyproject.toml` to 0.9.1 and sync the `uv.lock` package version.
- Leave `## [Unreleased]` with “Nothing yet.”

See #240, #241, #234 (already merged).

## Changes
- `CHANGELOG.md`: `## [0.9.1] - 2026-08-19` + compare link
- `pyproject.toml`: `version = "0.9.1"`
- `uv.lock`: package version `0.9.1`

## Test plan
- [x] Diff limited to changelog, version, lockfile package version
- [ ] CI green on this PR
- [ ] After merge: tag `v0.9.1` and push (publish.yml → PyPI + GitHub Release)

## Review findings addressed
- **Plan review** (`git-plan`): skipped (small, follows last cut)
- **Implementation review**: same shape as v0.9.0 + uv.lock sync (#239)

## Acknowledged debt
None.

## Stack position
- **Base**: `main`
- **Next**: end (standalone)

Assisted-by: Cursor (Grok 4.6)