### PR TITLE
release: v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet.
 
+## [0.10.0] - 2026-08-24
+
+### Added
+
+- CoP Automation Good Practices as `search_docs` source `cop-good-practices`, plus `fetch_doc` for allowlisted raw GitHub `README.adoc` (#172, #249)
+
+### Chore
+
+- Fork/upstream workflow in CONTRIBUTING.md (#245)
+
 ## [0.9.1] - 2026-08-19
 
 ### Fixed
@@ -271,6 +281,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OWASP security hardening: FQCN input validation, path traversal protection, error sanitization, output size limits, audit logging
 - 77 tests covering tools, parser, skills, docs, collection manifests, and security
 
+[0.10.0]: https://github.com/leogallego/ansible-know-mcp/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/leogallego/ansible-know-mcp/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/leogallego/ansible-know-mcp/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/leogallego/ansible-know-mcp/compare/v0.7.0...v0.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ansible-know-mcp"
-version = "0.9.1"
+version = "0.10.0"
 description = "Ansible Knowledge MCP Server — module and role discovery, documentation, and skill generation for AI agents"
 requires-python = ">=3.10"
 license = "GPL-3.0-or-later"

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "ansible-know-mcp"
-version = "0.9.1"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- Cut v0.10.0 with changelog Added for CoP `search_docs` / `fetch_doc` (#249, #172) and Chore for CONTRIBUTING fork workflow (#245).
- Bump `pyproject.toml` to 0.10.0 and sync the `uv.lock` package version.
- Leave `## [Unreleased]` with “Nothing yet.”

See #249, #172, #245 (already merged).

## Changes
- `CHANGELOG.md`: `## [0.10.0] - 2026-08-24` + compare link
- `pyproject.toml`: `version = "0.10.0"`
- `uv.lock`: package version `0.10.0`

## Test plan
- [x] Diff limited to changelog, version, lockfile package version
- [ ] CI green on this PR
- [ ] After merge: tag `v0.10.0` and push (publish.yml → PyPI + GitHub Release)

## Review findings addressed
- **Plan review** (`git-plan`): skipped (small, follows last cut)
- **Implementation review**: same shape as v0.9.1 + uv.lock sync

## Acknowledged debt
None.

## Stack position
- **Base**: `main`
- **Next**: end (standalone)

Assisted-by: Cursor (Grok 4.6)